### PR TITLE
feat: offline queue for trip saves with auto-sync

### DIFF
--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -3,9 +3,11 @@ import { Outlet } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { BottomNav } from "./BottomNav";
 import { PullToRefresh } from "@/components/ui/PullToRefresh";
+import { useOfflineSync } from "@/hooks/useOfflineSync";
 
 export function AppShell() {
   const queryClient = useQueryClient();
+  useOfflineSync();
 
   const handleRefresh = useCallback(async () => {
     await queryClient.invalidateQueries();

--- a/client/src/hooks/useOfflineSync.ts
+++ b/client/src/hooks/useOfflineSync.ts
@@ -1,0 +1,45 @@
+import { useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/api";
+import { getPendingTrips, removePendingTrip } from "@/lib/offline-queue";
+import type { Trip } from "@ecoride/shared/types";
+
+export function useOfflineSync() {
+  const queryClient = useQueryClient();
+
+  const syncPending = useCallback(async () => {
+    const pending = getPendingTrips();
+    if (pending.length === 0) return;
+
+    // Process from last to first so that removing by index stays valid
+    for (let i = pending.length - 1; i >= 0; i--) {
+      try {
+        await apiFetch<{ ok: boolean; data: { trip: Trip } }>("/trips", {
+          method: "POST",
+          body: JSON.stringify(pending[i]),
+        });
+        removePendingTrip(i);
+      } catch {
+        // Keep in queue, will retry next time
+      }
+    }
+
+    // If at least one succeeded, invalidate queries
+    if (getPendingTrips().length < pending.length) {
+      queryClient.invalidateQueries({ queryKey: ["trips"] });
+      queryClient.invalidateQueries({ queryKey: ["stats"] });
+      queryClient.invalidateQueries({ queryKey: ["achievements"] });
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+    }
+  }, [queryClient]);
+
+  useEffect(() => {
+    // Try on mount
+    syncPending();
+
+    // Try when coming back online
+    const handleOnline = () => syncPending();
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, [syncPending]);
+}

--- a/client/src/lib/offline-queue.ts
+++ b/client/src/lib/offline-queue.ts
@@ -1,0 +1,29 @@
+import type { CreateTripRequest } from "@ecoride/shared/api-contracts";
+
+const STORAGE_KEY = "ecoride-pending-trips";
+
+export function queueTrip(data: CreateTripRequest): void {
+  const pending = getPendingTrips();
+  pending.push(data);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+}
+
+export function getPendingTrips(): CreateTripRequest[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as CreateTripRequest[];
+  } catch {
+    return [];
+  }
+}
+
+export function removePendingTrip(index: number): void {
+  const pending = getPendingTrips();
+  pending.splice(index, 1);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+}
+
+export function hasPendingTrips(): boolean {
+  return getPendingTrips().length > 0;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import { Bike, Leaf, MapPin, ChevronRight, Car, X } from "lucide-react";
+import { Bike, Leaf, MapPin, ChevronRight, Car, X, CloudOff } from "lucide-react";
 import { ImpactMeter } from "@/components/ui/ImpactMeter";
 import { useDashboardSummary, useProfile } from "@/hooks/queries";
+import { getPendingTrips } from "@/lib/offline-queue";
 import appLogo from "/pwa-192x192.png?url";
 
 export function DashboardPage() {
@@ -10,6 +11,7 @@ export function DashboardPage() {
   const { data: allTime, isPending: allTimePending } = useDashboardSummary("all");
   const { data: profileData } = useProfile();
   const [vehiclePromptDismissed, setVehiclePromptDismissed] = useState(false);
+  const pendingTrips = getPendingTrips();
 
   const isPending = todayPending || allTimePending;
 
@@ -32,6 +34,16 @@ export function DashboardPage() {
           <span className="text-primary-light">Ride</span>
         </span>
       </header>
+
+      {/* Offline pending trips banner */}
+      {pendingTrips.length > 0 && (
+        <div className="mx-6 flex items-center gap-3 rounded-xl border border-primary/20 bg-primary/10 px-4 py-3">
+          <CloudOff size={18} className="shrink-0 text-primary-light" />
+          <span className="flex-1 text-xs font-medium text-text">
+            {pendingTrips.length} trajet{pendingTrips.length > 1 ? "s" : ""} en attente de synchronisation
+          </span>
+        </div>
+      )}
 
       {isNewUser ? (
         /* ---- Empty state: first-time user ---- */

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef } from "react";
-import { Play, Square, Keyboard, AlertTriangle, RotateCcw } from "lucide-react";
+import { Play, Square, Keyboard, AlertTriangle, CloudOff } from "lucide-react";
 import { MapContainer, TileLayer, Polyline, CircleMarker, useMap } from "react-leaflet";
 import type { LatLngExpression } from "leaflet";
 import { useCreateTrip, useProfile } from "@/hooks/queries";
 import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
 import { useGpsTracking } from "@/hooks/useGpsTracking";
 import type { TrackingSession } from "@/hooks/useGpsTracking";
+import { queueTrip } from "@/lib/offline-queue";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -76,14 +77,15 @@ export function TripPage() {
     setSaveError("");
     const endedAt = session?.endedAt ?? new Date().toISOString();
     const startedAt = session?.startedAt ?? new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
+    const tripData = {
+      distanceKm: Math.round(km * 100) / 100,
+      durationSec,
+      startedAt,
+      endedAt,
+      gpsPoints: session?.gpsPoints?.length ? session.gpsPoints : null,
+    };
     createTrip.mutate(
-      {
-        distanceKm: Math.round(km * 100) / 100,
-        durationSec,
-        startedAt,
-        endedAt,
-        gpsPoints: session?.gpsPoints?.length ? session.gpsPoints : null,
-      },
+      tripData,
       {
         onSuccess: () => {
           setSaveError("");
@@ -94,7 +96,17 @@ export function TripPage() {
           gps.reset();
         },
         onError: () => {
-          setSaveError("Impossible d'enregistrer le trajet. Vérifiez votre connexion.");
+          queueTrip(tripData);
+          setSaveError("Trajet sauvegardé hors-ligne. Il sera envoyé automatiquement.");
+          // Reset UI to idle after a short delay so the user sees the message
+          setTimeout(() => {
+            setUiState("idle");
+            setManualKm("");
+            setManualMinutes("");
+            sessionRef.current = null;
+            gps.reset();
+            setSaveError("");
+          }, 3000);
         },
       },
     );
@@ -231,19 +243,11 @@ export function TripPage() {
               {createTrip.isPending ? "Enregistrement..." : "Enregistrer"}
             </button>
             {saveError && (
-              <div className="mt-4 rounded-xl bg-danger/10 p-4">
+              <div className="mt-4 rounded-xl bg-primary/10 p-4">
                 <div className="flex items-center gap-3">
-                  <AlertTriangle size={16} className="shrink-0 text-danger" />
-                  <span className="text-sm font-medium text-danger">{saveError}</span>
+                  <CloudOff size={16} className="shrink-0 text-primary-light" />
+                  <span className="text-sm font-medium text-primary-light">{saveError}</span>
                 </div>
-                <button
-                  onClick={() => handleSaveTrip(distance, elapsed, sessionRef.current)}
-                  disabled={createTrip.isPending}
-                  className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-danger/20 py-3 text-sm font-bold text-danger active:scale-95 disabled:opacity-50"
-                >
-                  <RotateCcw size={14} />
-                  Réessayer
-                </button>
               </div>
             )}
           </div>
@@ -299,25 +303,11 @@ export function TripPage() {
               </button>
             </div>
             {saveError && (
-              <div className="mt-4 rounded-xl bg-danger/10 p-4">
+              <div className="mt-4 rounded-xl bg-primary/10 p-4">
                 <div className="flex items-center gap-3">
-                  <AlertTriangle size={16} className="shrink-0 text-danger" />
-                  <span className="text-sm font-medium text-danger">{saveError}</span>
+                  <CloudOff size={16} className="shrink-0 text-primary-light" />
+                  <span className="text-sm font-medium text-primary-light">{saveError}</span>
                 </div>
-                <button
-                  onClick={() => {
-                    const km = parseFloat(manualKm);
-                    if (km > 0) {
-                      const estimatedDuration = Math.round((km / 15) * 3600);
-                      handleSaveTrip(km, estimatedDuration);
-                    }
-                  }}
-                  disabled={createTrip.isPending}
-                  className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-danger/20 py-3 text-sm font-bold text-danger active:scale-95 disabled:opacity-50"
-                >
-                  <RotateCcw size={14} />
-                  Réessayer
-                </button>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- **New `offline-queue.ts` lib**: `queueTrip()`, `getPendingTrips()`, `removePendingTrip()`, `hasPendingTrips()` -- stores pending trips in localStorage under `ecoride-pending-trips`
- **New `useOfflineSync` hook**: on mount and on `online` event, attempts to POST each pending trip to `/api/trips`, removes on success, keeps on failure. Runs in `AppShell`.
- **TripPage**: on save error, queues the trip data offline and shows a friendly message ("Trajet sauvegarde hors-ligne. Il sera envoye automatiquement.") with a CloudOff icon, then resets to idle after 3s
- **DashboardPage**: shows info banner ("X trajet(s) en attente de synchronisation") with CloudOff icon when pending trips exist

## Test plan
- [ ] Turn off network, finish a GPS trip, confirm it saves to localStorage and UI resets with offline message
- [ ] Turn off network, do a manual entry, confirm same offline behavior
- [ ] Turn network back on, confirm pending trips sync automatically
- [ ] Verify dashboard shows pending count banner while trips are queued
- [ ] Verify banner disappears after successful sync
- [ ] Run `bun run typecheck` -- client passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)