### PR TITLE
fix: revert Dockerfile to full node_modules (drizzle-kit crash)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,7 @@ COPY tsconfig.json drizzle.config.ts ./
 ENV GIT_HASH=$GIT_HASH
 RUN cd client && bun run build
 
-# Separate production dependencies from full node_modules
-RUN cp -r node_modules node_modules_full && \
-    rm -rf node_modules && \
-    bun install --frozen-lockfile --production
+# Keep full node_modules (drizzle-kit needed at runtime for migrations)
 
 # ---- Stage 2: Runtime ----
 FROM oven/bun:1-alpine AS runtime
@@ -37,7 +34,7 @@ WORKDIR /app
 # Without this, BuildKit caches the runtime stage even when the build stage changed
 ARG CACHEBUST=1
 
-# Copy only production node_modules (no devDependencies)
+# Copier tout depuis le build stage (node_modules inclus, avec drizzle-kit)
 COPY --from=build /app/node_modules node_modules/
 COPY --from=build /app/shared shared/
 COPY --from=build /app/server server/


### PR DESCRIPTION
Container crash-loops because drizzle-kit was removed by --production install. Reverting.