### PR TITLE
fix: load all weekly trips for stats chart

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -36,6 +36,27 @@ export function useTrips(page = 1, limit = 50) {
   });
 }
 
+export function useWeeklyTrips() {
+  const now = new Date();
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+  monday.setHours(0, 0, 0, 0);
+  const from = monday.toISOString();
+  const to = now.toISOString();
+
+  return useQuery({
+    queryKey: ["trips", "weekly", from],
+    queryFn: () =>
+      apiFetch<{
+        ok: boolean;
+        data: { trips: Trip[] };
+        pagination: { page: number; limit: number; total: number; totalPages: number };
+      }>(`/trips?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&limit=100`).then(
+        (r) => r.data.trips,
+      ),
+  });
+}
+
 export function useLeaderboard(period: StatsPeriod = "all") {
   return useQuery({
     queryKey: ["leaderboard", period],

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "recharts";
 import { BADGES } from "@ecoride/shared/types";
 import type { BadgeId } from "@ecoride/shared/types";
-import { useDashboardSummary, useTrips, useAchievements, useDeleteTrip } from "@/hooks/queries";
+import { useDashboardSummary, useTrips, useWeeklyTrips, useAchievements, useDeleteTrip } from "@/hooks/queries";
 
 type Period = "week" | "month" | "year";
 type Metric = "km" | "co2" | "eur";
@@ -38,10 +38,11 @@ export function StatsPage() {
   const [selectedTrip, setSelectedTrip] = useState<Trip | null>(null);
   const { data: s, isPending: summaryLoading } = useDashboardSummary("month");
   const { data: tripsData, isPending: tripsLoading } = useTrips(1, 10);
+  const { data: weeklyTrips, isPending: weeklyLoading } = useWeeklyTrips();
   const { data: achievements, isPending: achievementsLoading } = useAchievements();
   const deleteTrip = useDeleteTrip();
 
-  const isPending = summaryLoading || tripsLoading || achievementsLoading;
+  const isPending = summaryLoading || tripsLoading || weeklyLoading || achievementsLoading;
 
   if (isPending || !s) {
     return (
@@ -52,23 +53,18 @@ export function StatsPage() {
   }
 
   const trips = tripsData?.trips ?? [];
+  const chartTrips = weeklyTrips ?? [];
 
-  // Build weekly chart data from recent trips
+  // Build weekly chart data from all trips this week
   const weeklyData = DAY_LABELS.map((day) => ({ day, km: 0, co2: 0, eur: 0 }));
-  const now = new Date();
-  const mondayStart = new Date(now);
-  mondayStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
-  mondayStart.setHours(0, 0, 0, 0);
 
-  for (const trip of trips) {
+  for (const trip of chartTrips) {
     const tripDate = new Date(trip.startedAt);
-    if (tripDate >= mondayStart) {
-      const dayIdx = (tripDate.getDay() + 6) % 7; // Mon=0, Sun=6
-      if (weeklyData[dayIdx]) {
-        weeklyData[dayIdx].km += trip.distanceKm;
-        weeklyData[dayIdx].co2 += trip.co2SavedKg;
-        weeklyData[dayIdx].eur += trip.moneySavedEur;
-      }
+    const dayIdx = (tripDate.getDay() + 6) % 7; // Mon=0, Sun=6
+    if (weeklyData[dayIdx]) {
+      weeklyData[dayIdx].km += trip.distanceKm;
+      weeklyData[dayIdx].co2 += trip.co2SavedKg;
+      weeklyData[dayIdx].eur += trip.moneySavedEur;
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `useWeeklyTrips()` hook that fetches trips filtered by current week date range (`from`/`to` query params, limit 100) instead of relying on paginated `useTrips(1, 10)`
- StatsPage chart now uses the date-filtered weekly trips for complete chart data
- "Activite recente" list still uses `useTrips(1, 10)` for showing latest trips

## Problem
The stats chart was built from `useTrips(1, 10)` which only fetched 10 trips. If a user had more than 10 trips in a week, the chart was incomplete.

## Test plan
- [ ] Verify the weekly chart displays all trips for the current week
- [ ] Verify "Activite recente" still shows the 10 most recent trips
- [ ] Verify loading spinner shows while both queries are pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)