### PR TITLE
feat: add empty states for new users

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router";
 import { Bike, Leaf, Euro, TrendingUp } from "lucide-react";
 import { PeriodSwitcher } from "@/components/ui/PeriodSwitcher";
 import { StatCard } from "@/components/ui/StatCard";
@@ -20,6 +21,8 @@ export function DashboardPage() {
     );
   }
 
+  const hasNoTrips = s.tripCount === 0;
+
   return (
     <>
       {/* Header */}
@@ -29,6 +32,29 @@ export function DashboardPage() {
         </span>
       </header>
 
+      {hasNoTrips ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
+            <Bike size={40} className="text-primary-light" />
+          </div>
+          <div className="flex flex-col items-center gap-2 text-center">
+            <h2 className="text-2xl font-bold">
+              Bienvenue sur{" "}
+              <span className="text-text">eco</span>
+              <span className="text-primary-light">Ride</span> !
+            </h2>
+            <p className="max-w-xs text-sm text-text-muted">
+              Enregistrez votre premier trajet vélo pour commencer à suivre vos économies CO₂.
+            </p>
+          </div>
+          <Link
+            to="/trip"
+            className="mt-2 rounded-xl bg-primary px-8 py-3 text-sm font-bold text-bg transition-colors hover:bg-primary-light"
+          >
+            Démarrer un trajet
+          </Link>
+        </div>
+      ) : (
       <div className="flex flex-col gap-6 px-6 pb-6">
         {/* Period Switcher */}
         <PeriodSwitcher value={period} onChange={setPeriod} />
@@ -93,6 +119,7 @@ export function DashboardPage() {
           </div>
         </div>
       </div>
+      )}
     </>
   );
 }

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -1,3 +1,4 @@
+import { Trophy } from "lucide-react";
 import { useLeaderboard } from "@/hooks/queries";
 import { useSession } from "@/lib/auth";
 
@@ -38,6 +39,20 @@ export function LeaderboardPage() {
           </p>
         </section>
 
+        {entries.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-6 py-20">
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
+              <Trophy size={40} className="text-primary-light" />
+            </div>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <h3 className="text-xl font-bold">Pas encore de classement</h3>
+              <p className="max-w-xs text-sm text-text-muted">
+                Enregistrez des trajets pour apparaître ici.
+              </p>
+            </div>
+          </div>
+        ) : (
+        <>
         {/* Podium */}
         <section className="mb-12 grid grid-cols-3 items-end gap-4">
           {/* Rank 2 */}
@@ -156,6 +171,8 @@ export function LeaderboardPage() {
             );
           })}
         </div>
+        </>
+        )}
       </div>
     </>
   );

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Bike } from "lucide-react";
+import { Bike, BarChart3 } from "lucide-react";
 import {
   LineChart,
   Line,
@@ -89,6 +89,20 @@ export function StatsPage() {
       </header>
 
       <div className="space-y-12 px-6 pb-6">
+        {s.tripCount === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-6 py-20">
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
+              <BarChart3 size={40} className="text-primary-light" />
+            </div>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <h3 className="text-xl font-bold">Pas encore de statistiques</h3>
+              <p className="max-w-xs text-sm text-text-muted">
+                Vos données apparaîtront ici après votre premier trajet.
+              </p>
+            </div>
+          </div>
+        ) : (
+        <>
         {/* Monthly Totals */}
         <section className="space-y-6">
           <div className="flex items-end justify-between">
@@ -273,6 +287,8 @@ export function StatsPage() {
             ))}
           </div>
         </section>
+        </>
+        )}
 
         {/* Badges */}
         <section className="space-y-4">


### PR DESCRIPTION
## Summary
- **DashboardPage**: When `tripCount === 0`, show a welcoming empty state with Bike icon, friendly message, and a CTA button linking to `/trip` instead of zero-value stat cards
- **LeaderboardPage**: When `entries.length === 0`, show a Trophy icon with "Pas encore de classement" message instead of an empty podium
- **StatsPage**: When `tripCount === 0`, show a BarChart3 icon with "Pas encore de statistiques" message instead of zero-value stat cards and an empty chart; the Badges section remains visible

## Test plan
- [ ] Sign up as a new user with zero trips and verify each page shows the empty state
- [ ] On Dashboard, verify the "Démarrer un trajet" CTA links to `/trip`
- [ ] On Leaderboard, verify the title/subtitle section still renders above the empty state
- [ ] On Stats, verify the Badges section still renders below the empty state
- [ ] Record a trip and verify all three pages switch back to the normal data views
- [ ] Run `bun run typecheck` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)