### PR TITLE
fix: tracking timer + GPS + version display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ---- Stage 1: Build client ----
 FROM oven/bun:1-alpine AS build
 
-ARG GIT_HASH=unknown
+ARG GIT_HASH=
 
 WORKDIR /app
 

--- a/client/e2e/tracking.spec.ts
+++ b/client/e2e/tracking.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+test("clicking Démarrer starts tracking with counters", async ({ page, context }) => {
+  // Grant geolocation permission and fake position
+  await context.grantPermissions(["geolocation"]);
+  await context.setGeolocation({ latitude: 48.8566, longitude: 2.3522 });
+
+  // Stub API
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  // Click Démarrer
+  const startBtn = page.getByText("Démarrer");
+  await expect(startBtn).toBeVisible();
+  await startBtn.click();
+
+  // Should now see Terminer button (tracking mode)
+  const stopBtn = page.getByText("Terminer");
+  await expect(stopBtn).toBeVisible({ timeout: 5000 });
+
+  // Should see speed display (km/h label)
+  const speedLabel = page.getByText("km/h");
+  await expect(speedLabel).toBeVisible({ timeout: 3000 });
+
+  // Wait 4 seconds for timer to tick
+  await page.waitForTimeout(4000);
+
+  // Check all visible text for debugging
+  const allText = await page.locator("body").textContent();
+  console.log("Body text:", allText?.slice(0, 500));
+
+  // Timer should have ticked (not 00:00)
+  const timeValues = await page.locator("text=/\\d{2}:\\d{2}/").allTextContents();
+  console.log("Time values found:", timeValues);
+  expect(timeValues.some(t => t !== "00:00")).toBeTruthy();
+});

--- a/client/src/hooks/useGpsTracking.ts
+++ b/client/src/hooks/useGpsTracking.ts
@@ -219,15 +219,67 @@ export function useGpsTracking() {
     dispatch({ type: "START" });
     startRef.current = new Date().toISOString();
     retryCountRef.current = 0;
+  }, []);
+
+  // Start/stop GPS watch, timer, wake lock, and backup based on isTracking state.
+  // Only depends on state.isTracking — other refs are stable across renders.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!state.isTracking) return;
+
     wakeLock.request();
 
-    startWatch();
+    // GPS watch
+    if (watchRef.current !== null) navigator.geolocation.clearWatch(watchRef.current);
+    watchRef.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        if (pos.coords.accuracy > MAX_ACCURACY_M) return;
+        retryCountRef.current = 0;
+        dispatch({
+          type: "GPS_POINT",
+          point: { lat: pos.coords.latitude, lng: pos.coords.longitude, ts: pos.timestamp },
+          accuracy: pos.coords.accuracy,
+          speed: pos.coords.speed,
+        });
+      },
+      (err) => {
+        const msgs: Record<number, string> = {
+          1: "Permission GPS refusée",
+          2: "Position non disponible",
+          3: "Timeout GPS",
+        };
+        dispatch({ type: "ERROR", message: msgs[err.code] ?? "Erreur GPS" });
+        if (err.code === 1 || err.code === 2) wakeLock.release();
+      },
+      { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 },
+    );
 
-    timerRef.current = setInterval(() => dispatch({ type: "TICK" }), 1000);
+    // Timer
+    const timer = setInterval(() => dispatch({ type: "TICK" }), 1000);
 
-    // Fix 1.3: Periodic GPS backup to localStorage
-    backupTimerRef.current = setInterval(saveBackup, BACKUP_INTERVAL_MS);
-  }, [wakeLock, startWatch, saveBackup]);
+    // Backup
+    const backupTimer = setInterval(() => {
+      const s = stateRef.current;
+      if (!s.isTracking || s.gpsPoints.length === 0) return;
+      const backup: TrackingBackup = {
+        gpsPoints: s.gpsPoints,
+        distanceKm: s.distanceKm,
+        durationSec: s.durationSec,
+        startedAt: startRef.current ?? new Date().toISOString(),
+      };
+      localStorage.setItem(BACKUP_KEY, JSON.stringify(backup));
+    }, BACKUP_INTERVAL_MS);
+
+    return () => {
+      if (watchRef.current !== null) {
+        navigator.geolocation.clearWatch(watchRef.current);
+        watchRef.current = null;
+      }
+      clearInterval(timer);
+      clearInterval(backupTimer);
+      wakeLock.release();
+    };
+  }, [state.isTracking]);
 
   /** Restore tracking from a backup (called externally by TripPage). */
   const restore = useCallback(
@@ -276,13 +328,7 @@ export function useGpsTracking() {
     clearTrackingBackup();
   }, [cleanup, wakeLock]);
 
-  // Fix 1.4: Release wake lock on component unmount
-  useEffect(() => {
-    return () => {
-      cleanup();
-      wakeLock.release();
-    };
-  }, [cleanup, wakeLock]);
+  // Cleanup is now handled by the isTracking effect above
 
   return { state, start, stop, reset, restore };
 }


### PR DESCRIPTION
## Bug
Timer stayed at 00:00 during tracking. GPS never requested permission.

## Root cause
useCallback deps (startWatch, saveBackup, cleanup) changed every render,
causing the useEffect to cleanup/restart infinitely — clearing the timer
each time.

## Fix
Inlined all side effects in a single useEffect keyed only on `state.isTracking`.
Also fixed Dockerfile GIT_HASH default from "unknown" to empty string.

## Tests
- Tracking test added: clicks Démarrer, waits 4s, verifies timer > 00:00
- 8/8 tests pass (7 smoke + 1 tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)