### PR TITLE
feat: push notifications for badge unlocks and leaderboard overtakes

### DIFF
--- a/server/src/lib/leaderboard-notifications.ts
+++ b/server/src/lib/leaderboard-notifications.ts
@@ -1,0 +1,70 @@
+import { eq, sql, sum, desc } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import { trips } from "../db/schema";
+import { sendPushToUser } from "./push";
+
+/**
+ * After a trip is created, check if the user overtook anyone on the all-time
+ * CO2 leaderboard and send push notifications to both parties.
+ *
+ * "Overtaken" = any opted-in user whose total CO2 is now strictly less than
+ * the current user's total, but was >= before this trip (i.e. their total
+ * falls within [userTotal - tripCo2, userTotal)).
+ */
+export async function checkLeaderboardChanges(
+  userId: string,
+  tripCo2SavedKg: number,
+): Promise<void> {
+  try {
+    // 1. Get full all-time leaderboard (only opted-in users)
+    const entries = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+      })
+      .from(user)
+      .leftJoin(trips, eq(user.id, trips.userId))
+      .where(eq(user.leaderboardOptOut, false))
+      .groupBy(user.id, user.name)
+      .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`));
+
+    // 2. Find the current user in the results
+    const currentEntry = entries.find((e) => e.userId === userId);
+    if (!currentEntry) return; // user opted out or not found
+
+    const currentTotal = currentEntry.totalCo2SavedKg;
+    const previousTotal = currentTotal - tripCo2SavedKg;
+
+    // 3. Find users who were just overtaken:
+    //    Their total is in [previousTotal, currentTotal) — they were ahead or tied
+    //    before, but are now behind.
+    const overtaken = entries.filter(
+      (e) =>
+        e.userId !== userId &&
+        e.totalCo2SavedKg >= previousTotal &&
+        e.totalCo2SavedKg < currentTotal,
+    );
+
+    if (overtaken.length === 0) return;
+
+    // 4. Send notifications (fire-and-forget, errors caught per-send)
+    for (const other of overtaken) {
+      // Notify the overtaken user
+      sendPushToUser(other.userId, {
+        title: "ecoRide",
+        body: `${currentEntry.name} vient de vous dépasser au classement ! 🏆`,
+      }).catch(() => {});
+
+      // Notify the current user
+      sendPushToUser(userId, {
+        title: "ecoRide",
+        body: `Vous venez de dépasser ${other.name} au classement ! 💪`,
+      }).catch(() => {});
+    }
+  } catch (err) {
+    // Never let leaderboard notification errors propagate
+    console.error("[leaderboard-notifications] Error:", err);
+  }
+}

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -12,6 +12,10 @@ import { getFuelPrice } from "../lib/fuel-price";
 import { notFound, forbidden } from "../lib/errors";
 import { paginationToOffset, buildPagination } from "../lib/pagination";
 import { evaluateAndUnlockBadges, reevaluateBadges } from "../lib/badges";
+import { sendPushToUser } from "../lib/push";
+import { checkLeaderboardChanges } from "../lib/leaderboard-notifications";
+import { BADGES } from "@ecoride/shared/types";
+import type { BadgeId } from "@ecoride/shared/types";
 import type { AuthEnv } from "../types/context";
 
 const tripsRouter = new Hono<AuthEnv>();
@@ -58,6 +62,18 @@ tripsRouter.post(
 
     // Evaluate badge thresholds and unlock any newly earned achievements
     const newBadges = await evaluateAndUnlockBadges(currentUser.id);
+
+    // Fire-and-forget: push notifications for newly unlocked badges
+    for (const badgeId of newBadges) {
+      const badge = BADGES[badgeId as BadgeId];
+      sendPushToUser(currentUser.id, {
+        title: "ecoRide",
+        body: `Badge débloqué : ${badge.label} ${badge.icon}`,
+      }).catch(() => {});
+    }
+
+    // Fire-and-forget: check leaderboard overtakes
+    checkLeaderboardChanges(currentUser.id, savings.co2SavedKg).catch(() => {});
 
     return c.json({ ok: true, data: { trip, newBadges } }, 201);
   },


### PR DESCRIPTION
## Summary
- Send push notifications when users unlock badges during trip creation, using badge label and icon from `BADGES` constant
- Detect leaderboard overtakes after trip creation: notify both the user who climbed and those who were passed
- All push sends are fire-and-forget (non-blocking) with error swallowing to never impact trip creation
- New helper `checkLeaderboardChanges()` in `server/src/lib/leaderboard-notifications.ts` queries the all-time leaderboard and compares CO2 totals before/after the trip

## Test plan
- [ ] Create a trip and verify badge unlock push notification is received when a new badge threshold is crossed
- [ ] Create a trip that pushes the user past another user's CO2 total and verify both parties receive leaderboard notifications
- [ ] Verify trip creation response is not delayed or affected when push service is unavailable
- [ ] Verify users with `leaderboardOptOut = true` are excluded from leaderboard notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)