### PR TITLE
fix: responsive bottom nav for iPhone SE

### DIFF
--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -17,24 +17,24 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-4 pb-[calc(0.75rem+env(safe-area-inset-bottom,0.5rem))] pt-3 backdrop-blur-2xl border-t border-outline-variant/10">
+    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-2 sm:px-4 pb-[calc(0.5rem+env(safe-area-inset-bottom,0.5rem))] pt-2 backdrop-blur-2xl border-t border-outline-variant/10">
       {tabs.map(({ to, icon: Icon, label }) => (
         <NavLink
           key={to}
           to={to}
           end={to === "/"}
           className={({ isActive }) =>
-            `flex flex-col items-center justify-center gap-1 min-h-[44px] transition-all duration-150 active:scale-90 ${
+            `flex flex-col items-center justify-center gap-0.5 min-h-[44px] min-w-0 transition-all duration-150 active:scale-90 ${
               isActive
-                ? "text-primary-light rounded-2xl bg-primary/10 px-3 py-1.5"
-                : "text-text-dim hover:text-text-muted px-2 py-1.5"
+                ? "text-primary-light rounded-xl bg-primary/10 px-2 py-1"
+                : "text-text-dim hover:text-text-muted px-1 py-1"
             }`
           }
         >
           {({ isActive }) => (
             <>
-              <Icon size={24} strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
-              <span className="text-xs font-bold uppercase tracking-widest">
+              <Icon size={20} className="sm:w-6 sm:h-6" strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
+              <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider sm:tracking-widest truncate max-w-[56px] sm:max-w-none text-center">
                 {label}
               </span>
             </>


### PR DESCRIPTION
Bottom nav was too wide on 375px screens. Smaller icons, tighter padding, truncated labels on small viewports.