### PR TITLE
fix: data integrity — prevent overlapping trips, add idempotency keys

### DIFF
--- a/client/src/lib/offline-queue.ts
+++ b/client/src/lib/offline-queue.ts
@@ -4,7 +4,8 @@ const STORAGE_KEY = "ecoride-pending-trips";
 
 export function queueTrip(data: CreateTripRequest): void {
   const pending = getPendingTrips();
-  pending.push(data);
+  const key = crypto.randomUUID();
+  pending.push({ ...data, idempotencyKey: key });
   localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
 }
 

--- a/server/src/db/schema/trips.ts
+++ b/server/src/db/schema/trips.ts
@@ -17,6 +17,7 @@ export const trips = pgTable("trips", {
   endedAt: timestamp("ended_at", { withTimezone: true, mode: "date" }).notNull(),
 
   gpsPoints: jsonb("gps_points"), // GpsPoint[] | null
+  idempotencyKey: text("idempotency_key"),
 }, (table) => [
   index("trips_user_id_idx").on(table.userId),
   index("trips_started_at_idx").on(table.startedAt),

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { eq, and, desc, gte, lte, count, sql } from "drizzle-orm";
+import { eq, and, desc, gte, lte, lt, gt, count, sql } from "drizzle-orm";
 import { db } from "../db";
 import { trips } from "../db/schema";
 import { user } from "../db/schema/auth";
@@ -29,6 +29,41 @@ tripsRouter.post(
   async (c) => {
     const data = c.req.valid("json");
     const currentUser = c.get("user");
+
+    // Idempotency: if key provided and trip already exists, return it
+    if (data.idempotencyKey) {
+      const [existing] = await db
+        .select({ id: trips.id })
+        .from(trips)
+        .where(and(
+          eq(trips.userId, currentUser.id),
+          eq(trips.idempotencyKey, data.idempotencyKey),
+        ))
+        .limit(1);
+      if (existing) {
+        return c.json({ ok: true, data: { trip: existing } }, 200);
+      }
+    }
+
+    // Reject trips that overlap in time with an existing trip
+    const [overlap] = await db
+      .select({ id: trips.id })
+      .from(trips)
+      .where(
+        and(
+          eq(trips.userId, currentUser.id),
+          lt(trips.startedAt, new Date(data.endedAt)),
+          gt(trips.endedAt, new Date(data.startedAt)),
+        )
+      )
+      .limit(1);
+
+    if (overlap) {
+      return c.json({
+        ok: false,
+        error: { code: "VALIDATION_ERROR", message: "Ce trajet chevauche un trajet existant." }
+      }, 409);
+    }
 
     // Get user's vehicle profile for savings calculation
     const [profile] = await db
@@ -68,6 +103,7 @@ tripsRouter.post(
       startedAt: new Date(data.startedAt),
       endedAt: new Date(data.endedAt),
       gpsPoints: data.gpsPoints ?? null,
+      idempotencyKey: data.idempotencyKey ?? null,
     }).returning();
 
     // Evaluate badge thresholds and unlock any newly earned achievements

--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -12,6 +12,7 @@ export const createTripSchema = z.object({
   startedAt: z.string().datetime(),
   endedAt: z.string().datetime(),
   gpsPoints: z.array(gpsPointSchema).max(10000).nullable().optional(),
+  idempotencyKey: z.string().uuid().optional(),
 }).refine(
   (data) => new Date(data.startedAt) < new Date(data.endedAt),
   { message: "startedAt must be before endedAt", path: ["startedAt"] }

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -44,6 +44,7 @@ export interface CreateTripRequest {
   startedAt: string;  // ISO 8601
   endedAt: string;    // ISO 8601
   gpsPoints?: GpsPoint[] | null;
+  idempotencyKey?: string;
 }
 
 export interface UpdateUserRequest {


### PR DESCRIPTION
## Summary
- **Prevent overlapping trips**: Before inserting a new trip, verify no existing trip for the same user overlaps in time (409 Conflict if overlap detected)
- **Add idempotency keys to offline queue**: Generate a UUID for each queued trip so duplicate submissions from the offline queue are safely deduplicated server-side
- Schema, validator, API contract, and route all updated to support the new `idempotencyKey` field

## Changes
- `server/src/routes/trips.routes.ts` — overlap check + idempotency check before insert (fail-fast, before fuel price fetch); import `lt`/`gt` from drizzle-orm; persist `idempotencyKey` on insert
- `server/src/db/schema/trips.ts` — add nullable `idempotency_key` text column
- `server/src/validators/trips.ts` — add optional `idempotencyKey: z.string().uuid()` to Zod schema
- `shared/api-contracts.ts` — add `idempotencyKey?: string` to `CreateTripRequest`
- `client/src/lib/offline-queue.ts` — generate `crypto.randomUUID()` when queueing a trip

## Test plan
- [ ] Create a trip and verify it succeeds (201)
- [ ] Create a second trip with overlapping times and verify 409 response with French error message
- [ ] Send the same request twice with the same `idempotencyKey` and verify the second returns 200 with the existing trip (no duplicate)
- [ ] Queue a trip while offline, come back online, and verify it syncs without duplicates
- [ ] Verify trips without `idempotencyKey` still work (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)