### PR TITLE
fix: add trip validation constraints

### DIFF
--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -7,11 +7,14 @@ const gpsPointSchema = z.object({
 });
 
 export const createTripSchema = z.object({
-  distanceKm: z.number().positive(),
-  durationSec: z.number().int().nonnegative(),
+  distanceKm: z.number().positive().max(500),
+  durationSec: z.number().int().min(1),
   startedAt: z.string().datetime(),
   endedAt: z.string().datetime(),
   gpsPoints: z.array(gpsPointSchema).nullable().optional(),
-});
+}).refine(
+  (data) => new Date(data.startedAt) < new Date(data.endedAt),
+  { message: "startedAt must be before endedAt", path: ["startedAt"] }
+);
 
 export type CreateTripInput = z.infer<typeof createTripSchema>;


### PR DESCRIPTION
## Summary
- Add `.max(500)` to `distanceKm` to reject unrealistic single-trip distances
- Change `durationSec` from `.nonnegative()` to `.min(1)` to prevent zero-duration trips (avoids division-by-zero in speed calculations)
- Add `.refine()` to validate that `startedAt` is strictly before `endedAt`

## Test plan
- [ ] Submit a trip with `distanceKm > 500` and verify it is rejected
- [ ] Submit a trip with `durationSec: 0` and verify it is rejected
- [ ] Submit a trip where `startedAt >= endedAt` and verify it is rejected
- [ ] Submit a valid trip and verify it still succeeds
- [ ] Run `bun run typecheck` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)