### PR TITLE
fix: UX mobile polish — touch targets, text, contrast, safe area

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#2ecc71" />
+    <meta name="theme-color" content="#1e272e" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/png" href="/favicon.png" />

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -20,7 +20,7 @@
   /* Text */
   --color-text: #FFFFFF;
   --color-text-muted: #8a9ba8;
-  --color-text-dim: #566a78;
+  --color-text-dim: #7a8e9e;
   --color-on-surface-variant: #a3b1ba;
 
   /* Borders & outline */

--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -17,14 +17,14 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-4 pb-8 pt-3 backdrop-blur-2xl border-t border-outline-variant/10">
+    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-4 pb-[calc(0.75rem+env(safe-area-inset-bottom,0.5rem))] pt-3 backdrop-blur-2xl border-t border-outline-variant/10">
       {tabs.map(({ to, icon: Icon, label }) => (
         <NavLink
           key={to}
           to={to}
           end={to === "/"}
           className={({ isActive }) =>
-            `flex flex-col items-center justify-center gap-1 transition-all duration-150 active:scale-90 ${
+            `flex flex-col items-center justify-center gap-1 min-h-[44px] transition-all duration-150 active:scale-90 ${
               isActive
                 ? "text-primary-light rounded-2xl bg-primary/10 px-3 py-1.5"
                 : "text-text-dim hover:text-text-muted px-2 py-1.5"
@@ -33,8 +33,8 @@ export function BottomNav() {
         >
           {({ isActive }) => (
             <>
-              <Icon size={22} strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
-              <span className="text-[10px] font-bold uppercase tracking-widest">
+              <Icon size={24} strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
+              <span className="text-xs font-bold uppercase tracking-widest">
                 {label}
               </span>
             </>

--- a/client/src/components/ui/StatCard.tsx
+++ b/client/src/components/ui/StatCard.tsx
@@ -14,7 +14,7 @@ export function StatCard({ icon: Icon, value, unit }: StatCardProps) {
         <div className="text-lg font-black leading-none tracking-tight">
           {value}
         </div>
-        <div className="mt-1 text-[10px] font-medium uppercase tracking-wider text-text-muted">
+        <div className="mt-1 text-xs font-medium uppercase tracking-wider text-text-muted">
           {unit}
         </div>
       </div>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -111,7 +111,7 @@ export function DashboardPage() {
                 <button
                   onClick={() => setVehiclePromptDismissed(true)}
                   aria-label="Fermer"
-                  className="shrink-0 rounded p-1 text-text-muted hover:text-text"
+                  className="shrink-0 rounded p-2 text-text-muted hover:text-text"
                 >
                   <X size={14} />
                 </button>
@@ -132,7 +132,7 @@ export function DashboardPage() {
                       {today.tripCount}
                     </span>
                   </div>
-                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                  <span className="text-xs font-bold uppercase text-text-muted">
                     {today.tripCount > 1 ? "trajets" : "trajet"}
                   </span>
                 </div>
@@ -143,7 +143,7 @@ export function DashboardPage() {
                       {today.totalDistanceKm.toFixed(1)}
                     </span>
                   </div>
-                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                  <span className="text-xs font-bold uppercase text-text-muted">
                     km
                   </span>
                 </div>
@@ -154,7 +154,7 @@ export function DashboardPage() {
                       {today.totalCo2SavedKg.toFixed(1)}
                     </span>
                   </div>
-                  <span className="text-[10px] font-bold uppercase text-text-muted">
+                  <span className="text-xs font-bold uppercase text-text-muted">
                     kg CO₂
                   </span>
                 </div>

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -64,14 +64,14 @@ export function LeaderboardPage() {
                     {top3[1].name.charAt(0)}
                   </span>
                 </div>
-                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-high text-[10px] font-bold text-text">
+                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-high text-xs font-bold text-text">
                   2
                 </div>
               </div>
               <span className="w-full truncate text-center text-xs font-bold">
                 {top3[1].name}
               </span>
-              <span className="mt-1 text-[10px] font-black uppercase tracking-widest text-primary-light">
+              <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
                 {top3[1].totalCo2SavedKg} KG
               </span>
             </div>
@@ -108,14 +108,14 @@ export function LeaderboardPage() {
                     {top3[2].name.charAt(0)}
                   </span>
                 </div>
-                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-highest text-[10px] font-bold text-text-muted">
+                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-highest text-xs font-bold text-text-muted">
                   3
                 </div>
               </div>
               <span className="w-full truncate text-center text-xs font-bold">
                 {top3[2].name}
               </span>
-              <span className="mt-1 text-[10px] font-black uppercase tracking-widest text-primary-light">
+              <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
                 {top3[2].totalCo2SavedKg} KG
               </span>
             </div>

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -138,7 +138,7 @@ export function ProfilePage() {
         {/* Stats Bento Grid */}
         <section className="grid grid-cols-2 gap-4">
           <div className="group relative col-span-2 overflow-hidden rounded-lg bg-surface-low p-6">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-primary/70">
+            <p className="text-xs font-bold uppercase tracking-widest text-primary/70">
               Total CO₂ Économisé
             </p>
             <div className="mt-2 flex items-baseline gap-2">
@@ -151,7 +151,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-text-dim">
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
               Distance
             </p>
             <div className="mt-1 flex items-baseline gap-1">
@@ -164,7 +164,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-text-dim">
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
               Trajets
             </p>
             <div className="mt-1 flex items-baseline gap-1">
@@ -174,7 +174,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-text-dim">
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
               Carburant
             </p>
             <div className="mt-1 flex items-baseline gap-1">
@@ -187,7 +187,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-text-dim">
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
               Economisé
             </p>
             <div className="mt-1 flex items-baseline gap-1">
@@ -221,7 +221,7 @@ export function ProfilePage() {
                   {fuelPrice.fuelType.toUpperCase()}
                 </span>
               </div>
-              <p className="text-[10px] text-text-muted">
+              <p className="text-xs text-text-muted">
                 {fuelPrice.stationName ? fuelPrice.stationName : "Prix moyen national"}
               </p>
             </div>
@@ -253,7 +253,7 @@ export function ProfilePage() {
                   >
                     <span className="text-2xl">{badge.icon}</span>
                   </div>
-                  <span className="text-center text-[10px] font-bold uppercase leading-tight text-text-muted">
+                  <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
                     {badge.label}
                   </span>
                 </div>
@@ -270,7 +270,7 @@ export function ProfilePage() {
             </h2>
             <div className="space-y-3">
               <div>
-                <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                   Modèle
                 </label>
                 <input
@@ -281,7 +281,7 @@ export function ProfilePage() {
                 />
               </div>
               <div>
-                <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                   Carburant
                 </label>
                 <select
@@ -297,7 +297,7 @@ export function ProfilePage() {
                 </select>
               </div>
               <div>
-                <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                   Consommation (L/100km)
                 </label>
                 <input
@@ -350,7 +350,7 @@ export function ProfilePage() {
             {showPersonalInfo && (
               <div className="space-y-3 px-4 pb-4">
                 <div>
-                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                     Nom
                   </label>
                   <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
@@ -358,7 +358,7 @@ export function ProfilePage() {
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                     Email
                   </label>
                   <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
@@ -366,7 +366,7 @@ export function ProfilePage() {
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
                     Membre depuis
                   </label>
                   <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
@@ -407,13 +407,13 @@ export function ProfilePage() {
                 <div className="flex flex-col items-start">
                   <span className="text-sm font-medium">Notifications</span>
                   {push.status === "unsupported" && (
-                    <span className="text-[10px] text-text-dim">Non supporté par ce navigateur</span>
+                    <span className="text-xs text-text-dim">Non supporté par ce navigateur</span>
                   )}
                   {push.status === "denied" && (
-                    <span className="text-[10px] text-text-dim">Autorisation refusée dans les paramètres du navigateur</span>
+                    <span className="text-xs text-text-dim">Autorisation refusée dans les paramètres du navigateur</span>
                   )}
                   {push.status === "subscribed" && (
-                    <span className="text-[10px] text-primary/70">Activées</span>
+                    <span className="text-xs text-primary/70">Activées</span>
                   )}
                 </div>
               </div>
@@ -473,7 +473,7 @@ export function ProfilePage() {
             </div>
           </button>
 
-          <p className="mt-4 text-center text-[10px] text-text-dim">
+          <p className="mt-4 text-center text-xs text-text-dim">
             v{__APP_VERSION__}
           </p>
         </section>

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -154,7 +154,7 @@ export function StatsPage() {
         <section className="space-y-6">
           <div className="flex items-end justify-between">
             <div>
-              <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+              <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
                 Ce mois
               </span>
               <h2 className="text-3xl font-extrabold tracking-tight">
@@ -245,7 +245,7 @@ export function StatsPage() {
               <button
                 key={m}
                 onClick={() => setMetric(m)}
-                className={`rounded-lg px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                className={`rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
                   m === metric
                     ? "bg-primary/20 text-primary-light"
                     : "bg-surface-high text-text-muted"
@@ -315,7 +315,7 @@ export function StatsPage() {
                   </div>
                   <div>
                     <p className="text-sm font-bold">{tripLabel(trip.startedAt)}</p>
-                    <p className="text-[10px] font-medium text-on-surface-variant">
+                    <p className="text-xs font-medium text-on-surface-variant">
                       {new Date(trip.startedAt).toLocaleDateString("fr-FR", {
                         day: "numeric",
                         month: "short",
@@ -327,7 +327,7 @@ export function StatsPage() {
                   <p className="text-sm font-bold text-primary-light">
                     +{trip.distanceKm} KM
                   </p>
-                  <p className="text-[10px] font-bold uppercase tracking-tighter text-on-surface-variant">
+                  <p className="text-xs font-bold uppercase tracking-tighter text-on-surface-variant">
                     {trip.co2SavedKg.toFixed(1)} KG CO₂
                   </p>
                 </div>
@@ -365,7 +365,7 @@ export function StatsPage() {
                   >
                     <span className="text-2xl">{badge.icon}</span>
                   </div>
-                  <span className="text-center text-[10px] font-bold uppercase leading-tight text-text-muted">
+                  <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
                     {badge.label}
                   </span>
                 </div>
@@ -389,7 +389,7 @@ export function StatsPage() {
 
           {/* Sheet */}
           <div
-            className="relative w-full max-w-lg rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
+            className="relative w-full max-w-lg overflow-y-auto max-h-[85vh] rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Handle */}
@@ -428,15 +428,15 @@ export function StatsPage() {
             <div className="mb-6 grid grid-cols-3 gap-4 text-center">
               <div>
                 <p className="text-xl font-bold text-primary-light">{selectedTrip.distanceKm}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">km</p>
+                <p className="text-xs font-bold uppercase text-text-muted">km</p>
               </div>
               <div>
                 <p className="text-xl font-bold text-primary-light">{selectedTrip.co2SavedKg.toFixed(1)}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">kg CO₂</p>
+                <p className="text-xs font-bold uppercase text-text-muted">kg CO₂</p>
               </div>
               <div>
                 <p className="text-xl font-bold text-primary-light">{selectedTrip.moneySavedEur.toFixed(2)}</p>
-                <p className="text-[10px] font-bold uppercase text-text-muted">€</p>
+                <p className="text-xs font-bold uppercase text-text-muted">€</p>
               </div>
             </div>
 

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -166,7 +166,7 @@ export function TripPage() {
         {uiState === "tracking" && (
           <div className="absolute left-1/2 top-4 z-[1000] -translate-x-1/2">
             <div className="flex items-center gap-3 rounded-full border border-primary/30 bg-primary/20 px-5 py-2.5 backdrop-blur-md">
-              <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+              <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
                 CO₂ Saved
               </span>
               <span className="text-xl font-extrabold text-primary-light">
@@ -182,7 +182,7 @@ export function TripPage() {
         <div className="space-y-4 px-6 pb-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="rounded-xl border border-outline-variant/10 bg-surface-low/80 p-6 backdrop-blur-2xl">
-              <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.15em] text-text-dim">
+              <p className="mb-2 text-xs font-bold uppercase tracking-[0.15em] text-text-dim">
                 Distance
               </p>
               <div className="flex items-baseline gap-1">
@@ -193,7 +193,7 @@ export function TripPage() {
               </div>
             </div>
             <div className="rounded-xl border border-outline-variant/10 bg-surface-low/80 p-6 backdrop-blur-2xl">
-              <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.15em] text-text-dim">
+              <p className="mb-2 text-xs font-bold uppercase tracking-[0.15em] text-text-dim">
                 Temps
               </p>
               <div className="flex items-baseline gap-1">
@@ -216,13 +216,13 @@ export function TripPage() {
                 <div className="text-2xl font-black text-primary-light">
                   {distance.toFixed(1)}
                 </div>
-                <div className="text-[10px] font-bold uppercase text-text-muted">km</div>
+                <div className="text-xs font-bold uppercase text-text-muted">km</div>
               </div>
               <div>
                 <div className="text-2xl font-black text-primary-light">
                   {co2Saved.toFixed(1)}
                 </div>
-                <div className="text-[10px] font-bold uppercase text-text-muted">
+                <div className="text-xs font-bold uppercase text-text-muted">
                   kg CO₂
                 </div>
               </div>
@@ -230,7 +230,7 @@ export function TripPage() {
                 <div className="text-2xl font-black text-primary-light">
                   {formatTime(elapsed)}
                 </div>
-                <div className="text-[10px] font-bold uppercase text-text-muted">
+                <div className="text-xs font-bold uppercase text-text-muted">
                   durée
                 </div>
               </div>
@@ -257,7 +257,19 @@ export function TripPage() {
       {/* Manual entry */}
       {uiState === "manual" && (
         <div className="space-y-4 px-6 pb-4">
-          <div className="rounded-xl bg-surface-container p-6">
+          <form
+            className="rounded-xl bg-surface-container p-6"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const km = parseFloat(manualKm);
+              if (km > 0) {
+                const durationSec = manualMinutes
+                  ? parseInt(manualMinutes) * 60
+                  : Math.round((km / 15) * 3600); // Fallback: estimate ~15 km/h
+                handleSaveTrip(km, durationSec);
+              }
+            }}
+          >
             <h2 className="mb-4 text-lg font-bold">Saisie manuelle</h2>
             <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-text-muted">
               Distance (km)
@@ -281,21 +293,14 @@ export function TripPage() {
             />
             <div className="flex gap-3">
               <button
+                type="button"
                 onClick={() => setUiState("idle")}
                 className="flex-1 rounded-xl bg-surface-high py-4 text-sm font-bold text-text-muted active:scale-95"
               >
                 Annuler
               </button>
               <button
-                onClick={() => {
-                  const km = parseFloat(manualKm);
-                  if (km > 0) {
-                    const durationSec = manualMinutes
-                      ? parseInt(manualMinutes) * 60
-                      : Math.round((km / 15) * 3600); // Fallback: estimate ~15 km/h
-                    handleSaveTrip(km, durationSec);
-                  }
-                }}
+                type="submit"
                 disabled={createTrip.isPending || !manualKm || parseFloat(manualKm) <= 0}
                 className="flex-1 rounded-xl bg-primary py-4 text-sm font-black uppercase tracking-widest text-bg active:scale-95 disabled:opacity-50"
               >
@@ -310,7 +315,7 @@ export function TripPage() {
                 </div>
               </div>
             )}
-          </div>
+          </form>
         </div>
       )}
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
         name: "ecoRide",
         short_name: "ecoRide",
         description: "Suivez vos trajets vélo et vos économies CO₂",
-        theme_color: "#2ecc71",
+        theme_color: "#1e272e",
         background_color: "#1e272e",
         display: "standalone",
         orientation: "portrait",


### PR DESCRIPTION
## Summary
- **Touch targets**: BottomNav tabs now `min-h-[44px]` with `size={24}` icons; metric switcher buttons increased to `px-4 py-2.5`; dismiss button padded to `p-2`
- **Text sizes**: Replaced all `text-[10px]` with `text-xs` (12px) across BottomNav, Dashboard, Stats, Profile, Trip, Leaderboard, and StatCard
- **Contrast**: `--color-text-dim` changed from `#566a78` to `#7a8e9e` for 4.5:1 ratio against charcoal
- **Status bar**: `theme-color` set to charcoal `#1e272e` in both `index.html` and PWA manifest
- **Safe area**: BottomNav uses `pb-[calc(0.75rem+env(safe-area-inset-bottom,0.5rem))]` for notch/home indicator
- **Bottom sheet scroll**: Trip detail sheet gets `overflow-y-auto max-h-[85vh]` for small screens
- **Form semantics**: Manual entry inputs wrapped in `<form>` so Return key submits

## Test plan
- [ ] Verify bottom nav tabs are at least 44px tall on mobile
- [ ] Confirm all label text is at least 12px (no `text-[10px]` remaining)
- [ ] Check `text-dim` color contrast against charcoal background
- [ ] Verify status bar matches charcoal on iOS/Android
- [ ] Test safe area padding on notched devices (iPhone with home indicator)
- [ ] Open trip detail bottom sheet on small screen — content should scroll
- [ ] In manual entry, fill distance and press Return — form should submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)