### PR TITLE
feat: add basic accessibility attributes across all pages

### DIFF
--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -17,7 +17,7 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-4 pb-8 pt-3 backdrop-blur-2xl border-t border-outline-variant/10">
+    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-4 pb-8 pt-3 backdrop-blur-2xl border-t border-outline-variant/10">
       {tabs.map(({ to, icon: Icon, label }) => (
         <NavLink
           key={to}
@@ -33,7 +33,7 @@ export function BottomNav() {
         >
           {({ isActive }) => (
             <>
-              <Icon size={22} strokeWidth={isActive ? 2.2 : 1.8} />
+              <Icon size={22} strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
               <span className="text-[10px] font-bold uppercase tracking-widest">
                 {label}
               </span>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -15,7 +15,7 @@ export function DashboardPage() {
 
   if (isPending || !today || !allTime) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -26,7 +26,7 @@ export function DashboardPage() {
   return (
     <>
       {/* Header */}
-      <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-2xl font-black tracking-tighter">
           <span className="text-text">eco</span>
           <span className="text-primary-light">Ride</span>
@@ -98,6 +98,7 @@ export function DashboardPage() {
                 </Link>
                 <button
                   onClick={() => setVehiclePromptDismissed(true)}
+                  aria-label="Fermer"
                   className="shrink-0 rounded p-1 text-text-muted hover:text-text"
                 >
                   <X size={14} />

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -8,7 +8,7 @@ export function LeaderboardPage() {
 
   if (isPending || !data) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -22,7 +22,7 @@ export function LeaderboardPage() {
   return (
     <>
       {/* Header */}
-      <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-lg font-bold tracking-tight">
           <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
         </span>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -69,6 +69,7 @@ export function LoginPage() {
         {/* Google Sign In */}
         <button
           onClick={handleGoogleLogin}
+          aria-label="Se connecter avec Google"
           className="flex w-full items-center justify-center gap-3 rounded-xl bg-white px-6 py-4 text-sm font-bold text-gray-800 shadow-lg active:scale-95"
         >
           <svg width="20" height="20" viewBox="0 0 24 24">
@@ -102,35 +103,47 @@ export function LoginPage() {
         {/* Email/Password Form */}
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
           {isRegister && (
-            <input
-              type="text"
-              placeholder="Nom"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary"
-            />
+            <label>
+              <span className="sr-only">Nom</span>
+              <input
+                type="text"
+                placeholder="Nom"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                autoComplete="name"
+                className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary w-full"
+              />
+            </label>
           )}
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary"
-          />
-          <input
-            type="password"
-            placeholder="Mot de passe"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={8}
-            className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary"
-          />
+          <label>
+            <span className="sr-only">Email</span>
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary w-full"
+            />
+          </label>
+          <label>
+            <span className="sr-only">Mot de passe</span>
+            <input
+              type="password"
+              placeholder="Mot de passe"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              autoComplete={isRegister ? "new-password" : "current-password"}
+              className="rounded-xl border border-surface-high bg-surface px-4 py-3 text-white placeholder-text-muted outline-none focus:border-primary w-full"
+            />
+          </label>
 
           {error && (
-            <p className="text-sm text-red-400">{error}</p>
+            <p role="alert" className="text-sm text-red-400">{error}</p>
           )}
 
           <button

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -52,7 +52,7 @@ export function ProfilePage() {
 
   if (profileLoading || achievementsLoading || !user || !stats) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -85,7 +85,7 @@ export function ProfilePage() {
   return (
     <>
       {/* Header */}
-      <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-xl font-bold tracking-tighter">
           <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
         </span>

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -94,7 +94,7 @@ export function StatsPage() {
 
   if (isPending || !s) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -126,7 +126,7 @@ export function StatsPage() {
   return (
     <>
       {/* Header */}
-      <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-lg font-bold tracking-tight text-primary-light">
           Stats
         </span>
@@ -378,6 +378,9 @@ export function StatsPage() {
       {/* Bottom sheet — trip detail / delete */}
       {selectedTrip && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Détail du trajet"
           className="fixed inset-0 z-[60] flex items-end justify-center"
           onClick={() => setSelectedTrip(null)}
         >
@@ -406,6 +409,7 @@ export function StatsPage() {
               </div>
               <button
                 onClick={() => setSelectedTrip(null)}
+                aria-label="Fermer"
                 className="rounded-lg p-2 text-text-muted active:bg-surface-high"
               >
                 <X size={20} />

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -103,7 +103,7 @@ export function TripPage() {
   return (
     <div className="relative flex h-full flex-col">
       {/* Header */}
-      <header className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
         <span className="text-lg font-bold tracking-tight">
           <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
         </span>


### PR DESCRIPTION
## Summary
- **LoginPage**: Wrap inputs in `<label>`, add `aria-label` on Google sign-in button, add `autocomplete` attributes on email/password/name inputs, add `role="alert"` on error message
- **BottomNav**: Add `aria-label="Navigation principale"` on `<nav>`, add `aria-hidden="true"` on decorative icons (NavLink already provides `aria-current="page"`)
- **All page headers**: Add `role="banner"` on `<header>` elements (Dashboard, Leaderboard, Profile, Stats, Trip)
- **Loading spinners**: Add `role="status"` and `aria-label="Chargement"` on spinner containers (Dashboard, Leaderboard, Profile, Stats)
- **StatsPage bottom sheet**: Add `role="dialog"`, `aria-modal="true"`, `aria-label="Détail du trajet"` on overlay; add `aria-label="Fermer"` on close button
- **DashboardPage**: Add `aria-label="Fermer"` on vehicle prompt dismiss button

No structural changes — only ARIA attributes and HTML semantics added.

## Test plan
- [ ] Verify all pages load correctly without regressions
- [ ] Check screen reader announces loading states, navigation, and dialog
- [ ] Confirm autocomplete suggestions appear on login form inputs
- [ ] Run `bun run typecheck` (passes cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)