### PR TITLE
feat: auto-update via server version polling

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,21 +7,34 @@ import { App } from "./App";
 import "./app.css";
 
 // Purge all SW caches when app version changes
+async function purgeAndReload() {
+  const names = await caches.keys();
+  await Promise.all(names.map((n) => caches.delete(n)));
+  const regs = await navigator.serviceWorker?.getRegistrations();
+  if (regs) await Promise.all(regs.map((r) => r.unregister()));
+  window.location.reload();
+}
+
 (async () => {
   const CACHE_VERSION_KEY = "ecoride-version";
   const prev = localStorage.getItem(CACHE_VERSION_KEY);
   if (prev !== __APP_VERSION__) {
     localStorage.setItem(CACHE_VERSION_KEY, __APP_VERSION__);
-    if (prev !== null) {
-      // Version changed — nuke all caches and reload once
-      const names = await caches.keys();
-      await Promise.all(names.map((n) => caches.delete(n)));
-      const regs = await navigator.serviceWorker?.getRegistrations();
-      if (regs) await Promise.all(regs.map((r) => r.unregister()));
-      window.location.reload();
-    }
+    if (prev !== null) await purgeAndReload();
   }
 })();
+
+// Poll server for new version every 5 minutes (catches updates while app stays open)
+setInterval(async () => {
+  try {
+    const res = await fetch("/api/health");
+    const data = await res.json();
+    if (data.version && data.version !== __APP_VERSION__) {
+      localStorage.setItem("ecoride-version", data.version);
+      await purgeAndReload();
+    }
+  } catch { /* offline or error — ignore */ }
+}, 5 * 60 * 1000);
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,8 +37,12 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
   return auth.handler(c.req.raw);
 });
 
-// ---- Health check (public) ----
-app.get("/api/health", (c) => c.json({ ok: true, status: "healthy" }));
+// ---- Health check + version (public) ----
+const appVersion = (() => {
+  try { return require("../../package.json").version; }
+  catch { return "unknown"; }
+})();
+app.get("/api/health", (c) => c.json({ ok: true, status: "healthy", version: appVersion }));
 
 // ---- Auth middleware for all other /api routes ----
 app.use("/api/*", authMiddleware);


### PR DESCRIPTION
## Summary
- Server `/api/health` now returns `version` from package.json
- Client polls `/api/health` every 5 minutes
- If server version differs from built-in `__APP_VERSION__`: purge caches + reload
- Catches updates even when the PWA stays open without being closed

## Test plan
- [ ] Deploy v1.2.0 → user has app open → within 5 min the app reloads with new version
- [ ] Offline: poll silently fails, no crash
- [ ] Same version: no reload triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)