### PR TITLE
fix: use user's consumption profile for live CO2 display

### DIFF
--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -2,7 +2,8 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { Play, Square, Keyboard } from "lucide-react";
 import { MapContainer, TileLayer, Polyline, CircleMarker, useMap } from "react-leaflet";
 import type { LatLngExpression } from "leaflet";
-import { useCreateTrip } from "@/hooks/queries";
+import { useCreateTrip, useProfile } from "@/hooks/queries";
+import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -26,6 +27,7 @@ export function TripPage() {
   const timerRef = useRef<ReturnType<typeof setInterval>>(null);
   const startTimeRef = useRef<Date>(new Date());
   const createTrip = useCreateTrip();
+  const { data: profileData } = useProfile();
 
   const startTracking = useCallback(() => {
     setState("tracking");
@@ -66,7 +68,8 @@ export function TripPage() {
     return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
   };
 
-  const co2Saved = distance * 0.065 * 2.31;
+  const consumptionL100 = profileData?.user.consumptionL100 ?? 7; // Default 7 L/100km (matches server)
+  const co2Saved = distance * (consumptionL100 / 100) * CO2_KG_PER_LITER;
 
   const handleSaveTrip = (km: number, durationSec: number) => {
     const endedAt = new Date();


### PR DESCRIPTION
## Summary
- Replace hardcoded 6.5 L/100km (`distance * 0.065 * 2.31`) in TripPage's live CO2 display with the user's actual `consumptionL100` from their profile via `useProfile()` hook
- Fall back to 7 L/100km when profile data is unavailable, matching the server-side default in `trips.routes.ts:32`
- Import `CO2_KG_PER_LITER` constant from `shared/types.ts` instead of hardcoding `2.31`

## Test plan
- [ ] Start a trip (GPS tracking mode) and verify the CO2 chip updates live using the user's configured consumption
- [ ] Verify with a user who has **no** `consumptionL100` set: should default to 7 L/100km (previously was 6.5)
- [ ] Verify with a user who has a custom `consumptionL100` (e.g. 5.5): the live CO2 should reflect that value
- [ ] Verify the "Trajet termine" (stopped) summary shows the same CO2 value as the live chip
- [ ] Confirm `bun run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)