### PR TITLE
feat: redesign Dashboard as quick-action entry point

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,27 +1,16 @@
-import { useState } from "react";
 import { Link } from "react-router";
-import { Bike, Leaf, Euro, TrendingUp, Trash2, X } from "lucide-react";
-import { PeriodSwitcher } from "@/components/ui/PeriodSwitcher";
-import { StatCard } from "@/components/ui/StatCard";
+import { Bike, Leaf, MapPin, ChevronRight } from "lucide-react";
 import { ImpactMeter } from "@/components/ui/ImpactMeter";
-import { useDashboardSummary, useTrips, useDeleteTrip } from "@/hooks/queries";
-import type { StatsPeriod } from "@ecoride/shared/api-contracts";
-import type { Trip } from "@ecoride/shared/types";
+import { useDashboardSummary } from "@/hooks/queries";
 import appLogo from "/pwa-192x192.png?url";
 
-type Period = "day" | "week" | "month";
-
 export function DashboardPage() {
-  const [period, setPeriod] = useState<Period>("week");
-  const [selectedTrip, setSelectedTrip] = useState<Trip | null>(null);
-  const { data: s, isPending } = useDashboardSummary(period as StatsPeriod);
-  const { data: tripsData } = useTrips(1, 5);
-  const deleteTrip = useDeleteTrip();
+  const { data: today, isPending: todayPending } = useDashboardSummary("day");
+  const { data: allTime, isPending: allTimePending } = useDashboardSummary("all");
 
-  const recentTrips = tripsData?.trips ?? [];
-  const hasNoTrips = recentTrips.length === 0 && s?.tripCount === 0;
+  const isPending = todayPending || allTimePending;
 
-  if (isPending || !s) {
+  if (isPending || !today || !allTime) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
@@ -29,17 +18,20 @@ export function DashboardPage() {
     );
   }
 
+  const isNewUser = allTime.tripCount === 0;
 
   return (
     <>
       {/* Header */}
       <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-2xl font-black tracking-tighter">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </span>
       </header>
 
-      {hasNoTrips ? (
+      {isNewUser ? (
+        /* ---- Empty state: first-time user ---- */
         <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6">
           <img src={appLogo} alt="ecoRide" className="h-20 w-20 rounded-2xl" />
           <div className="flex flex-col items-center gap-2 text-center">
@@ -49,181 +41,107 @@ export function DashboardPage() {
               <span className="text-primary-light">Ride</span> !
             </h2>
             <p className="max-w-xs text-sm text-text-muted">
-              Enregistrez votre premier trajet vélo pour commencer à suivre vos économies CO₂.
+              Enregistrez votre premier trajet vélo pour commencer à suivre vos
+              économies CO₂.
             </p>
           </div>
           <Link
             to="/trip"
-            className="mt-2 rounded-xl bg-primary px-8 py-3 text-sm font-bold text-bg transition-colors hover:bg-primary-light"
+            className="mt-2 flex items-center gap-3 rounded-xl bg-primary px-8 py-4 text-sm font-bold text-bg transition-colors hover:bg-primary-light active:scale-95"
           >
+            <Bike size={20} />
             Démarrer un trajet
           </Link>
         </div>
       ) : (
-      <div className="flex flex-col gap-6 px-6 pb-6">
-        {/* Period Switcher */}
-        <PeriodSwitcher value={period} onChange={setPeriod} />
-
-        {/* Stat Cards Row */}
-        <div className="grid grid-cols-3 gap-3">
-          <StatCard icon={Bike} value={s.totalDistanceKm.toFixed(1)} unit="km" />
-          <StatCard icon={Leaf} value={s.totalCo2SavedKg.toFixed(1)} unit="kg CO₂" />
-          <StatCard icon={Euro} value={s.totalMoneySavedEur.toFixed(2)} unit="€" />
-        </div>
-
-        {/* Comparison Card */}
-        <div className="flex items-center justify-between rounded-xl bg-surface-container p-5">
-          <div className="flex flex-col">
-            <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-text-muted">
-              Économie Mensuelle
-            </span>
-            <span className="mt-1 text-xl font-black">
-              {s.totalMoneySavedEur.toFixed(0)}€{" "}
-              <span className="text-sm font-medium text-text-muted">
-                économisés
-              </span>
-            </span>
-          </div>
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-            <TrendingUp size={20} className="text-primary-light" />
-          </div>
-        </div>
-
-        {/* Impact Meter */}
-        <ImpactMeter co2TotalKg={s.totalCo2SavedKg} />
-
-        {/* Streak + Goal */}
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between px-2">
-            <div className="flex items-center gap-2">
-              <span className="text-lg">🔥</span>
-              <span className="text-sm font-black uppercase tracking-wider text-text">
-                {s.currentStreak} jours consécutifs
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-4 rounded-xl bg-surface-container p-5">
-            <div className="flex items-end justify-between">
-              <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
-                Objectif mensuel
-              </span>
-              <span className="text-lg font-black">
-                {Math.round(s.totalDistanceKm)}
-                <span className="text-sm font-medium text-text-muted">
-                  /100 km
-                </span>
-              </span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-surface-highest">
-              <div
-                className="h-full rounded-full bg-primary-light"
-                style={{ width: `${Math.min(s.totalDistanceKm, 100)}%` }}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Recent Trips */}
-        {recentTrips.length > 0 && (
-          <section className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xs font-bold uppercase tracking-widest text-text-muted">
-                Derniers trajets
-              </h3>
-              <Link to="/stats" className="text-xs font-bold text-primary-light">
-                Tout voir
-              </Link>
-            </div>
-            {recentTrips.map((trip) => (
-              <button
-                key={trip.id}
-                onClick={() => setSelectedTrip(trip)}
-                className="flex w-full items-center justify-between rounded-xl bg-surface-container p-4 text-left active:scale-[0.98] transition-transform"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-surface-high">
-                    <Bike size={18} className="text-primary-light" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-bold">{trip.distanceKm} km</p>
-                    <p className="text-[10px] text-text-muted">
-                      {new Date(trip.startedAt).toLocaleDateString("fr-FR", {
-                        day: "numeric",
-                        month: "short",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </p>
-                  </div>
-                </div>
-                <span className="text-xs font-bold text-primary-light">
-                  {trip.co2SavedKg.toFixed(1)} kg CO₂
-                </span>
-              </button>
-            ))}
-          </section>
-        )}
-      </div>
-      )}
-
-      {/* Bottom sheet — trip detail / delete */}
-      {selectedTrip && (
-        <div
-          className="fixed inset-0 z-[60] flex items-end justify-center"
-          onClick={() => setSelectedTrip(null)}
-        >
-          <div className="absolute inset-0 bg-black/50" />
-          <div
-            className="relative w-full max-w-lg rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
-            onClick={(e) => e.stopPropagation()}
+        /* ---- Main dashboard ---- */
+        <div className="flex flex-col gap-6 px-6 pb-6">
+          {/* Quick Action CTA */}
+          <Link
+            to="/trip"
+            className="group flex items-center justify-between rounded-2xl bg-primary p-6 shadow-[0_8px_32px_rgba(46,204,113,0.25)] transition-all hover:bg-primary-light active:scale-[0.98]"
           >
-            <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-surface-highest" />
-            <div className="mb-6 flex items-start justify-between">
-              <div>
-                <h3 className="text-lg font-bold">Trajet</h3>
-                <p className="text-sm text-text-muted">
-                  {new Date(selectedTrip.startedAt).toLocaleDateString("fr-FR", {
-                    weekday: "long",
-                    day: "numeric",
-                    month: "long",
-                  })}
-                </p>
-              </div>
-              <button
-                onClick={() => setSelectedTrip(null)}
-                className="rounded-lg p-2 text-text-muted active:bg-surface-high"
-              >
-                <X size={20} />
-              </button>
-            </div>
-            <div className="mb-6 grid grid-cols-3 gap-4 text-center">
-              <div>
-                <p className="text-xl font-bold text-primary-light">{selectedTrip.distanceKm}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">km</p>
+            <div className="flex items-center gap-4">
+              <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-bg/20">
+                <Bike size={28} className="text-bg" />
               </div>
               <div>
-                <p className="text-xl font-bold text-primary-light">{selectedTrip.co2SavedKg.toFixed(1)}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">kg CO₂</p>
-              </div>
-              <div>
-                <p className="text-xl font-bold text-primary-light">{selectedTrip.moneySavedEur.toFixed(2)}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">€</p>
+                <span className="block text-lg font-black text-bg">
+                  Démarrer un trajet
+                </span>
+                <span className="block text-sm font-medium text-bg/70">
+                  GPS ou saisie manuelle
+                </span>
               </div>
             </div>
-            <button
-              onClick={() => {
-                deleteTrip.mutate(selectedTrip.id, {
-                  onSuccess: () => setSelectedTrip(null),
-                });
-              }}
-              disabled={deleteTrip.isPending}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-danger/10 py-3 text-sm font-bold text-danger active:scale-95 disabled:opacity-50"
-            >
-              <Trash2 size={16} />
-              {deleteTrip.isPending ? "Suppression..." : "Supprimer ce trajet"}
-            </button>
+            <ChevronRight
+              size={24}
+              className="text-bg/60 transition-transform group-hover:translate-x-1"
+            />
+          </Link>
+
+          {/* Today's Summary */}
+          <section className="rounded-xl bg-surface-container p-5">
+            <h3 className="mb-4 text-xs font-bold uppercase tracking-widest text-text-muted">
+              Aujourd'hui
+            </h3>
+            {today.tripCount > 0 ? (
+              <div className="grid grid-cols-3 gap-4 text-center">
+                <div>
+                  <div className="flex items-center justify-center gap-1">
+                    <MapPin size={14} className="text-primary-light" />
+                    <span className="text-2xl font-black text-text">
+                      {today.tripCount}
+                    </span>
+                  </div>
+                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                    {today.tripCount > 1 ? "trajets" : "trajet"}
+                  </span>
+                </div>
+                <div>
+                  <div className="flex items-center justify-center gap-1">
+                    <Bike size={14} className="text-primary-light" />
+                    <span className="text-2xl font-black text-text">
+                      {today.totalDistanceKm.toFixed(1)}
+                    </span>
+                  </div>
+                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                    km
+                  </span>
+                </div>
+                <div>
+                  <div className="flex items-center justify-center gap-1">
+                    <Leaf size={14} className="text-primary-light" />
+                    <span className="text-2xl font-black text-text">
+                      {today.totalCo2SavedKg.toFixed(1)}
+                    </span>
+                  </div>
+                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                    kg CO₂
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p className="text-center text-sm text-text-muted">
+                Pas encore de trajet aujourd'hui — c'est le moment !
+              </p>
+            )}
+          </section>
+
+          {/* Streak */}
+          <div className="flex items-center gap-3 rounded-xl bg-surface-container px-5 py-4">
+            <span className="text-xl">
+              {allTime.currentStreak > 0 ? "\uD83D\uDD25" : "\uD83D\uDEF4"}
+            </span>
+            <span className="text-sm font-bold text-text">
+              {allTime.currentStreak > 0
+                ? `${allTime.currentStreak} jour${allTime.currentStreak > 1 ? "s" : ""} consécutif${allTime.currentStreak > 1 ? "s" : ""}`
+                : "Commencez votre série !"}
+            </span>
           </div>
+
+          {/* Impact Meter (all-time) */}
+          <ImpactMeter co2TotalKg={allTime.totalCo2SavedKg} />
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- **Replaced** the stats-heavy Dashboard (period switcher, stat cards, recent trips, monthly savings, goal bar) with a focused daily motivation + quick action screen
- **Added** a prominent "Demarrer un trajet" CTA card as the hero element linking to `/trip`
- **Added** compact "Aujourd'hui" summary card showing today's trip count, distance, and CO2 saved (with empty-state nudge)
- **Added** streak display using all-time data (fire emoji for active streaks, encouraging message for zero)
- **Kept** the ImpactMeter component powered by all-time CO2 data (`useDashboardSummary("all")`)
- **Kept** the empty state for first-time users with app logo, welcome message, and CTA
- **Removed** period switcher, stat cards row, recent trips list, monthly savings card, goal progress bar, and trip deletion bottom sheet (all live in Stats page)

## Test plan
- [ ] Verify Dashboard loads correctly for a user with existing trips
- [ ] Verify the "Demarrer un trajet" CTA navigates to `/trip`
- [ ] Verify "Aujourd'hui" card shows today's stats or empty-state message
- [ ] Verify streak displays correctly (active streak vs zero)
- [ ] Verify ImpactMeter shows all-time CO2 data
- [ ] Verify empty state appears for brand-new users (zero trips ever)
- [ ] Verify Stats page still has all the detailed stats, charts, and trip management

🤖 Generated with [Claude Code](https://claude.com/claude-code)