### PR TITLE
fix: use trip GPS coordinates for nearest station fuel price

### DIFF
--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -37,8 +37,9 @@ tripsRouter.post(
     const consumptionL100 = profile?.consumptionL100 ?? 7; // Default 7L/100km
     const fuelType = (profile?.fuelType ?? "sp95") as "sp95" | "sp98" | "diesel" | "e85" | "gpl";
 
-    // Get current fuel price
-    const fuelPriceData = await getFuelPrice(fuelType);
+    // Get current fuel price — use GPS coordinates for nearest station when available
+    const startPoint = data.gpsPoints?.[0];
+    const fuelPriceData = await getFuelPrice(fuelType, startPoint?.lat, startPoint?.lng);
     const fuelPriceEur = fuelPriceData.priceEur;
 
     const savings = calculateSavings({


### PR DESCRIPTION
## Summary
- When creating a trip with GPS tracking data, extract the first GPS point's lat/lng and pass it to `getFuelPrice()` so the fuel price comes from the nearest station (within 20km) instead of the national average.
- Manual trips (no GPS points) continue to use the national average as before.
- Server-only change: no client modifications needed since `gpsPoints` are already sent in the create trip request.

## Test plan
- [ ] Create a trip with GPS tracking enabled and verify the fuel price comes from a nearby station (check `stationName` in response or logs)
- [ ] Create a manual trip (no GPS points) and verify the national average is still used
- [ ] Verify typecheck passes (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)