### PR TITLE
feat: auto-bump version in CI (conventional commits)

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -1,0 +1,64 @@
+name: Auto-bump version
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bump:
+    name: Bump version
+    runs-on: ubuntu-latest
+    # Skip if the commit is already a version bump (prevent infinite loop)
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine bump type from commit message
+        id: bump
+        run: |
+          MSG="${{ github.event.head_commit.message }}"
+          # Extract type from conventional commit (first line)
+          TYPE=$(echo "$MSG" | head -1 | grep -oP '^(feat|fix|perf|refactor)' || echo "")
+
+          if [ "$TYPE" = "feat" ]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif [ "$TYPE" = "fix" ] || [ "$TYPE" = "perf" ]; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            echo "type=none" >> $GITHUB_OUTPUT
+          fi
+          echo "Commit type: $TYPE → bump: $(cat $GITHUB_OUTPUT | grep type= | cut -d= -f2)"
+
+      - name: Bump package.json version
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          BUMP="${{ steps.bump.outputs.type }}"
+          CURRENT=$(node -p "require('./package.json').version")
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          if [ "$BUMP" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif [ "$BUMP" = "patch" ]; then
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW="${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bumping: $CURRENT → $NEW ($BUMP)"
+
+          # Update package.json
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '$NEW';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          # Commit and push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to $NEW"
+          git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: homelab-runner
+    # Only deploy on auto-bump commits (ensures correct version is built)
+    if: "startsWith(github.event.head_commit.message, 'chore: bump version')"
     steps:
       - name: Trigger Coolify deploy
         run: |


### PR DESCRIPTION
## Summary
Adds a GitHub Action that auto-bumps package.json version after each merge to main.

## Rules
- `feat:` commits → minor bump (1.3.4 → 1.4.0)
- `fix:` / `perf:` commits → patch bump (1.3.4 → 1.3.5)
- `chore:` / `docs:` / `refactor:` → no bump
- Commits starting with "chore: bump version" are skipped (prevents infinite loop)

## Why
We forgot to bump 3 times this evening, causing PWA auto-update to not trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)