### PR TITLE
fix: auto-purge SW caches on version change

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,23 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { App } from "./App";
 import "./app.css";
 
+// Purge all SW caches when app version changes
+(async () => {
+  const CACHE_VERSION_KEY = "ecoride-version";
+  const prev = localStorage.getItem(CACHE_VERSION_KEY);
+  if (prev !== __APP_VERSION__) {
+    localStorage.setItem(CACHE_VERSION_KEY, __APP_VERSION__);
+    if (prev !== null) {
+      // Version changed — nuke all caches and reload once
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      window.location.reload();
+    }
+  }
+})();
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
## Summary
- On app startup, compare stored version with `__APP_VERSION__`
- If version changed: delete all SW caches, unregister service workers, reload
- Ensures PWA users always get fresh assets after a deploy (no more stale cached images)

## Test plan
- [ ] Deploy new version → open PWA → should auto-reload with fresh cache
- [ ] First visit (no stored version) → no reload, just stores version
- [ ] Same version → no reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)