### PR TITLE
fix: StatsPage crash + TripPage missing map

### DIFF
--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -102,18 +102,11 @@ export function StatsPage() {
 
   const isPending = summaryLoading || tripsLoading || weeklyLoading || achievementsLoading;
 
-  if (isPending || !s) {
-    return (
-      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    );
-  }
-
   const trips = tripsData?.trips ?? [];
   const chartTrips = weeklyTrips ?? [];
 
   // Build weekly chart data from all trips this week (memoized)
+  // MUST be before any early return to respect Rules of Hooks
   const weeklyData = useMemo(() => {
     const data = DAY_LABELS.map((day) => ({ day, km: 0, co2: 0, eur: 0 }));
 
@@ -136,6 +129,14 @@ export function StatsPage() {
 
     return data;
   }, [chartTrips]);
+
+  if (isPending || !s) {
+    return (
+      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -195,7 +195,7 @@ export function TripPage() {
       )}
 
       {/* Map */}
-      <div className="relative flex-1">
+      <div className="relative" style={{ height: "50vh", minHeight: "250px" }}>
         <MapContainer
           center={currentPos as LatLngExpression}
           zoom={15}


### PR DESCRIPTION
## Bugs fixed
- **StatsPage crash**: useMemo was after early return → React error #310 (hooks order). Moved before.
- **TripPage no map**: PullToRefresh wrapper broke flex-1 height chain. Fixed with explicit 50vh.

## Root cause
Agent PRs (#36, #38, #39) introduced these regressions that passed typecheck but failed at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)