### PR TITLE
feat: lazy load secondary routes to reduce initial bundle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,30 +1,56 @@
+import { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router";
 import { AppShell } from "@/components/layout/AppShell";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { LoginPage } from "@/pages/LoginPage";
 import { DashboardPage } from "@/pages/DashboardPage";
-import { TripPage } from "@/pages/TripPage";
-import { StatsPage } from "@/pages/StatsPage";
-import { LeaderboardPage } from "@/pages/LeaderboardPage";
-import { ProfilePage } from "@/pages/ProfilePage";
-import { NotFoundPage } from "@/pages/NotFoundPage";
-import { PrivacyPage } from "@/pages/PrivacyPage";
+
+const TripPage = lazy(() =>
+  import("@/pages/TripPage").then((m) => ({ default: m.TripPage })),
+);
+const StatsPage = lazy(() =>
+  import("@/pages/StatsPage").then((m) => ({ default: m.StatsPage })),
+);
+const LeaderboardPage = lazy(() =>
+  import("@/pages/LeaderboardPage").then((m) => ({
+    default: m.LeaderboardPage,
+  })),
+);
+const ProfilePage = lazy(() =>
+  import("@/pages/ProfilePage").then((m) => ({ default: m.ProfilePage })),
+);
+const NotFoundPage = lazy(() =>
+  import("@/pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })),
+);
+const PrivacyPage = lazy(() =>
+  import("@/pages/PrivacyPage").then((m) => ({ default: m.PrivacyPage })),
+);
+
+function LoadingSpinner() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  );
+}
 
 export function App() {
   return (
-    <Routes>
-      <Route path="login" element={<LoginPage />} />
-      <Route path="privacy" element={<PrivacyPage />} />
-      <Route element={<ProtectedRoute />}>
-        <Route element={<AppShell />}>
-          <Route index element={<DashboardPage />} />
-          <Route path="trip" element={<TripPage />} />
-          <Route path="stats" element={<StatsPage />} />
-          <Route path="leaderboard" element={<LeaderboardPage />} />
-          <Route path="profile" element={<ProfilePage />} />
+    <Suspense fallback={<LoadingSpinner />}>
+      <Routes>
+        <Route path="login" element={<LoginPage />} />
+        <Route path="privacy" element={<PrivacyPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route element={<AppShell />}>
+            <Route index element={<DashboardPage />} />
+            <Route path="trip" element={<TripPage />} />
+            <Route path="stats" element={<StatsPage />} />
+            <Route path="leaderboard" element={<LeaderboardPage />} />
+            <Route path="profile" element={<ProfilePage />} />
+          </Route>
         </Route>
-      </Route>
-      <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Replace synchronous imports with `React.lazy()` for StatsPage, LeaderboardPage, ProfilePage, TripPage, and NotFoundPage
- Keep LoginPage and DashboardPage eagerly loaded as primary entry points
- Wrap lazy routes with `<Suspense>` and a loading spinner fallback for smooth transitions

## Test plan
- [ ] Verify the app loads correctly on `/` (DashboardPage renders immediately, no spinner)
- [ ] Navigate to `/stats`, `/leaderboard`, `/profile`, `/trip` and confirm each loads after a brief spinner
- [ ] Confirm the 404 page still renders for unknown routes
- [ ] Check the network tab to verify secondary pages are loaded as separate chunks on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)