### PR TITLE
fix: security hardening (5 audit items)

### DIFF
--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -29,6 +29,12 @@ export const auth = betterAuth({
   advanced: {
     useSecureCookies: env.NODE_ENV === "production",
     trustedProxyHeaders: true,
+    // sameSite must remain "lax" (not "strict") because Better Auth's
+    // OAuth callback flow uses a cross-site redirect from the provider
+    // (e.g. Google) back to /api/auth/callback/*. With "strict", the
+    // session cookie would not be sent on that redirect, breaking login.
+    // CSRF protection is handled by Better Auth's built-in state/nonce
+    // verification on OAuth callbacks and its CSRF token on form posts.
     defaultCookieAttributes: {
       sameSite: "lax",
       secure: env.NODE_ENV === "production",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,17 @@ const app = new Hono();
 app.use("*", requestId());
 app.use("*", logger());
 
+// ---- HTTP security headers ----
+app.use("*", async (c, next) => {
+  if (env.NODE_ENV === "production") {
+    c.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  }
+  c.header("X-Frame-Options", "DENY");
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  await next();
+});
+
 // ---- CORS for auth routes (before handler, with explicit methods) ----
 app.use("/api/auth/*", cors({
   origin: env.FRONTEND_URL,

--- a/server/src/lib/rate-limit.ts
+++ b/server/src/lib/rate-limit.ts
@@ -21,16 +21,25 @@ setInterval(() => {
 
 /**
  * Extract client IP from request, accounting for reverse proxies.
+ *
+ * Prefer Cloudflare's cf-connecting-ip (set by Cloudflare and cannot be
+ * spoofed by the client), then x-real-ip (set by Nginx), then the first
+ * entry of x-forwarded-for, and finally fall back to "unknown".
  */
 function getClientIp(req: Request): string {
-  // Behind reverse proxy (Cloudflare / Nginx), the real IP is in x-forwarded-for
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    // x-forwarded-for may contain multiple IPs: "client, proxy1, proxy2"
-    return forwarded.split(",")[0]!.trim();
-  }
+  // Cloudflare sets this header; it cannot be spoofed by the client
+  const cfIp = req.headers.get("cf-connecting-ip");
+  if (cfIp) return cfIp.trim();
+
   const realIp = req.headers.get("x-real-ip");
   if (realIp) return realIp.trim();
+
+  // x-forwarded-for may contain multiple IPs: "client, proxy1, proxy2"
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]!.trim();
+  }
+
   return "unknown";
 }
 

--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -8,10 +8,10 @@ const gpsPointSchema = z.object({
 
 export const createTripSchema = z.object({
   distanceKm: z.number().positive().max(500),
-  durationSec: z.number().int().min(1),
+  durationSec: z.number().int().min(1).max(86400),
   startedAt: z.string().datetime(),
   endedAt: z.string().datetime(),
-  gpsPoints: z.array(gpsPointSchema).nullable().optional(),
+  gpsPoints: z.array(gpsPointSchema).max(10000).nullable().optional(),
 }).refine(
   (data) => new Date(data.startedAt) < new Date(data.endedAt),
   { message: "startedAt must be before endedAt", path: ["startedAt"] }


### PR DESCRIPTION
## Summary
- **Fix 2.1:** Limit GPS points array to 10,000 entries to prevent payload abuse
- **Fix 2.2:** Fix rate-limit IP extraction — prefer `cf-connecting-ip` (Cloudflare, non-spoofable) over `x-forwarded-for`
- **Fix 2.3:** Add HTTP security headers (HSTS in production, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy)
- **Fix 2.4:** Document why `sameSite: "lax"` is required for OAuth callback flow (cannot use "strict")
- **Fix 1.8:** Cap trip duration at 86,400 seconds (24 hours)

## Test plan
- [ ] Verify GPS points arrays > 10,000 entries are rejected by the API
- [ ] Verify rate limiting still works correctly (check `cf-connecting-ip` priority)
- [ ] Verify security headers appear on responses (`curl -I`)
- [ ] Verify HSTS header only appears in production
- [ ] Verify trips with duration > 86,400s are rejected
- [ ] Verify Google OAuth login still works (sameSite "lax" preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)