### PR TITLE
feat: account deletion and data export (GDPR)

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -177,3 +177,31 @@ export function useUpdateProfile() {
     },
   });
 }
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<{ ok: boolean }>("/user/profile", { method: "DELETE" }),
+  });
+}
+
+export function useExportData() {
+  return useMutation({
+    mutationFn: async () => {
+      const API_BASE = import.meta.env.VITE_API_URL || "/api";
+      const res = await fetch(`${API_BASE}/user/export`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Export failed");
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "ecoride-data-export.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+  });
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -11,10 +11,12 @@ import {
   Loader2,
   Check,
   Droplets,
+  Download,
+  Trash2,
 } from "lucide-react";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
-import { useProfile, useAchievements, useUpdateProfile, useFuelPrice } from "@/hooks/queries";
+import { useProfile, useAchievements, useUpdateProfile, useFuelPrice, useDeleteAccount, useExportData } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { signOut } from "@/lib/auth";
 
@@ -27,6 +29,8 @@ export function ProfilePage() {
   const updateProfile = useUpdateProfile();
 
   const push = usePushNotifications();
+  const deleteAccount = useDeleteAccount();
+  const exportData = useExportData();
 
   const userFuelType = profileData?.user?.fuelType ?? "sp95";
   const { data: fuelPrice, isPending: fuelPriceLoading } = useFuelPrice(userFuelType);
@@ -80,6 +84,20 @@ export function ProfilePage() {
   const handleLogout = async () => {
     await signOut();
     navigate("/login");
+  };
+
+  const handleDeleteAccount = () => {
+    const confirmed = window.confirm(
+      "Êtes-vous sûr ? Toutes vos données seront supprimées définitivement.",
+    );
+    if (!confirmed) return;
+    deleteAccount.mutate(undefined, {
+      onSuccess: () => navigate("/login"),
+    });
+  };
+
+  const handleExportData = () => {
+    exportData.mutate();
   };
 
   return (
@@ -430,6 +448,28 @@ export function ProfilePage() {
             <div className="flex items-center justify-center gap-2">
               <LogOut size={16} />
               Déconnexion
+            </div>
+          </button>
+
+          <button
+            onClick={handleExportData}
+            disabled={exportData.isPending}
+            className="mt-4 w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Download size={16} />
+              {exportData.isPending ? "Export en cours..." : "Exporter mes données"}
+            </div>
+          </button>
+
+          <button
+            onClick={handleDeleteAccount}
+            disabled={deleteAccount.isPending}
+            className="mt-4 w-full rounded-lg border border-red-500/30 bg-red-500/10 py-4 text-xs font-bold uppercase tracking-widest text-red-400 active:scale-95 disabled:opacity-50"
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Trash2 size={16} />
+              {deleteAccount.isPending ? "Suppression..." : "Supprimer mon compte"}
             </div>
           </button>
 

--- a/server/src/routes/users.routes.ts
+++ b/server/src/routes/users.routes.ts
@@ -3,7 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { eq, sum, count, sql } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
-import { trips } from "../db/schema";
+import { trips, achievements } from "../db/schema";
 import { updateUserSchema } from "../validators/users";
 import { validationHook } from "../lib/validation";
 import type { AuthEnv } from "../types/context";
@@ -65,5 +65,40 @@ usersRouter.patch(
     return c.json({ ok: true, data: { user: updated } });
   },
 );
+
+// GET /api/user/export — GDPR data export
+usersRouter.get("/export", async (c) => {
+  const currentUser = c.get("user");
+
+  const userTrips = await db
+    .select()
+    .from(trips)
+    .where(eq(trips.userId, currentUser.id));
+
+  const userAchievements = await db
+    .select()
+    .from(achievements)
+    .where(eq(achievements.userId, currentUser.id));
+
+  const exportData = {
+    profile: currentUser,
+    trips: userTrips,
+    achievements: userAchievements,
+    exportedAt: new Date().toISOString(),
+  };
+
+  c.header("Content-Disposition", 'attachment; filename="ecoride-data-export.json"');
+  c.header("Content-Type", "application/json");
+  return c.json(exportData);
+});
+
+// DELETE /api/user/profile — Delete account (GDPR right to erasure)
+usersRouter.delete("/profile", async (c) => {
+  const currentUser = c.get("user");
+
+  await db.delete(user).where(eq(user.id, currentUser.id));
+
+  return c.json({ ok: true });
+});
 
 export { usersRouter };


### PR DESCRIPTION
## Summary
- Add `DELETE /api/user/profile` endpoint that deletes the user from the DB (CASCADE cleans up trips, achievements, sessions, accounts, push subscriptions)
- Add `GET /api/user/export` endpoint that returns all user data (profile, trips, achievements) as a downloadable JSON file with Content-Disposition header
- Add `useDeleteAccount` and `useExportData` hooks in `client/src/hooks/queries.ts`
- Add "Exporter mes données" and "Supprimer mon compte" buttons to the profile page, below the logout button

## Test plan
- [ ] Tap "Exporter mes données" — should trigger a JSON file download containing profile, trips, and achievements
- [ ] Tap "Supprimer mon compte" — should show a confirmation dialog in French
- [ ] Cancel the confirmation — nothing should happen
- [ ] Confirm deletion — account should be deleted and user redirected to /login
- [ ] Verify CASCADE: after deletion, check that trips, achievements, sessions, accounts, and push subscriptions for that user are also gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)