### PR TITLE
feat: add 404 page and React error boundary

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { TripPage } from "@/pages/TripPage";
 import { StatsPage } from "@/pages/StatsPage";
 import { LeaderboardPage } from "@/pages/LeaderboardPage";
 import { ProfilePage } from "@/pages/ProfilePage";
+import { NotFoundPage } from "@/pages/NotFoundPage";
 
 export function App() {
   return (
@@ -21,6 +22,7 @@ export function App() {
           <Route path="profile" element={<ProfilePage />} />
         </Route>
       </Route>
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { Bike } from "lucide-react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-dvh flex-col items-center justify-center bg-bg px-6 text-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-3xl bg-primary/15">
+            <Bike size={40} className="text-primary-light" />
+          </div>
+
+          <h1 className="mt-8 text-2xl font-bold text-text">
+            Une erreur est survenue
+          </h1>
+
+          <p className="mt-2 text-sm text-text-muted">
+            Quelque chose s'est mal passé. Essayez de recharger la page.
+          </p>
+
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-8 rounded-xl bg-primary px-8 py-3 font-bold text-black active:scale-95"
+          >
+            Recharger
+          </button>
+
+          <p className="mt-6 text-xs text-text-muted">
+            <span className="text-text">eco</span>
+            <span className="text-primary-light">Ride</span>
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { App } from "./App";
 import "./app.css";
 
@@ -16,10 +17,12 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router";
+import { Bike } from "lucide-react";
+
+export function NotFoundPage() {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-bg px-6 text-center">
+      <div className="flex h-20 w-20 items-center justify-center rounded-3xl bg-primary/15">
+        <Bike size={40} className="text-primary-light" />
+      </div>
+
+      <p className="mt-8 text-8xl font-black tracking-tighter text-text-muted">
+        404
+      </p>
+
+      <h1 className="mt-4 text-2xl font-bold text-text">
+        Page introuvable
+      </h1>
+
+      <p className="mt-2 text-sm text-text-muted">
+        La page que vous recherchez n'existe pas ou a été déplacée.
+      </p>
+
+      <Link
+        to="/"
+        className="mt-8 rounded-xl bg-primary px-8 py-3 font-bold text-black active:scale-95"
+      >
+        Retour à{" "}
+        <span className="text-black/70">eco</span>
+        <span className="text-black/90">Ride</span>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `NotFoundPage` with 404 display, French messaging, and a link back to home, matching the dark charcoal ecoRide theme
- Add a class-based `ErrorBoundary` component that catches unhandled JS errors and shows a "Recharger" button
- Register a catch-all `<Route path="*">` in App.tsx so unknown paths render the 404 page
- Wrap the entire app in `<ErrorBoundary>` in main.tsx to prevent white-screen crashes

## Test plan
- [ ] Navigate to a non-existent route (e.g. `/foo`) and verify the 404 page renders
- [ ] Verify the "Retour" link navigates back to the dashboard
- [ ] Temporarily throw an error in a component to confirm the ErrorBoundary fallback UI appears
- [ ] Verify the "Recharger" button triggers a page reload
- [ ] Run `bun run typecheck` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)