### PR TITLE
fix: PWA manifest — maskable icon, lang fr, app shortcuts

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         name: "ecoRide",
         short_name: "ecoRide",
         description: "Suivez vos trajets vélo et vos économies CO₂",
+        lang: "fr",
         theme_color: "#1e272e",
         background_color: "#1e272e",
         display: "standalone",
@@ -40,6 +41,10 @@ export default defineConfig({
           { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
           { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
           { src: "pwa-maskable-512x512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
+        ],
+        shortcuts: [
+          { name: "Démarrer un trajet", short_name: "Trajet", url: "/trip", icons: [{ src: "pwa-192x192.png", sizes: "192x192" }] },
+          { name: "Voir les stats", short_name: "Stats", url: "/stats", icons: [{ src: "pwa-192x192.png", sizes: "192x192" }] },
         ],
       },
       workbox: {


### PR DESCRIPTION
## Summary
- **Maskable icon**: Verified the `pwa-maskable-512x512.png` entry with `purpose: "maskable"` is present in the manifest icons array
- **Lang attribute**: Added `lang: "fr"` to the PWA manifest configuration
- **App shortcuts**: Added two shortcuts (start a trip, view stats) to the manifest for quick actions from the home screen

## Test plan
- [ ] Build the app and inspect the generated `manifest.webmanifest` for the `lang`, `shortcuts`, and maskable icon entries
- [ ] Install the PWA on Android and verify shortcuts appear on long-press of the app icon
- [ ] Run Lighthouse PWA audit and confirm maskable icon warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)