### PR TITLE
fix: handle empty/invalid VAPID key + regression tests

### DIFF
--- a/client/e2e/notifications.spec.ts
+++ b/client/e2e/notifications.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for: "DOMException: Invalid raw ECDSA P-256 public key"
+ * When VAPID key is empty or invalid, subscribeToPush must return null
+ * instead of crashing. The profile page must remain functional.
+ *
+ * Note: Profile page requires auth, so we test via the smoke test pattern
+ * (stubbed API) and verify no crash. The actual VAPID validation logic
+ * is tested via vitest in client/src/lib/__tests__/push.test.ts.
+ */
+
+test("profile page does not crash with empty VAPID key stub", async ({ page }) => {
+  // Stub all API calls — including auth session
+  await page.route("**/api/**", (route) => {
+    const url = route.request().url();
+    if (url.includes("/push/vapid-key")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { publicKey: "" } }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    });
+  });
+
+  await page.goto("/profile", { waitUntil: "networkidle" });
+
+  // The error boundary text should NOT be visible
+  const errorBoundary = page.getByText("Une erreur est survenue");
+  await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
+});

--- a/client/src/lib/__tests__/push.test.ts
+++ b/client/src/lib/__tests__/push.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { urlBase64ToUint8Array } from "../push";
+
+describe("urlBase64ToUint8Array", () => {
+  it("converts a valid VAPID key to Uint8Array", () => {
+    const key = "BNGNvPNmn6BuBQG3_nvuAO-wngOKDhXHsZ2Eieav73pAY2h6ko_mNPzolDDJK3iItk9Pb5eOBmc5Z9L2ZLghk7g";
+    const result = urlBase64ToUint8Array(key);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(65); // P-256 public key = 65 bytes
+  });
+
+  it("handles empty string without throwing", () => {
+    const result = urlBase64ToUint8Array("");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(0);
+  });
+
+  it("throws on truly invalid base64 (guarded by subscribeToPush length check)", () => {
+    // atob throws on invalid chars — subscribeToPush guards against this
+    // by checking key.length >= 20 before calling urlBase64ToUint8Array
+    expect(() => urlBase64ToUint8Array("!!!invalid!!!")).toThrow();
+  });
+});

--- a/client/src/lib/push.ts
+++ b/client/src/lib/push.ts
@@ -41,10 +41,21 @@ export async function subscribeToPush(): Promise<PushSubscription | null> {
   const registration = await navigator.serviceWorker.ready;
   const vapidPublicKey = await getVapidPublicKey();
 
-  const subscription = await registration.pushManager.subscribe({
-    userVisibleOnly: true,
-    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
-  });
+  if (!vapidPublicKey || vapidPublicKey.length < 20) {
+    console.warn("[push] VAPID public key is empty or invalid — push disabled");
+    return null;
+  }
+
+  let subscription: PushSubscription;
+  try {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
+    });
+  } catch (err) {
+    console.error("[push] Failed to subscribe:", err);
+    return null;
+  }
 
   // Send subscription to server
   const keys = subscription.toJSON().keys!;


### PR DESCRIPTION
Fixes DOMException crash when VAPID key is empty or invalid. Includes vitest + Playwright regression tests.