### PR TITLE
feat: wire real GPS tracking into TripPage

### DIFF
--- a/client/src/hooks/useGpsTracking.ts
+++ b/client/src/hooks/useGpsTracking.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { haversineDistance } from "@/lib/haversine";
+import { useWakeLock } from "./useWakeLock";
+import type { GpsPoint } from "@ecoride/shared/types";
+
+const MAX_ACCURACY_M = 50;
+const MIN_DISTANCE_KM = 0.005; // 5m
+
+export interface TrackingState {
+  isTracking: boolean;
+  distanceKm: number;
+  durationSec: number;
+  gpsPoints: GpsPoint[];
+  error: string | null;
+}
+
+export interface TrackingSession {
+  distanceKm: number;
+  durationSec: number;
+  gpsPoints: GpsPoint[];
+  startedAt: string;
+  endedAt: string;
+}
+
+type Action =
+  | { type: "START" }
+  | { type: "STOP" }
+  | { type: "GPS_POINT"; point: GpsPoint }
+  | { type: "TICK" }
+  | { type: "ERROR"; message: string };
+
+const initial: TrackingState = {
+  isTracking: false,
+  distanceKm: 0,
+  durationSec: 0,
+  gpsPoints: [],
+  error: null,
+};
+
+function reducer(state: TrackingState, action: Action): TrackingState {
+  switch (action.type) {
+    case "START":
+      return { ...initial, isTracking: true };
+    case "STOP":
+      return { ...state, isTracking: false };
+    case "GPS_POINT": {
+      const points = [...state.gpsPoints, action.point];
+      let added = 0;
+      if (state.gpsPoints.length > 0) {
+        const prev = state.gpsPoints[state.gpsPoints.length - 1]!;
+        const d = haversineDistance(prev.lat, prev.lng, action.point.lat, action.point.lng);
+        if (d >= MIN_DISTANCE_KM) added = d;
+      }
+      return { ...state, gpsPoints: points, distanceKm: state.distanceKm + added, error: null };
+    }
+    case "TICK":
+      return { ...state, durationSec: state.durationSec + 1 };
+    case "ERROR":
+      return { ...state, error: action.message };
+  }
+}
+
+export function useGpsTracking() {
+  const [state, dispatch] = useReducer(reducer, initial);
+  const watchRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startRef = useRef<string | null>(null);
+  const wakeLock = useWakeLock();
+
+  const cleanup = useCallback(() => {
+    if (watchRef.current !== null) {
+      navigator.geolocation.clearWatch(watchRef.current);
+      watchRef.current = null;
+    }
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    if (!("geolocation" in navigator)) {
+      dispatch({ type: "ERROR", message: "Geolocation not supported" });
+      return;
+    }
+
+    dispatch({ type: "START" });
+    startRef.current = new Date().toISOString();
+    wakeLock.request();
+
+    watchRef.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        if (pos.coords.accuracy > MAX_ACCURACY_M) return;
+        dispatch({
+          type: "GPS_POINT",
+          point: { lat: pos.coords.latitude, lng: pos.coords.longitude, ts: pos.timestamp },
+        });
+      },
+      (err) => {
+        const msgs: Record<number, string> = {
+          1: "Permission GPS refusée",
+          2: "Position non disponible",
+          3: "Timeout GPS",
+        };
+        dispatch({ type: "ERROR", message: msgs[err.code] ?? "Erreur GPS" });
+      },
+      { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 },
+    );
+
+    timerRef.current = setInterval(() => dispatch({ type: "TICK" }), 1000);
+  }, [wakeLock]);
+
+  const stop = useCallback((): TrackingSession => {
+    cleanup();
+    dispatch({ type: "STOP" });
+    wakeLock.release();
+
+    return {
+      distanceKm: state.distanceKm,
+      durationSec: state.durationSec,
+      gpsPoints: state.gpsPoints,
+      startedAt: startRef.current ?? new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+    };
+  }, [cleanup, state, wakeLock]);
+
+  const reset = useCallback(() => {
+    cleanup();
+    wakeLock.release();
+    dispatch({ type: "START" });
+    dispatch({ type: "STOP" });
+    startRef.current = null;
+  }, [cleanup, wakeLock]);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  return { state, start, stop, reset };
+}

--- a/client/src/hooks/useWakeLock.ts
+++ b/client/src/hooks/useWakeLock.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef, useState } from "react";
+
+export function useWakeLock() {
+  const [isActive, setIsActive] = useState(false);
+  const sentinelRef = useRef<WakeLockSentinel | null>(null);
+
+  const request = useCallback(async () => {
+    if (!("wakeLock" in navigator)) return;
+    try {
+      const sentinel = await navigator.wakeLock.request("screen");
+      sentinelRef.current = sentinel;
+      setIsActive(true);
+
+      sentinel.addEventListener("release", () => {
+        sentinelRef.current = null;
+        setIsActive(false);
+      });
+    } catch {
+      // Permission denied or API error — degrade gracefully
+    }
+  }, []);
+
+  const release = useCallback(async () => {
+    if (sentinelRef.current) {
+      await sentinelRef.current.release();
+      sentinelRef.current = null;
+      setIsActive(false);
+    }
+  }, []);
+
+  return { isActive, request, release };
+}

--- a/client/src/lib/haversine.ts
+++ b/client/src/lib/haversine.ts
@@ -1,0 +1,24 @@
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/** Haversine distance between two GPS coordinates, in kilometers */
+export function haversineDistance(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) ** 2;
+
+  return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,9 +1,11 @@
-import { useState, useCallback, useRef, useEffect } from "react";
-import { Play, Square, Keyboard } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Play, Square, Keyboard, AlertTriangle } from "lucide-react";
 import { MapContainer, TileLayer, Polyline, CircleMarker, useMap } from "react-leaflet";
 import type { LatLngExpression } from "leaflet";
 import { useCreateTrip, useProfile } from "@/hooks/queries";
 import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
+import { useGpsTracking } from "@/hooks/useGpsTracking";
+import type { TrackingSession } from "@/hooks/useGpsTracking";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -18,49 +20,36 @@ function RecenterMap({ position }: { position: [number, number] }) {
 }
 
 export function TripPage() {
-  const [state, setState] = useState<TripState>("idle");
-  const [distance, setDistance] = useState(0);
-  const [elapsed, setElapsed] = useState(0);
+  const [uiState, setUiState] = useState<TripState>("idle");
   const [manualKm, setManualKm] = useState("");
-  const [positions, setPositions] = useState<[number, number][]>([]);
-  const [currentPos, setCurrentPos] = useState<[number, number]>(DEFAULT_CENTER);
-  const timerRef = useRef<ReturnType<typeof setInterval>>(null);
-  const startTimeRef = useRef<Date>(new Date());
+  const sessionRef = useRef<TrackingSession | null>(null);
   const createTrip = useCreateTrip();
   const { data: profileData } = useProfile();
+  const gps = useGpsTracking();
 
-  const startTracking = useCallback(() => {
-    setState("tracking");
-    setDistance(0);
-    setElapsed(0);
-    setPositions([DEFAULT_CENTER]);
-    setCurrentPos(DEFAULT_CENTER);
-    startTimeRef.current = new Date();
+  // Derive map data from GPS state
+  const positions: [number, number][] = gps.state.gpsPoints.map((p) => [p.lat, p.lng]);
+  const lastPos = positions.length > 0 ? positions[positions.length - 1] : undefined;
+  const currentPos: [number, number] = lastPos ?? DEFAULT_CENTER;
 
-    timerRef.current = setInterval(() => {
-      setElapsed((e) => e + 1);
-      setDistance((d) => d + 0.003 + Math.random() * 0.005);
-      setCurrentPos((prev) => {
-        const next: [number, number] = [
-          prev[0] + (Math.random() - 0.3) * 0.0003,
-          prev[1] + (Math.random() - 0.3) * 0.0004,
-        ];
-        setPositions((pts) => [...pts, next]);
-        return next;
-      });
-    }, 1000);
-  }, []);
+  const distance = uiState === "stopped" && sessionRef.current
+    ? sessionRef.current.distanceKm
+    : gps.state.distanceKm;
+  const elapsed = uiState === "stopped" && sessionRef.current
+    ? sessionRef.current.durationSec
+    : gps.state.durationSec;
 
-  const stopTracking = useCallback(() => {
-    if (timerRef.current) clearInterval(timerRef.current);
-    setState("stopped");
-  }, []);
+  const startTracking = () => {
+    sessionRef.current = null;
+    gps.start();
+    setUiState("tracking");
+  };
 
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, []);
+  const stopTracking = () => {
+    const session = gps.stop();
+    sessionRef.current = session;
+    setUiState("stopped");
+  };
 
   const formatTime = (sec: number) => {
     const m = Math.floor(sec / 60);
@@ -71,23 +60,23 @@ export function TripPage() {
   const consumptionL100 = profileData?.user.consumptionL100 ?? 7; // Default 7 L/100km (matches server)
   const co2Saved = distance * (consumptionL100 / 100) * CO2_KG_PER_LITER;
 
-  const handleSaveTrip = (km: number, durationSec: number) => {
-    const endedAt = new Date();
-    const startedAt = new Date(endedAt.getTime() - durationSec * 1000);
+  const handleSaveTrip = (km: number, durationSec: number, session?: TrackingSession | null) => {
+    const endedAt = session?.endedAt ?? new Date().toISOString();
+    const startedAt = session?.startedAt ?? new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
     createTrip.mutate(
       {
         distanceKm: Math.round(km * 100) / 100,
         durationSec,
-        startedAt: startedAt.toISOString(),
-        endedAt: endedAt.toISOString(),
+        startedAt,
+        endedAt,
+        gpsPoints: session?.gpsPoints?.length ? session.gpsPoints : null,
       },
       {
         onSuccess: () => {
-          setState("idle");
-          setDistance(0);
-          setElapsed(0);
+          setUiState("idle");
           setManualKm("");
-          setPositions([]);
+          sessionRef.current = null;
+          gps.reset();
         },
       },
     );
@@ -101,6 +90,14 @@ export function TripPage() {
           <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
         </span>
       </header>
+
+      {/* GPS Error banner */}
+      {gps.state.error && (
+        <div className="z-50 flex items-center gap-3 bg-danger/20 px-6 py-3">
+          <AlertTriangle size={16} className="shrink-0 text-danger" />
+          <span className="text-sm font-medium text-danger">{gps.state.error}</span>
+        </div>
+      )}
 
       {/* Map */}
       <div className="relative flex-1">
@@ -136,7 +133,7 @@ export function TripPage() {
         </MapContainer>
 
         {/* Floating CO2 chip */}
-        {state === "tracking" && (
+        {uiState === "tracking" && (
           <div className="absolute left-1/2 top-4 z-[1000] -translate-x-1/2">
             <div className="flex items-center gap-3 rounded-full border border-primary/30 bg-primary/20 px-5 py-2.5 backdrop-blur-md">
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
@@ -151,7 +148,7 @@ export function TripPage() {
       </div>
 
       {/* Stats overlay */}
-      {state === "tracking" && (
+      {uiState === "tracking" && (
         <div className="space-y-4 px-6 pb-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="rounded-xl border border-outline-variant/10 bg-surface-low/80 p-6 backdrop-blur-2xl">
@@ -180,7 +177,7 @@ export function TripPage() {
       )}
 
       {/* Stopped summary */}
-      {state === "stopped" && (
+      {uiState === "stopped" && (
         <div className="space-y-4 px-6 pb-4">
           <div className="rounded-xl bg-surface-container p-6">
             <h2 className="mb-4 text-lg font-bold">Trajet terminé</h2>
@@ -209,7 +206,7 @@ export function TripPage() {
               </div>
             </div>
             <button
-              onClick={() => handleSaveTrip(distance, elapsed)}
+              onClick={() => handleSaveTrip(distance, elapsed, sessionRef.current)}
               disabled={createTrip.isPending}
               className="mt-6 w-full rounded-xl bg-primary py-4 text-sm font-black uppercase tracking-widest text-bg active:scale-95 disabled:opacity-50"
             >
@@ -220,7 +217,7 @@ export function TripPage() {
       )}
 
       {/* Manual entry */}
-      {state === "manual" && (
+      {uiState === "manual" && (
         <div className="space-y-4 px-6 pb-4">
           <div className="rounded-xl bg-surface-container p-6">
             <h2 className="mb-4 text-lg font-bold">Saisie manuelle</h2>
@@ -236,7 +233,7 @@ export function TripPage() {
             />
             <div className="flex gap-3">
               <button
-                onClick={() => setState("idle")}
+                onClick={() => setUiState("idle")}
                 className="flex-1 rounded-xl bg-surface-high py-4 text-sm font-bold text-text-muted active:scale-95"
               >
                 Annuler
@@ -261,7 +258,7 @@ export function TripPage() {
       )}
 
       {/* Action buttons */}
-      {state === "idle" && (
+      {uiState === "idle" && (
         <div className="space-y-3 px-6 pb-6">
           <button
             onClick={startTracking}
@@ -273,7 +270,7 @@ export function TripPage() {
             </span>
           </button>
           <button
-            onClick={() => setState("manual")}
+            onClick={() => setUiState("manual")}
             className="flex w-full items-center justify-center gap-3 rounded-xl bg-surface-container py-4 active:scale-95"
           >
             <Keyboard size={18} className="text-text-muted" />
@@ -284,7 +281,7 @@ export function TripPage() {
         </div>
       )}
 
-      {state === "tracking" && (
+      {uiState === "tracking" && (
         <div className="px-6 pb-6">
           <button
             onClick={stopTracking}


### PR DESCRIPTION
## Summary
- **Replace fake GPS simulation** (Math.random + setInterval) in `TripPage.tsx` with real `navigator.geolocation.watchPosition()` via a new `useGpsTracking` hook
- **Add haversine distance calculation** (`client/src/lib/haversine.ts`) for accurate distance measurement between GPS points, with a 5m minimum threshold to filter noise
- **Add wake lock support** (`client/src/hooks/useWakeLock.ts`) to keep the screen on during active tracking
- **Send GPS points to the server** when saving a trip — the `gpsPoints` field is included in the `createTrip.mutate()` call (already supported by `CreateTripRequest`)
- **Show GPS errors** (permission denied, position unavailable, timeout) in a visible danger-colored banner below the header
- Manual entry mode is unchanged and does not send GPS points

## Files changed
- `client/src/lib/haversine.ts` — new: Haversine formula for GPS distance
- `client/src/hooks/useWakeLock.ts` — new: Screen Wake Lock API wrapper
- `client/src/hooks/useGpsTracking.ts` — new: GPS tracking hook with useReducer state machine, watchPosition, timer, error handling
- `client/src/pages/TripPage.tsx` — refactored to use `useGpsTracking` instead of fake setInterval tracking

## Test plan
- [ ] Open TripPage on a mobile device with GPS enabled
- [ ] Tap "Demarrer" and verify the browser requests location permission
- [ ] Walk/cycle and verify the distance counter increases based on real movement
- [ ] Verify the map Polyline traces the actual path and CircleMarker follows current position
- [ ] Verify the CO2 chip updates during tracking
- [ ] Tap "Terminer" and verify the summary shows correct distance/duration
- [ ] Tap "Enregistrer" and verify the trip is saved with `gpsPoints` in the POST body
- [ ] Deny GPS permission and verify the error banner appears ("Permission GPS refusee")
- [ ] Test manual entry mode — verify it still works and does not send gpsPoints
- [ ] Verify screen stays on during active tracking (wake lock)
- [ ] Verify TypeScript compiles cleanly (`bun run --filter client typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)