### PR TITLE
feat: vehicle onboarding prompt + auto-name trips

### DIFF
--- a/client/src/lib/trip-utils.ts
+++ b/client/src/lib/trip-utils.ts
@@ -1,0 +1,9 @@
+export function tripLabel(startedAt: string): string {
+  const hour = new Date(startedAt).getHours();
+  if (hour < 6) return "Trajet de nuit";
+  if (hour < 10) return "Trajet du matin";
+  if (hour < 14) return "Trajet du midi";
+  if (hour < 18) return "Trajet de l'après-midi";
+  if (hour < 21) return "Trajet du soir";
+  return "Trajet de nuit";
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,12 +1,15 @@
+import { useState } from "react";
 import { Link } from "react-router";
-import { Bike, Leaf, MapPin, ChevronRight } from "lucide-react";
+import { Bike, Leaf, MapPin, ChevronRight, Car, X } from "lucide-react";
 import { ImpactMeter } from "@/components/ui/ImpactMeter";
-import { useDashboardSummary } from "@/hooks/queries";
+import { useDashboardSummary, useProfile } from "@/hooks/queries";
 import appLogo from "/pwa-192x192.png?url";
 
 export function DashboardPage() {
   const { data: today, isPending: todayPending } = useDashboardSummary("day");
   const { data: allTime, isPending: allTimePending } = useDashboardSummary("all");
+  const { data: profileData } = useProfile();
+  const [vehiclePromptDismissed, setVehiclePromptDismissed] = useState(false);
 
   const isPending = todayPending || allTimePending;
 
@@ -79,6 +82,28 @@ export function DashboardPage() {
               className="text-bg/60 transition-transform group-hover:translate-x-1"
             />
           </Link>
+
+          {/* Vehicle onboarding prompt */}
+          {!vehiclePromptDismissed &&
+            profileData?.user.consumptionL100 == null &&
+            allTime.tripCount > 0 && (
+              <div className="flex items-center gap-3 rounded-xl border border-warning/20 bg-warning/10 px-4 py-3">
+                <Car size={18} className="shrink-0 text-warning" />
+                <Link
+                  to="/profile"
+                  className="flex-1 text-xs font-medium text-text"
+                >
+                  Configurez votre véhicule de référence pour des calculs CO₂
+                  plus précis
+                </Link>
+                <button
+                  onClick={() => setVehiclePromptDismissed(true)}
+                  className="shrink-0 rounded p-1 text-text-muted hover:text-text"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            )}
 
           {/* Today's Summary */}
           <section className="rounded-xl bg-surface-container p-5">

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -15,6 +15,7 @@ import L from "leaflet";
 import { BADGES } from "@ecoride/shared/types";
 import type { BadgeId } from "@ecoride/shared/types";
 import { useDashboardSummary, useTrips, useTrip, useWeeklyTrips, useAchievements, useDeleteTrip } from "@/hooks/queries";
+import { tripLabel } from "@/lib/trip-utils";
 
 type Period = "week" | "month" | "year";
 type Metric = "km" | "co2" | "eur";
@@ -313,7 +314,7 @@ export function StatsPage() {
                     <Bike size={20} className="text-primary-light" />
                   </div>
                   <div>
-                    <p className="text-sm font-bold">Trajet</p>
+                    <p className="text-sm font-bold">{tripLabel(trip.startedAt)}</p>
                     <p className="text-[10px] font-medium text-on-surface-variant">
                       {new Date(trip.startedAt).toLocaleDateString("fr-FR", {
                         day: "numeric",
@@ -394,7 +395,7 @@ export function StatsPage() {
             {/* Header */}
             <div className="mb-6 flex items-start justify-between">
               <div>
-                <h3 className="text-lg font-bold">Trajet</h3>
+                <h3 className="text-lg font-bold">{tripLabel(selectedTrip.startedAt)}</h3>
                 <p className="text-sm text-text-muted">
                   {new Date(selectedTrip.startedAt).toLocaleDateString("fr-FR", {
                     weekday: "long",


### PR DESCRIPTION
## Summary
- **Vehicle onboarding prompt**: When a user has trips but hasn't configured their vehicle (`consumptionL100` is null), the Dashboard now shows a subtle dismissible card linking to `/profile` with the message "Configurez votre véhicule de référence pour des calculs CO₂ plus précis"
- **Auto-name trips by time of day**: Trips are no longer all labeled "Trajet" — they now display contextual names based on start hour (matin, midi, après-midi, soir, nuit) via a new `tripLabel()` utility, used in both the trip list and the trip detail bottom sheet on StatsPage

## Test plan
- [ ] Log in with a user that has trips but no `consumptionL100` set — verify the warning card appears on Dashboard between the CTA and Today's Summary
- [ ] Dismiss the card with the X button — verify it disappears for the session
- [ ] Set `consumptionL100` in profile — verify the card no longer appears
- [ ] Check StatsPage trip list — verify trips show time-based names (e.g. "Trajet du matin", "Trajet du soir")
- [ ] Tap a trip to open the detail sheet — verify the sheet header also shows the time-based name
- [ ] Verify new user empty state still works (no vehicle prompt shown when tripCount is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)