### PR TITLE
chore: bump to 1.3.2 (hotfix patches)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecoride",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "private": true,
   "workspaces": ["shared", "server", "client"],
   "scripts": {


### PR DESCRIPTION
Bump for PWA auto-update after hotfixes #47 and #48.