### PR TITLE
fix: show all users in leaderboard including those with no trips

### DIFF
--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -47,18 +47,22 @@ leaderboardRouter.get(
       ? [gte(trips.startedAt, periodStart)]
       : [];
 
+    const joinCondition = periodStart
+      ? and(eq(user.id, trips.userId), gte(trips.startedAt, periodStart))
+      : eq(user.id, trips.userId);
+
     const entries = await db
       .select({
         userId: user.id,
         name: user.name,
         image: user.image,
-        totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
       })
       .from(user)
-      .innerJoin(trips, eq(user.id, trips.userId))
-      .where(and(...conditions, ...tripConditions))
+      .leftJoin(trips, joinCondition)
+      .where(and(...conditions))
       .groupBy(user.id, user.name, user.image)
-      .orderBy(desc(sum(trips.co2SavedKg)))
+      .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`))
       .limit(limit);
 
     // Add rank


### PR DESCRIPTION
## Summary
- Replace `INNER JOIN` with `LEFT JOIN` + `COALESCE` on the leaderboard query
- Users with 0 trips now appear with 0 kg CO₂ instead of being invisible
- Period filter moved to the JOIN condition to avoid filtering out users without trips in that period

## Test plan
- [ ] Register 2 users, neither records a trip → both should appear in leaderboard at 0 kg
- [ ] One user records a trip → they move to #1, other stays at 0 kg
- [ ] Verify period filtering still works (user with trip only in "month" view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)