### PR TITLE
fix: GPS tracking robustness — recovery, backup, wake lock, guards

### DIFF
--- a/client/src/hooks/useGpsTracking.ts
+++ b/client/src/hooks/useGpsTracking.ts
@@ -5,6 +5,10 @@ import type { GpsPoint } from "@ecoride/shared/types";
 
 const MAX_ACCURACY_M = 50;
 const MIN_DISTANCE_KM = 0.005; // 5m
+const BACKUP_KEY = "ecoride-tracking-backup";
+const BACKUP_INTERVAL_MS = 30_000;
+const MAX_TIMEOUT_RETRIES = 3;
+const TIMEOUT_RETRY_DELAY_MS = 3_000;
 
 export interface TrackingState {
   isTracking: boolean;
@@ -22,12 +26,20 @@ export interface TrackingSession {
   endedAt: string;
 }
 
+export interface TrackingBackup {
+  gpsPoints: GpsPoint[];
+  distanceKm: number;
+  durationSec: number;
+  startedAt: string;
+}
+
 type Action =
   | { type: "START" }
   | { type: "STOP" }
   | { type: "GPS_POINT"; point: GpsPoint }
   | { type: "TICK" }
-  | { type: "ERROR"; message: string };
+  | { type: "ERROR"; message: string }
+  | { type: "RESTORE"; backup: TrackingBackup };
 
 const initial: TrackingState = {
   isTracking: false,
@@ -57,15 +69,60 @@ function reducer(state: TrackingState, action: Action): TrackingState {
       return { ...state, durationSec: state.durationSec + 1 };
     case "ERROR":
       return { ...state, error: action.message };
+    case "RESTORE":
+      return {
+        isTracking: true,
+        gpsPoints: action.backup.gpsPoints,
+        distanceKm: action.backup.distanceKm,
+        durationSec: action.backup.durationSec,
+        error: null,
+      };
   }
+}
+
+/** Read a pending tracking backup from localStorage (if any). */
+export function getTrackingBackup(): TrackingBackup | null {
+  try {
+    const raw = localStorage.getItem(BACKUP_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as TrackingBackup;
+  } catch {
+    return null;
+  }
+}
+
+/** Clear the tracking backup from localStorage. */
+export function clearTrackingBackup(): void {
+  localStorage.removeItem(BACKUP_KEY);
 }
 
 export function useGpsTracking() {
   const [state, dispatch] = useReducer(reducer, initial);
   const watchRef = useRef<number | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const backupTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startRef = useRef<string | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stateRef = useRef(state);
   const wakeLock = useWakeLock();
+
+  // Keep stateRef in sync so backup timer reads latest state
+  stateRef.current = state;
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const clearBackupTimer = useCallback(() => {
+    if (backupTimerRef.current !== null) {
+      clearInterval(backupTimerRef.current);
+      backupTimerRef.current = null;
+    }
+  }, []);
 
   const cleanup = useCallback(() => {
     if (watchRef.current !== null) {
@@ -76,21 +133,37 @@ export function useGpsTracking() {
       clearInterval(timerRef.current);
       timerRef.current = null;
     }
+    clearRetryTimer();
+    clearBackupTimer();
+  }, [clearRetryTimer, clearBackupTimer]);
+
+  /** Save current tracking state to localStorage. */
+  const saveBackup = useCallback(() => {
+    const s = stateRef.current;
+    if (!s.isTracking || !startRef.current) return;
+    try {
+      const backup: TrackingBackup = {
+        gpsPoints: s.gpsPoints,
+        distanceKm: s.distanceKm,
+        durationSec: s.durationSec,
+        startedAt: startRef.current,
+      };
+      localStorage.setItem(BACKUP_KEY, JSON.stringify(backup));
+    } catch {
+      // localStorage full or unavailable — ignore
+    }
   }, []);
 
-  const start = useCallback(() => {
-    if (!("geolocation" in navigator)) {
-      dispatch({ type: "ERROR", message: "Geolocation not supported" });
-      return;
+  /** Start the GPS watch (used both for initial start and timeout retry). */
+  const startWatch = useCallback(() => {
+    if (watchRef.current !== null) {
+      navigator.geolocation.clearWatch(watchRef.current);
     }
-
-    dispatch({ type: "START" });
-    startRef.current = new Date().toISOString();
-    wakeLock.request();
 
     watchRef.current = navigator.geolocation.watchPosition(
       (pos) => {
         if (pos.coords.accuracy > MAX_ACCURACY_M) return;
+        retryCountRef.current = 0; // Reset retry counter on successful fix
         dispatch({
           type: "GPS_POINT",
           point: { lat: pos.coords.latitude, lng: pos.coords.longitude, ts: pos.timestamp },
@@ -102,18 +175,79 @@ export function useGpsTracking() {
           2: "Position non disponible",
           3: "Timeout GPS",
         };
+
+        // Fix 1.2: Auto-recovery after GPS timeout (tunnel)
+        if (err.code === 3 && retryCountRef.current < MAX_TIMEOUT_RETRIES) {
+          retryCountRef.current += 1;
+          dispatch({
+            type: "ERROR",
+            message: `Timeout GPS — nouvelle tentative ${retryCountRef.current}/${MAX_TIMEOUT_RETRIES}...`,
+          });
+          clearRetryTimer();
+          retryTimerRef.current = setTimeout(() => {
+            startWatch();
+          }, TIMEOUT_RETRY_DELAY_MS);
+          return;
+        }
+
         dispatch({ type: "ERROR", message: msgs[err.code] ?? "Erreur GPS" });
+
+        // Fix 1.5: Release wake lock on fatal GPS errors
+        if (err.code === 1 || err.code === 2) {
+          wakeLock.release();
+        }
       },
       { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 },
     );
+  }, [clearRetryTimer, wakeLock]);
+
+  const start = useCallback(() => {
+    if (!("geolocation" in navigator)) {
+      dispatch({ type: "ERROR", message: "Geolocation not supported" });
+      return;
+    }
+
+    dispatch({ type: "START" });
+    startRef.current = new Date().toISOString();
+    retryCountRef.current = 0;
+    wakeLock.request();
+
+    startWatch();
 
     timerRef.current = setInterval(() => dispatch({ type: "TICK" }), 1000);
-  }, [wakeLock]);
+
+    // Fix 1.3: Periodic GPS backup to localStorage
+    backupTimerRef.current = setInterval(saveBackup, BACKUP_INTERVAL_MS);
+  }, [wakeLock, startWatch, saveBackup]);
+
+  /** Restore tracking from a backup (called externally by TripPage). */
+  const restore = useCallback(
+    (backup: TrackingBackup) => {
+      if (!("geolocation" in navigator)) {
+        dispatch({ type: "ERROR", message: "Geolocation not supported" });
+        return;
+      }
+
+      dispatch({ type: "RESTORE", backup });
+      startRef.current = backup.startedAt;
+      retryCountRef.current = 0;
+      wakeLock.request();
+
+      startWatch();
+
+      timerRef.current = setInterval(() => dispatch({ type: "TICK" }), 1000);
+      backupTimerRef.current = setInterval(saveBackup, BACKUP_INTERVAL_MS);
+
+      clearTrackingBackup();
+    },
+    [wakeLock, startWatch, saveBackup],
+  );
 
   const stop = useCallback((): TrackingSession => {
     cleanup();
     dispatch({ type: "STOP" });
     wakeLock.release();
+    clearTrackingBackup(); // Fix 1.3: Clear backup on normal stop
 
     return {
       distanceKm: state.distanceKm,
@@ -130,9 +264,16 @@ export function useGpsTracking() {
     dispatch({ type: "START" });
     dispatch({ type: "STOP" });
     startRef.current = null;
+    clearTrackingBackup();
   }, [cleanup, wakeLock]);
 
-  useEffect(() => cleanup, [cleanup]);
+  // Fix 1.4: Release wake lock on component unmount
+  useEffect(() => {
+    return () => {
+      cleanup();
+      wakeLock.release();
+    };
+  }, [cleanup, wakeLock]);
 
-  return { state, start, stop, reset };
+  return { state, start, stop, reset, restore };
 }

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useRef } from "react";
-import { Play, Square, Keyboard, AlertTriangle, CloudOff } from "lucide-react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Play, Square, Keyboard, AlertTriangle, CloudOff, RotateCcw, X } from "lucide-react";
 import { MapContainer, TileLayer, Polyline, CircleMarker, useMap } from "react-leaflet";
 import type { LatLngExpression } from "leaflet";
+import { useBlocker } from "react-router";
 import { useCreateTrip, useProfile } from "@/hooks/queries";
 import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
-import { useGpsTracking } from "@/hooks/useGpsTracking";
-import type { TrackingSession } from "@/hooks/useGpsTracking";
+import { useGpsTracking, getTrackingBackup, clearTrackingBackup } from "@/hooks/useGpsTracking";
+import type { TrackingSession, TrackingBackup } from "@/hooks/useGpsTracking";
 import { queueTrip } from "@/lib/offline-queue";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
@@ -26,10 +27,40 @@ export function TripPage() {
   const [saveError, setSaveError] = useState("");
   const [manualMinutes, setManualMinutes] = useState("");
   const [initialPos, setInitialPos] = useState<[number, number]>(DEFAULT_CENTER);
+  const [pendingBackup, setPendingBackup] = useState<TrackingBackup | null>(null);
   const sessionRef = useRef<TrackingSession | null>(null);
   const createTrip = useCreateTrip();
   const { data: profileData } = useProfile();
   const gps = useGpsTracking();
+
+  // Fix 1.3: Check for tracking backup on mount
+  useEffect(() => {
+    const backup = getTrackingBackup();
+    if (backup) {
+      setPendingBackup(backup);
+    }
+  }, []);
+
+  // Fix 1.7: Navigation guard — beforeunload for browser close/refresh
+  useEffect(() => {
+    if (uiState !== "tracking") return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [uiState]);
+
+  // Fix 1.7: Navigation guard — React Router in-app navigation blocker
+  useBlocker(
+    useCallback(
+      () => {
+        if (uiState !== "tracking") return false;
+        return !window.confirm("Vous avez un trajet en cours. Quitter cette page ?");
+      },
+      [uiState],
+    ),
+  );
 
   // Get user's real position on page load (one-shot)
   useEffect(() => {
@@ -62,6 +93,19 @@ export function TripPage() {
     const session = gps.stop();
     sessionRef.current = session;
     setUiState("stopped");
+  };
+
+  // Fix 1.3: Restore tracking from backup
+  const handleRestore = () => {
+    if (!pendingBackup) return;
+    gps.restore(pendingBackup);
+    setUiState("tracking");
+    setPendingBackup(null);
+  };
+
+  const handleDismissBackup = () => {
+    clearTrackingBackup();
+    setPendingBackup(null);
   };
 
   const formatTime = (sec: number) => {
@@ -120,6 +164,32 @@ export function TripPage() {
           <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
         </span>
       </header>
+
+      {/* Fix 1.3: Recovery banner for interrupted trip */}
+      {pendingBackup && uiState === "idle" && (
+        <div className="z-50 flex items-center gap-3 bg-primary/20 px-6 py-3">
+          <RotateCcw size={16} className="shrink-0 text-primary-light" />
+          <div className="flex-1">
+            <span className="text-sm font-medium text-primary-light">
+              Un trajet en cours a été interrompu.{" "}
+              {pendingBackup.distanceKm.toFixed(1)} km — {formatTime(pendingBackup.durationSec)}
+            </span>
+          </div>
+          <button
+            onClick={handleRestore}
+            className="rounded-lg bg-primary px-3 py-1.5 text-xs font-bold text-bg"
+          >
+            Reprendre
+          </button>
+          <button
+            onClick={handleDismissBackup}
+            className="rounded-lg p-1.5 text-primary-light hover:bg-primary/10"
+            aria-label="Fermer"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
 
       {/* GPS Error banner */}
       {gps.state.error && (
@@ -317,9 +387,11 @@ export function TripPage() {
       {/* Action buttons */}
       {uiState === "idle" && (
         <div className="space-y-3 px-6 pb-6">
+          {/* Fix 1.6: Disable start button during tracking */}
           <button
             onClick={startTracking}
-            className="flex w-full items-center justify-center gap-4 rounded-xl bg-primary py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95"
+            disabled={uiState !== "idle"}
+            className="flex w-full items-center justify-center gap-4 rounded-xl bg-primary py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95 disabled:opacity-50"
           >
             <Play size={28} className="text-bg" fill="currentColor" />
             <span className="text-xl font-black uppercase tracking-widest text-bg">


### PR DESCRIPTION
## Summary
- **Fix 1.2** — Auto-recover after GPS timeout (tunnel): restart `watchPosition` after 3s with max 3 retries, reset counter on successful fix
- **Fix 1.3** — Periodic GPS backup to `localStorage` every 30s; recovery banner on TripPage mount ("Un trajet en cours a été interrompu. Reprendre ?") with restore/dismiss actions
- **Fix 1.4** — Release wake lock on component unmount (cleanup effect)
- **Fix 1.5** — Release wake lock on fatal GPS errors (permission denied, position unavailable)
- **Fix 1.6** — Disable "Démarrer" button with `disabled={uiState !== "idle"}` to prevent double-tap state reset
- **Fix 1.7** — Navigation guard: `beforeunload` event when tracking + React Router `useBlocker` to prevent in-app navigation with confirmation prompt

## Test plan
- [ ] Start tracking, simulate timeout (airplane mode briefly) — verify retry messages appear and tracking resumes
- [ ] Start tracking, kill the tab, reopen — verify recovery banner shows with correct distance/duration
- [ ] Click "Reprendre" on recovery banner — verify tracking resumes from saved state
- [ ] Click dismiss (X) on recovery banner — verify backup is cleared
- [ ] Start tracking then navigate away — verify `beforeunload` prompt fires on browser back/refresh
- [ ] Start tracking then click a React Router link — verify `useBlocker` confirmation dialog appears
- [ ] Verify "Démarrer" button cannot be double-tapped (disabled when not idle)
- [ ] Verify wake lock releases on unmount and on fatal GPS error
- [ ] Run `bun run typecheck` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)