### PR TITLE
feat: auto-unlock badges after trip creation

### DIFF
--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -1,0 +1,85 @@
+import { eq, sum, count } from "drizzle-orm";
+import { db } from "../db";
+import { trips, achievements } from "../db/schema";
+import { computeStreak } from "./streaks";
+import type { BadgeId } from "@ecoride/shared/types";
+
+/**
+ * Badge threshold definitions.
+ * Each entry maps a BadgeId to a predicate over the user's aggregate stats.
+ */
+interface UserStats {
+  totalDistanceKm: number;
+  totalCo2SavedKg: number;
+  tripCount: number;
+  currentStreak: number;
+}
+
+const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
+  first_trip:  (s) => s.tripCount >= 1,
+  trips_10:    (s) => s.tripCount >= 10,
+  trips_50:    (s) => s.tripCount >= 50,
+  trips_100:   (s) => s.tripCount >= 100,
+  km_100:      (s) => s.totalDistanceKm >= 100,
+  km_500:      (s) => s.totalDistanceKm >= 500,
+  km_1000:     (s) => s.totalDistanceKm >= 1000,
+  co2_10kg:    (s) => s.totalCo2SavedKg >= 10,
+  co2_100kg:   (s) => s.totalCo2SavedKg >= 100,
+  co2_1t:      (s) => s.totalCo2SavedKg >= 1000,
+  streak_7:    (s) => s.currentStreak >= 7,
+  streak_30:   (s) => s.currentStreak >= 30,
+};
+
+/**
+ * Evaluate all badge thresholds for a user and insert any newly unlocked badges.
+ * Uses ON CONFLICT DO NOTHING to gracefully handle races / duplicates.
+ *
+ * @returns Array of BadgeIds that were newly unlocked in this call.
+ */
+export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]> {
+  // 1. Aggregate lifetime stats
+  const [stats] = await db
+    .select({
+      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
+      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId));
+
+  const streaks = await computeStreak(userId);
+
+  const userStats: UserStats = {
+    totalDistanceKm: stats?.totalDistanceKm ?? 0,
+    totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
+    tripCount: stats?.tripCount ?? 0,
+    currentStreak: streaks.current,
+  };
+
+  // 2. Get already-unlocked badge IDs
+  const existing = await db
+    .select({ badgeId: achievements.badgeId })
+    .from(achievements)
+    .where(eq(achievements.userId, userId));
+
+  const unlockedSet = new Set(existing.map((r) => r.badgeId));
+
+  // 3. Determine which badges are newly earned
+  const newlyUnlocked: BadgeId[] = [];
+
+  for (const [badgeId, check] of Object.entries(BADGE_THRESHOLDS) as [BadgeId, (s: UserStats) => boolean][]) {
+    if (!unlockedSet.has(badgeId) && check(userStats)) {
+      newlyUnlocked.push(badgeId);
+    }
+  }
+
+  // 4. Bulk insert with ON CONFLICT DO NOTHING
+  if (newlyUnlocked.length > 0) {
+    await db
+      .insert(achievements)
+      .values(newlyUnlocked.map((badgeId) => ({ userId, badgeId })))
+      .onConflictDoNothing({ target: [achievements.userId, achievements.badgeId] });
+  }
+
+  return newlyUnlocked;
+}

--- a/server/src/lib/streaks.ts
+++ b/server/src/lib/streaks.ts
@@ -1,0 +1,64 @@
+import { eq, desc } from "drizzle-orm";
+import { db } from "../db";
+import { trips } from "../db/schema";
+
+/**
+ * Compute the current streak (consecutive days with at least one trip)
+ * and the longest streak ever recorded for a user.
+ */
+export async function computeStreak(userId: string): Promise<{ current: number; longest: number }> {
+  // Get distinct trip dates ordered descending
+  const rows = await db
+    .selectDistinctOn([trips.startedAt], {
+      date: trips.startedAt,
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId))
+    .orderBy(desc(trips.startedAt));
+
+  if (rows.length === 0) return { current: 0, longest: 0 };
+
+  // Extract unique dates (YYYY-MM-DD)
+  const dateSet = new Set<string>();
+  for (const row of rows) {
+    dateSet.add(row.date.toISOString().slice(0, 10));
+  }
+  const dates = Array.from(dateSet).sort().reverse();
+
+  let current = 0;
+  let longest = 0;
+  let streak = 0;
+
+  for (let i = 0; i < dates.length; i++) {
+    const d = dates[i]!;
+    if (i === 0) {
+      // Streak counts only if the most recent trip was today or yesterday
+      const diffDays = Math.floor((Date.now() - new Date(d).getTime()) / 86400000);
+      if (diffDays > 1) {
+        current = 0;
+        streak = 1;
+      } else {
+        streak = 1;
+        current = 1;
+      }
+    } else {
+      const prev = new Date(dates[i - 1]!);
+      const curr = new Date(d);
+      const diff = Math.floor((prev.getTime() - curr.getTime()) / 86400000);
+      if (diff === 1) {
+        streak++;
+        if (current > 0) current = streak;
+      } else {
+        longest = Math.max(longest, streak);
+        streak = 1;
+        if (current > 0) {
+          // Break in the current streak
+        }
+        current = current > 0 ? current : 0;
+      }
+    }
+  }
+  longest = Math.max(longest, streak);
+
+  return { current, longest };
+}

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -1,10 +1,11 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { eq, sum, count, gte, and, desc } from "drizzle-orm";
+import { eq, sum, count, gte, and } from "drizzle-orm";
 import { db } from "../db";
 import { trips } from "../db/schema";
 import { validationHook } from "../lib/validation";
+import { computeStreak } from "../lib/streaks";
 import type { AuthEnv } from "../types/context";
 import type { StatsPeriod } from "@ecoride/shared/api-contracts";
 
@@ -26,67 +27,6 @@ function getPeriodStart(period: StatsPeriod): Date | null {
     case "month": return new Date(now.getFullYear(), now.getMonth(), 1);
     case "year": return new Date(now.getFullYear(), 0, 1);
   }
-}
-
-/**
- * Compute the current streak (consecutive days with at least one trip).
- */
-async function computeStreak(userId: string): Promise<{ current: number; longest: number }> {
-  // Get distinct trip dates ordered descending
-  const rows = await db
-    .selectDistinctOn([trips.startedAt], {
-      date: trips.startedAt,
-    })
-    .from(trips)
-    .where(eq(trips.userId, userId))
-    .orderBy(desc(trips.startedAt));
-
-  if (rows.length === 0) return { current: 0, longest: 0 };
-
-  // Extract unique dates (YYYY-MM-DD)
-  const dateSet = new Set<string>();
-  for (const row of rows) {
-    dateSet.add(row.date.toISOString().slice(0, 10));
-  }
-  const dates = Array.from(dateSet).sort().reverse();
-
-  let current = 0;
-  let longest = 0;
-  let streak = 0;
-  const today = new Date().toISOString().slice(0, 10);
-
-  for (let i = 0; i < dates.length; i++) {
-    const d = dates[i]!;
-    if (i === 0) {
-      // Streak counts only if the most recent trip was today or yesterday
-      const diffDays = Math.floor((Date.now() - new Date(d).getTime()) / 86400000);
-      if (diffDays > 1) {
-        current = 0;
-        streak = 1;
-      } else {
-        streak = 1;
-        current = 1;
-      }
-    } else {
-      const prev = new Date(dates[i - 1]!);
-      const curr = new Date(d);
-      const diff = Math.floor((prev.getTime() - curr.getTime()) / 86400000);
-      if (diff === 1) {
-        streak++;
-        if (current > 0) current = streak;
-      } else {
-        longest = Math.max(longest, streak);
-        streak = 1;
-        if (current > 0) {
-          // Break in the current streak
-        }
-        current = current > 0 ? current : 0;
-      }
-    }
-  }
-  longest = Math.max(longest, streak);
-
-  return { current, longest };
 }
 
 const statsRouter = new Hono<AuthEnv>();

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -11,6 +11,7 @@ import { calculateSavings } from "../lib/calculations";
 import { getFuelPrice } from "../lib/fuel-price";
 import { notFound, forbidden } from "../lib/errors";
 import { paginationToOffset, buildPagination } from "../lib/pagination";
+import { evaluateAndUnlockBadges } from "../lib/badges";
 import type { AuthEnv } from "../types/context";
 
 const tripsRouter = new Hono<AuthEnv>();
@@ -55,7 +56,10 @@ tripsRouter.post(
       gpsPoints: data.gpsPoints ?? null,
     }).returning();
 
-    return c.json({ ok: true, data: { trip } }, 201);
+    // Evaluate badge thresholds and unlock any newly earned achievements
+    const newBadges = await evaluateAndUnlockBadges(currentUser.id);
+
+    return c.json({ ok: true, data: { trip, newBadges } }, 201);
   },
 );
 


### PR DESCRIPTION
## Summary
- **New `evaluateAndUnlockBadges(userId)`** in `server/src/lib/badges.ts` — queries aggregate stats (total distance, CO2, trip count, current streak), compares against all 12 badge thresholds, and bulk-inserts newly earned achievements with `ON CONFLICT DO NOTHING` for idempotency.
- **Extracted `computeStreak()`** from `stats.routes.ts` into `server/src/lib/streaks.ts` so both the stats endpoint and the badge evaluator share the same logic.
- **Hooked into trip creation** in `trips.routes.ts` — after a successful trip insert, badges are evaluated and the response includes `newBadges: BadgeId[]` for the client to display unlock animations.

## Badge thresholds
| Badge | Condition |
|-------|-----------|
| `first_trip` | >= 1 trip |
| `trips_10/50/100` | >= 10/50/100 trips |
| `km_100/500/1000` | >= 100/500/1000 km |
| `co2_10kg/100kg/1t` | >= 10/100/1000 kg CO2 |
| `streak_7/30` | >= 7/30 day streak |

## Test plan
- [ ] Create a first trip and verify `newBadges` contains `["first_trip"]` in the response
- [ ] Create 10 trips and verify `trips_10` appears in `newBadges` on the 10th trip
- [ ] Verify `GET /api/achievements` reflects the newly unlocked badges
- [ ] Verify duplicate trip creation does not fail (ON CONFLICT DO NOTHING)
- [ ] Verify `GET /api/stats/summary` still works (streak logic was extracted, not changed)
- [ ] Run `bun run typecheck` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)