### PR TITLE
fix: revoke badges when trip deletion breaks thresholds

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -107,6 +107,7 @@ export function useDeleteTrip() {
       qc.invalidateQueries({ queryKey: ["stats"] });
       qc.invalidateQueries({ queryKey: ["leaderboard"] });
       qc.invalidateQueries({ queryKey: ["profile"] });
+      qc.invalidateQueries({ queryKey: ["achievements"] });
     },
   });
 }

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -1,4 +1,4 @@
-import { eq, sum, count } from "drizzle-orm";
+import { eq, and, sum, count, inArray } from "drizzle-orm";
 import { db } from "../db";
 import { trips, achievements } from "../db/schema";
 import { computeStreak } from "./streaks";
@@ -82,4 +82,62 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
   }
 
   return newlyUnlocked;
+}
+
+/**
+ * Re-evaluate all unlocked badges for a user and revoke any whose thresholds
+ * are no longer met. This should be called after trip deletion.
+ *
+ * @returns Array of BadgeIds that were revoked.
+ */
+export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
+  // 1. Aggregate lifetime stats (same query as evaluateAndUnlockBadges)
+  const [stats] = await db
+    .select({
+      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
+      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId));
+
+  const streaks = await computeStreak(userId);
+
+  const userStats: UserStats = {
+    totalDistanceKm: stats?.totalDistanceKm ?? 0,
+    totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
+    tripCount: stats?.tripCount ?? 0,
+    currentStreak: streaks.current,
+  };
+
+  // 2. Get all currently unlocked badges
+  const existing = await db
+    .select({ badgeId: achievements.badgeId })
+    .from(achievements)
+    .where(eq(achievements.userId, userId));
+
+  // 3. Check each unlocked badge against thresholds — collect those no longer met
+  const revoked: BadgeId[] = [];
+
+  for (const row of existing) {
+    const badgeId = row.badgeId as BadgeId;
+    const check = BADGE_THRESHOLDS[badgeId];
+    if (check && !check(userStats)) {
+      revoked.push(badgeId);
+    }
+  }
+
+  // 4. Delete revoked achievements
+  if (revoked.length > 0) {
+    await db
+      .delete(achievements)
+      .where(
+        and(
+          eq(achievements.userId, userId),
+          inArray(achievements.badgeId, revoked),
+        ),
+      );
+  }
+
+  return revoked;
 }

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -11,7 +11,7 @@ import { calculateSavings } from "../lib/calculations";
 import { getFuelPrice } from "../lib/fuel-price";
 import { notFound, forbidden } from "../lib/errors";
 import { paginationToOffset, buildPagination } from "../lib/pagination";
-import { evaluateAndUnlockBadges } from "../lib/badges";
+import { evaluateAndUnlockBadges, reevaluateBadges } from "../lib/badges";
 import type { AuthEnv } from "../types/context";
 
 const tripsRouter = new Hono<AuthEnv>();
@@ -129,7 +129,10 @@ tripsRouter.delete(
 
     await db.delete(trips).where(eq(trips.id, id));
 
-    return c.json({ ok: true, data: null });
+    // Re-evaluate badges — revoke any that are no longer earned
+    const revokedBadges = await reevaluateBadges(currentUser.id);
+
+    return c.json({ ok: true, data: { revokedBadges } });
   },
 );
 


### PR DESCRIPTION
## Summary
- Add `reevaluateBadges(userId)` function in `server/src/lib/badges.ts` that checks all unlocked badges against current thresholds and deletes any that are no longer earned
- Call `reevaluateBadges` after successful trip deletion in the DELETE `/api/trips/:id` endpoint
- Invalidate the `achievements` query cache in `useDeleteTrip` so the client reflects revoked badges immediately

## Test plan
- [ ] Delete a trip that was the user's only trip — verify the `first_trip` badge is revoked
- [ ] Delete trips until below a threshold (e.g., drop from 10 to 9 trips) — verify `trips_10` badge is revoked
- [ ] Delete a trip and confirm the achievements list updates in the UI without a manual refresh
- [ ] Confirm that badges still within thresholds are not affected
- [ ] Confirm streak-based badges are re-evaluated correctly after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)