### PR TITLE
fix: timezone-aware streak calculations

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -11,12 +11,14 @@ import type {
 
 // ---- Queries ----
 
+const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export function useDashboardSummary(period: StatsPeriod = "week") {
   return useQuery({
     queryKey: ["stats", "summary", period],
     queryFn: () =>
       apiFetch<{ ok: boolean; data: StatsSummaryResponse }>(
-        `/stats/summary?period=${period}`,
+        `/stats/summary?period=${period}&tz=${encodeURIComponent(browserTz)}`,
       ).then((r) => r.data),
   });
 }

--- a/server/src/lib/streaks.ts
+++ b/server/src/lib/streaks.ts
@@ -3,10 +3,33 @@ import { db } from "../db";
 import { trips } from "../db/schema";
 
 /**
+ * Format a Date as YYYY-MM-DD in the given IANA timezone.
+ * Falls back to UTC if the timezone is not provided.
+ */
+function dateToLocalDay(date: Date, tz?: string): string {
+  return date.toLocaleDateString("sv-SE", { timeZone: tz ?? "UTC" });
+}
+
+/**
+ * Get "today" as YYYY-MM-DD in the given IANA timezone.
+ */
+function todayInTz(tz?: string): string {
+  return dateToLocalDay(new Date(), tz);
+}
+
+/**
  * Compute the current streak (consecutive days with at least one trip)
  * and the longest streak ever recorded for a user.
+ *
+ * @param userId - The user to compute streaks for
+ * @param tz - Optional IANA timezone (e.g. "Europe/Paris") used to determine
+ *   "today" and to bucket trip timestamps into local calendar days.
+ *   Falls back to UTC when omitted (backward compatible).
  */
-export async function computeStreak(userId: string): Promise<{ current: number; longest: number }> {
+export async function computeStreak(
+  userId: string,
+  tz?: string,
+): Promise<{ current: number; longest: number }> {
   // Get distinct trip dates ordered descending
   const rows = await db
     .selectDistinctOn([trips.startedAt], {
@@ -18,12 +41,14 @@ export async function computeStreak(userId: string): Promise<{ current: number; 
 
   if (rows.length === 0) return { current: 0, longest: 0 };
 
-  // Extract unique dates (YYYY-MM-DD)
+  // Extract unique dates (YYYY-MM-DD) in the user's local timezone
   const dateSet = new Set<string>();
   for (const row of rows) {
-    dateSet.add(row.date.toISOString().slice(0, 10));
+    dateSet.add(dateToLocalDay(row.date, tz));
   }
   const dates = Array.from(dateSet).sort().reverse();
+
+  const today = todayInTz(tz);
 
   let current = 0;
   let longest = 0;
@@ -33,7 +58,9 @@ export async function computeStreak(userId: string): Promise<{ current: number; 
     const d = dates[i]!;
     if (i === 0) {
       // Streak counts only if the most recent trip was today or yesterday
-      const diffDays = Math.floor((Date.now() - new Date(d).getTime()) / 86400000);
+      const diffDays = Math.floor(
+        (new Date(today).getTime() - new Date(d).getTime()) / 86400000,
+      );
       if (diffDays > 1) {
         current = 0;
         streak = 1;

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -11,6 +11,7 @@ import type { StatsPeriod } from "@ecoride/shared/api-contracts";
 
 const statsQuery = z.object({
   period: z.enum(["day", "week", "month", "year", "all"]).default("month"),
+  tz: z.string().optional(),
 });
 
 function getPeriodStart(period: StatsPeriod): Date | null {
@@ -36,7 +37,7 @@ statsRouter.get(
   "/summary",
   zValidator("query", statsQuery, validationHook),
   async (c) => {
-    const { period } = c.req.valid("query");
+    const { period, tz } = c.req.valid("query");
     const currentUser = c.get("user");
 
     const periodStart = getPeriodStart(period);
@@ -54,7 +55,7 @@ statsRouter.get(
       .from(trips)
       .where(and(...conditions));
 
-    const streaks = await computeStreak(currentUser.id);
+    const streaks = await computeStreak(currentUser.id, tz);
 
     return c.json({
       ok: true,


### PR DESCRIPTION
## Summary
- Accept an optional `tz` query parameter (IANA timezone string) on `GET /api/stats/summary`
- Use the user's timezone to compute "today" and bucket trip dates into local calendar days when calculating streaks, fixing incorrect streak breaks for users in non-UTC timezones (e.g. a UTC+2 user riding at 11pm no longer sees it as "tomorrow")
- Client automatically sends the browser's timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`; falls back to UTC on the server if omitted

## Test plan
- [ ] Verify streak calculations remain correct when no `tz` param is sent (backward compatibility)
- [ ] Verify that passing `tz=Europe/Paris` correctly computes "today" in CET/CEST
- [ ] Verify a late-night trip (e.g. 11pm UTC+2) counts toward the correct local day
- [ ] Confirm the client sends the `tz` query parameter on the summary endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)