### PR TITLE
fix: performance — non-blocking fuel price, map debounce, memoize chart, cache headers

### DIFF
--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Bike, BarChart3, Trash2, X } from "lucide-react";
 import type { Trip } from "@ecoride/shared/types";
 import {
@@ -103,25 +103,29 @@ export function StatsPage() {
   const trips = tripsData?.trips ?? [];
   const chartTrips = weeklyTrips ?? [];
 
-  // Build weekly chart data from all trips this week
-  const weeklyData = DAY_LABELS.map((day) => ({ day, km: 0, co2: 0, eur: 0 }));
+  // Build weekly chart data from all trips this week (memoized)
+  const weeklyData = useMemo(() => {
+    const data = DAY_LABELS.map((day) => ({ day, km: 0, co2: 0, eur: 0 }));
 
-  for (const trip of chartTrips) {
-    const tripDate = new Date(trip.startedAt);
-    const dayIdx = (tripDate.getDay() + 6) % 7; // Mon=0, Sun=6
-    if (weeklyData[dayIdx]) {
-      weeklyData[dayIdx].km += trip.distanceKm;
-      weeklyData[dayIdx].co2 += trip.co2SavedKg;
-      weeklyData[dayIdx].eur += trip.moneySavedEur;
+    for (const trip of chartTrips) {
+      const tripDate = new Date(trip.startedAt);
+      const dayIdx = (tripDate.getDay() + 6) % 7; // Mon=0, Sun=6
+      if (data[dayIdx]) {
+        data[dayIdx].km += trip.distanceKm;
+        data[dayIdx].co2 += trip.co2SavedKg;
+        data[dayIdx].eur += trip.moneySavedEur;
+      }
     }
-  }
 
-  // Round values for display
-  for (const d of weeklyData) {
-    d.km = Math.round(d.km * 10) / 10;
-    d.co2 = Math.round(d.co2 * 10) / 10;
-    d.eur = Math.round(d.eur * 100) / 100;
-  }
+    // Round values for display
+    for (const d of data) {
+      d.km = Math.round(d.km * 10) / 10;
+      d.co2 = Math.round(d.co2 * 10) / 10;
+      d.eur = Math.round(d.eur * 100) / 100;
+    }
+
+    return data;
+  }, [chartTrips]);
 
   return (
     <>

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -14,7 +14,11 @@ const DEFAULT_CENTER: [number, number] = [48.8566, 2.3522]; // Paris
 
 function RecenterMap({ position }: { position: [number, number] }) {
   const map = useMap();
+  const lastUpdateRef = useRef(0);
   useEffect(() => {
+    const now = Date.now();
+    if (now - lastUpdateRef.current < 500) return;
+    lastUpdateRef.current = now;
     map.setView(position, map.getZoom(), { animate: true });
   }, [map, position]);
   return null;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -95,6 +95,7 @@ if (env.NODE_ENV === "production") {
   // SPA fallback: serve index.html for non-API routes that don't match a static file
   app.get("*", (c, next) => {
     if (c.req.path.startsWith("/api")) return next();
+    c.header("Cache-Control", "public, max-age=0, must-revalidate");
     return c.html(Bun.file("./client/dist/index.html").text());
   });
 }

--- a/server/src/lib/fuel-price.ts
+++ b/server/src/lib/fuel-price.ts
@@ -59,7 +59,7 @@ export async function getFuelPrice(
     }
 
     const url = `https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-des-carburants-en-france-flux-instantane-v2/records?${params}`;
-    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    const response = await fetch(url, { signal: AbortSignal.timeout(1500) });
 
     if (!response.ok) {
       throw new Error(`API responded ${response.status}`);

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -39,10 +39,17 @@ tripsRouter.post(
     const consumptionL100 = profile?.consumptionL100 ?? 7; // Default 7L/100km
     const fuelType = (profile?.fuelType ?? "sp95") as "sp95" | "sp98" | "diesel" | "e85" | "gpl";
 
-    // Get current fuel price — use GPS coordinates for nearest station when available
+    // Get current fuel price — non-blocking: use cache or fallback immediately
     const startPoint = data.gpsPoints?.[0];
-    const fuelPriceData = await getFuelPrice(fuelType, startPoint?.lat, startPoint?.lng);
-    const fuelPriceEur = fuelPriceData.priceEur;
+    let fuelPriceEur: number;
+    try {
+      const fuelPriceData = await getFuelPrice(fuelType, startPoint?.lat, startPoint?.lng);
+      fuelPriceEur = fuelPriceData.priceEur;
+    } catch {
+      // On any failure, use hardcoded fallback so trip creation is never blocked
+      const FALLBACK: Record<string, number> = { sp95: 1.75, sp98: 1.85, diesel: 1.65, e85: 0.85, gpl: 0.95 };
+      fuelPriceEur = FALLBACK[fuelType] ?? 1.75;
+    }
 
     const savings = calculateSavings({
       distanceKm: data.distanceKm,


### PR DESCRIPTION
## Summary
- **Fix 4.1**: Make fuel price non-blocking for trip creation — wrap `getFuelPrice` in try/catch with hardcoded fallback, reduce API timeout from 5s to 1.5s
- **Fix 4.2**: Debounce map re-centering in `RecenterMap` — skip `setView` calls within 500ms of the last update using a ref
- **Fix 4.3**: Memoize `weeklyData` computation in `StatsPage` with `useMemo` keyed on `chartTrips`
- **Fix 4.10**: Add `Cache-Control: public, max-age=0, must-revalidate` header to the SPA fallback handler for `index.html`

## Test plan
- [ ] Create a trip — verify it succeeds even if fuel price API is slow/down
- [ ] Track a GPS trip — verify the map still follows position but without excessive re-renders
- [ ] Open Stats page — verify chart renders correctly, toggle metrics/periods
- [ ] Deploy to production — verify `index.html` response includes the `Cache-Control` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)