### PR TITLE
feat: wire push notification subscribe/unsubscribe in profile

### DIFF
--- a/client/src/hooks/usePushNotifications.ts
+++ b/client/src/hooks/usePushNotifications.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  isPushSupported,
+  subscribeToPush,
+  unsubscribeFromPush,
+  getCurrentPushSubscription,
+} from "@/lib/push";
+import { useUpdateProfile } from "./queries";
+
+export type PushStatus =
+  | "loading"       // checking current state
+  | "unsupported"   // browser doesn't support push
+  | "denied"        // user denied permission
+  | "subscribed"    // active subscription
+  | "unsubscribed"; // no subscription, can enable
+
+export function usePushNotifications() {
+  const [status, setStatus] = useState<PushStatus>("loading");
+  const [busy, setBusy] = useState(false);
+  const updateProfile = useUpdateProfile();
+
+  // Check initial state
+  useEffect(() => {
+    if (!isPushSupported()) {
+      setStatus("unsupported");
+      return;
+    }
+
+    if (Notification.permission === "denied") {
+      setStatus("denied");
+      return;
+    }
+
+    getCurrentPushSubscription().then((sub) => {
+      setStatus(sub ? "subscribed" : "unsubscribed");
+    });
+  }, []);
+
+  const toggle = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+
+    try {
+      if (status === "subscribed") {
+        // Unsubscribe
+        await unsubscribeFromPush();
+        updateProfile.mutate({ reminderEnabled: false });
+        setStatus("unsubscribed");
+      } else {
+        // Subscribe
+        const subscription = await subscribeToPush();
+        if (subscription) {
+          updateProfile.mutate({ reminderEnabled: true });
+          setStatus("subscribed");
+        } else {
+          // Permission denied
+          setStatus("denied");
+        }
+      }
+    } catch (err) {
+      console.error("Push notification toggle failed:", err);
+    } finally {
+      setBusy(false);
+    }
+  }, [status, busy, updateProfile]);
+
+  return { status, busy, toggle };
+}

--- a/client/src/lib/push.ts
+++ b/client/src/lib/push.ts
@@ -1,0 +1,95 @@
+import { apiFetch } from "./api";
+
+/**
+ * Convert a URL-safe base64 string to a Uint8Array
+ * (needed for applicationServerKey in pushManager.subscribe).
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/** Check whether the browser supports push notifications. */
+export function isPushSupported(): boolean {
+  return "Notification" in window && "serviceWorker" in navigator && "PushManager" in window;
+}
+
+/** Fetch the VAPID public key from the server. */
+async function getVapidPublicKey(): Promise<string> {
+  const res = await apiFetch<{ ok: boolean; data: { publicKey: string } }>(
+    "/push/vapid-key",
+  );
+  return res.data.publicKey;
+}
+
+/**
+ * Subscribe the browser to push notifications.
+ * Returns the PushSubscription on success, or null on failure.
+ */
+export async function subscribeToPush(): Promise<PushSubscription | null> {
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    return null;
+  }
+
+  const registration = await navigator.serviceWorker.ready;
+  const vapidPublicKey = await getVapidPublicKey();
+
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
+  });
+
+  // Send subscription to server
+  const keys = subscription.toJSON().keys!;
+  await apiFetch("/push/subscribe", {
+    method: "POST",
+    body: JSON.stringify({
+      endpoint: subscription.endpoint,
+      keys: {
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      },
+    }),
+  });
+
+  return subscription;
+}
+
+/**
+ * Unsubscribe the browser from push notifications.
+ */
+export async function unsubscribeFromPush(): Promise<void> {
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+
+  if (subscription) {
+    // Remove from server first
+    await apiFetch("/push/subscribe", {
+      method: "DELETE",
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    });
+
+    // Then unsubscribe locally
+    await subscription.unsubscribe();
+  }
+}
+
+/**
+ * Get the current push subscription, if any.
+ */
+export async function getCurrentPushSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null;
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    return await registration.pushManager.getSubscription();
+  } catch {
+    return null;
+  }
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -4,13 +4,16 @@ import {
   User as UserIcon,
   Bike,
   Bell,
+  BellOff,
   Shield,
   ChevronRight,
   LogOut,
+  Loader2,
 } from "lucide-react";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
 import { useProfile, useAchievements, useUpdateProfile } from "@/hooks/queries";
+import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { signOut } from "@/lib/auth";
 
 const allBadgeIds = Object.keys(BADGES) as BadgeId[];
@@ -20,6 +23,8 @@ export function ProfilePage() {
   const { data: profileData, isPending: profileLoading } = useProfile();
   const { data: achievements, isPending: achievementsLoading } = useAchievements();
   const updateProfile = useUpdateProfile();
+
+  const push = usePushNotifications();
 
   const [showVehicle, setShowVehicle] = useState(false);
   const [vehicleModel, setVehicleModel] = useState("");
@@ -228,30 +233,84 @@ export function ProfilePage() {
         <section className="space-y-2">
           <h2 className="mb-4 text-lg font-bold tracking-tight">Paramètres</h2>
           <div className="overflow-hidden rounded-lg bg-surface-low">
-            {[
-              { icon: UserIcon, label: "Informations personnelles" },
-              {
-                icon: Bike,
-                label: "Mon véhicule",
-                onClick: () => setShowVehicle(!showVehicle),
-              },
-              { icon: Bell, label: "Notifications" },
-              { icon: Shield, label: "Confidentialité" },
-            ].map(({ icon: Icon, label, onClick }, i) => (
-              <div key={label}>
-                {i > 0 && <div className="mx-4 h-px bg-white/5" />}
-                <button
-                  onClick={onClick}
-                  className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
-                >
-                  <div className="flex items-center gap-4">
-                    <Icon size={20} className="text-text-muted" />
-                    <span className="text-sm font-medium">{label}</span>
-                  </div>
-                  <ChevronRight size={18} className="text-text-dim" />
-                </button>
+            {/* Informations personnelles */}
+            <button className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high">
+              <div className="flex items-center gap-4">
+                <UserIcon size={20} className="text-text-muted" />
+                <span className="text-sm font-medium">Informations personnelles</span>
               </div>
-            ))}
+              <ChevronRight size={18} className="text-text-dim" />
+            </button>
+
+            <div className="mx-4 h-px bg-white/5" />
+
+            {/* Mon véhicule */}
+            <button
+              onClick={() => setShowVehicle(!showVehicle)}
+              className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
+            >
+              <div className="flex items-center gap-4">
+                <Bike size={20} className="text-text-muted" />
+                <span className="text-sm font-medium">Mon véhicule</span>
+              </div>
+              <ChevronRight size={18} className="text-text-dim" />
+            </button>
+
+            <div className="mx-4 h-px bg-white/5" />
+
+            {/* Notifications — toggle */}
+            <div className="flex w-full items-center justify-between p-4">
+              <div className="flex items-center gap-4">
+                {push.status === "subscribed" ? (
+                  <Bell size={20} className="text-primary-light" />
+                ) : (
+                  <BellOff size={20} className="text-text-muted" />
+                )}
+                <div className="flex flex-col items-start">
+                  <span className="text-sm font-medium">Notifications</span>
+                  {push.status === "unsupported" && (
+                    <span className="text-[10px] text-text-dim">Non supporté par ce navigateur</span>
+                  )}
+                  {push.status === "denied" && (
+                    <span className="text-[10px] text-text-dim">Autorisation refusée dans les paramètres du navigateur</span>
+                  )}
+                  {push.status === "subscribed" && (
+                    <span className="text-[10px] text-primary/70">Activées</span>
+                  )}
+                </div>
+              </div>
+              {(push.status === "subscribed" || push.status === "unsubscribed") && (
+                <button
+                  onClick={push.toggle}
+                  disabled={push.busy}
+                  aria-label={push.status === "subscribed" ? "Désactiver les notifications" : "Activer les notifications"}
+                  className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
+                    push.status === "subscribed" ? "bg-primary" : "bg-surface-high"
+                  }`}
+                >
+                  {push.busy ? (
+                    <Loader2 size={14} className="mx-auto animate-spin text-text-dim" />
+                  ) : (
+                    <span
+                      className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
+                        push.status === "subscribed" ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                  )}
+                </button>
+              )}
+            </div>
+
+            <div className="mx-4 h-px bg-white/5" />
+
+            {/* Confidentialité */}
+            <button className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high">
+              <div className="flex items-center gap-4">
+                <Shield size={20} className="text-text-muted" />
+                <span className="text-sm font-medium">Confidentialité</span>
+              </div>
+              <ChevronRight size={18} className="text-text-dim" />
+            </button>
           </div>
 
           <button


### PR DESCRIPTION
## Summary
- Wire up the non-functional "Notifications" button in the profile page with actual push notification subscribe/unsubscribe logic
- Add `client/src/lib/push.ts` with helpers: `urlBase64ToUint8Array`, `subscribeToPush`, `unsubscribeFromPush`, `getCurrentPushSubscription`, `isPushSupported`
- Add `client/src/hooks/usePushNotifications.ts` hook that manages push state (`loading`, `unsupported`, `denied`, `subscribed`, `unsubscribed`) and exposes a `toggle` function
- Replace the static Notifications menu item with a toggle switch that requests browser permission, subscribes via VAPID/PushManager, sends the subscription to `POST /api/push/subscribe`, and updates `reminderEnabled` on the user profile

## Behavior
- **Toggle ON**: requests `Notification.requestPermission()`, fetches VAPID key from `GET /api/push/vapid-key`, creates push subscription via service worker, sends it to `POST /api/push/subscribe`, sets `reminderEnabled: true`
- **Toggle OFF**: calls `subscription.unsubscribe()`, sends `DELETE /api/push/subscribe`, sets `reminderEnabled: false`
- **Unsupported browser**: shows "Non support par ce navigateur" (no toggle)
- **Permission denied**: shows "Autorisation refusee dans les parametres du navigateur" (no toggle)
- **Subscribed**: shows green Bell icon + "Activees" label

## Test plan
- [ ] On a supported browser (Chrome/Edge), tap the toggle to enable notifications -- browser permission prompt should appear
- [ ] After granting permission, verify the toggle shows "Activees" and the Bell icon is highlighted
- [ ] Tap the toggle again to disable -- verify it reverts to off state
- [ ] On Safari/Firefox, verify appropriate fallback behavior
- [ ] Deny permission in browser settings, reload -- verify "Autorisation refusee" message appears with no toggle
- [ ] Verify `bun run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)