### PR TITLE
feat: leaderboard categories backend (co2/streak/trips/speed)

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -7,6 +7,7 @@ import type {
   CreateTripRequest,
   UpdateUserRequest,
   StatsPeriod,
+  LeaderboardCategory,
 } from "@ecoride/shared/api-contracts";
 
 // ---- Queries ----
@@ -70,14 +71,14 @@ export function useWeeklyTrips() {
   });
 }
 
-export function useLeaderboard(period: StatsPeriod = "all") {
+export function useLeaderboard(period: StatsPeriod = "all", category: LeaderboardCategory = "co2") {
   return useQuery({
-    queryKey: ["leaderboard", period],
+    queryKey: ["leaderboard", period, category],
     queryFn: () =>
       apiFetch<{
         ok: boolean;
         data: { entries: LeaderboardEntry[]; userRank: number | null };
-      }>(`/stats/leaderboard?period=${period}`).then((r) => r.data),
+      }>(`/stats/leaderboard?period=${period}&category=${category}`).then((r) => r.data),
   });
 }
 

--- a/client/src/lib/__tests__/avg-speed.test.ts
+++ b/client/src/lib/__tests__/avg-speed.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { computeAvgSpeedKmh } from '../calculations'
+
+describe('computeAvgSpeedKmh', () => {
+  it('calculates speed as distance / duration in km/h', () => {
+    // 20 km in 3600 sec (1 hour) = 20 km/h
+    expect(computeAvgSpeedKmh(20, 3600)).toBe(20)
+  })
+
+  it('rounds to 1 decimal place', () => {
+    // 10 km in 3600 sec = 10.0 km/h
+    expect(computeAvgSpeedKmh(10, 3600)).toBe(10)
+    // 10 km in 2400 sec (40 min) = 15.0 km/h
+    expect(computeAvgSpeedKmh(10, 2400)).toBe(15)
+    // 7 km in 1800 sec (30 min) = 14.0 km/h
+    expect(computeAvgSpeedKmh(7, 1800)).toBe(14)
+    // 5 km in 720 sec (12 min) = 25.0 km/h
+    expect(computeAvgSpeedKmh(5, 720)).toBe(25)
+    // 12.5 km in 2700 sec (45 min) = 16.666... -> 16.7 km/h
+    expect(computeAvgSpeedKmh(12.5, 2700)).toBe(16.7)
+  })
+
+  it('returns 0 for 0 duration', () => {
+    expect(computeAvgSpeedKmh(10, 0)).toBe(0)
+  })
+
+  it('returns 0 for negative duration', () => {
+    expect(computeAvgSpeedKmh(10, -100)).toBe(0)
+  })
+
+  it('returns 0 for 0 distance with valid duration', () => {
+    expect(computeAvgSpeedKmh(0, 3600)).toBe(0)
+  })
+
+  it('handles typical cycling speeds', () => {
+    // Casual: 8 km in 30 min = 16 km/h
+    expect(computeAvgSpeedKmh(8, 1800)).toBeCloseTo(16)
+    // Fast commuter: 15 km in 35 min (2100s) = ~25.7 km/h
+    expect(computeAvgSpeedKmh(15, 2100)).toBe(25.7)
+    // Sprint: 2 km in 180 sec (3 min) = 40 km/h
+    expect(computeAvgSpeedKmh(2, 180)).toBe(40)
+  })
+
+  it('handles aggregated multi-trip values', () => {
+    // Total: 45 km over 9000 sec (2.5 hours) = 18.0 km/h
+    expect(computeAvgSpeedKmh(45, 9000)).toBe(18)
+    // Total: 100 km over 18000 sec (5 hours) = 20.0 km/h
+    expect(computeAvgSpeedKmh(100, 18000)).toBe(20)
+  })
+})

--- a/client/src/lib/calculations.ts
+++ b/client/src/lib/calculations.ts
@@ -38,3 +38,13 @@ export function computeSavings(
     fuelSavedL: fuel,
   }
 }
+
+/**
+ * Compute average speed in km/h from total distance (km) and total duration (seconds).
+ * Returns 0 if duration is 0 or negative. Result is rounded to 1 decimal place.
+ */
+export function computeAvgSpeedKmh(totalDistanceKm: number, totalDurationSec: number): number {
+  if (totalDurationSec <= 0) return 0
+  const hours = totalDurationSec / 3600
+  return Math.round((totalDistanceKm / hours) * 10) / 10
+}

--- a/client/src/lib/mock-data.ts
+++ b/client/src/lib/mock-data.ts
@@ -76,13 +76,13 @@ export const mockWeeklyData = [
 
 export const mockLeaderboard: LeaderboardResponse = {
   entries: [
-    { userId: "u-1", name: "Thomas D.", image: null, totalCo2SavedKg: 42.5, rank: 1 },
-    { userId: "u-2", name: "Sarah L.", image: null, totalCo2SavedKg: 38.2, rank: 2 },
-    { userId: "u-3", name: "Julien R.", image: null, totalCo2SavedKg: 31.8, rank: 3 },
-    { userId: "user-1", name: "Alex Chen", image: null, totalCo2SavedKg: 28.4, rank: 4 },
-    { userId: "u-5", name: "Léa Martin", image: null, totalCo2SavedKg: 25.1, rank: 5 },
-    { userId: "u-6", name: "Marc Antoine", image: null, totalCo2SavedKg: 22.9, rank: 6 },
-    { userId: "u-7", name: "Chloé Petit", image: null, totalCo2SavedKg: 19.4, rank: 7 },
+    { userId: "u-1", name: "Thomas D.", image: null, totalCo2SavedKg: 42.5, value: 42.5, rank: 1 },
+    { userId: "u-2", name: "Sarah L.", image: null, totalCo2SavedKg: 38.2, value: 38.2, rank: 2 },
+    { userId: "u-3", name: "Julien R.", image: null, totalCo2SavedKg: 31.8, value: 31.8, rank: 3 },
+    { userId: "user-1", name: "Alex Chen", image: null, totalCo2SavedKg: 28.4, value: 28.4, rank: 4 },
+    { userId: "u-5", name: "Léa Martin", image: null, totalCo2SavedKg: 25.1, value: 25.1, rank: 5 },
+    { userId: "u-6", name: "Marc Antoine", image: null, totalCo2SavedKg: 22.9, value: 22.9, rank: 6 },
+    { userId: "u-7", name: "Chloé Petit", image: null, totalCo2SavedKg: 19.4, value: 19.4, rank: 7 },
   ],
   userRank: 4,
 };

--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { eq, sql, sum, desc, asc, and, gte } from "drizzle-orm";
+import { eq, sql, sum, desc, asc, and, gte, count } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { trips } from "../db/schema";
@@ -12,6 +12,7 @@ import type { StatsPeriod } from "@ecoride/shared/api-contracts";
 const leaderboardQuery = z.object({
   period: z.enum(["day", "week", "month", "year", "all"]).default("all"),
   limit: z.coerce.number().int().positive().max(100).default(50),
+  category: z.enum(["co2", "streak", "trips", "speed"]).default("co2"),
 });
 
 function getPeriodStart(period: StatsPeriod): Date | null {
@@ -30,6 +31,55 @@ function getPeriodStart(period: StatsPeriod): Date | null {
   }
 }
 
+/**
+ * Format a Date as YYYY-MM-DD (UTC).
+ */
+function dateToDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Compute the current streak from an array of trip date strings (YYYY-MM-DD).
+ * Dates should be unique. Returns the number of consecutive days ending today or yesterday.
+ */
+export function computeStreakFromDates(tripDates: string[]): number {
+  if (tripDates.length === 0) return 0;
+
+  const unique = [...new Set(tripDates)].sort().reverse();
+  const today = dateToDay(new Date());
+  const last = unique[0]!;
+
+  const diffMs = new Date(today).getTime() - new Date(last).getTime();
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  // Streak counts only if the most recent trip was today or yesterday
+  if (diffDays > 1) return 0;
+
+  let streak = 1;
+  for (let i = 1; i < unique.length; i++) {
+    const prev = new Date(unique[i - 1]!);
+    const curr = new Date(unique[i]!);
+    const diff = Math.floor((prev.getTime() - curr.getTime()) / 86400000);
+    if (diff === 1) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+
+  return streak;
+}
+
+/**
+ * Compute average speed in km/h from total distance (km) and total duration (seconds).
+ * Returns 0 if duration is 0.
+ */
+export function computeAvgSpeedKmh(totalDistanceKm: number, totalDurationSec: number): number {
+  if (totalDurationSec <= 0) return 0;
+  const hours = totalDurationSec / 3600;
+  return Math.round((totalDistanceKm / hours) * 10) / 10;
+}
+
 const leaderboardRouter = new Hono<AuthEnv>();
 
 // GET /api/stats/leaderboard
@@ -37,49 +87,186 @@ leaderboardRouter.get(
   "/",
   zValidator("query", leaderboardQuery, validationHook),
   async (c) => {
-    const { period, limit } = c.req.valid("query");
+    const { period, limit, category } = c.req.valid("query");
     const currentUser = c.get("user");
 
     const periodStart = getPeriodStart(period);
 
     const conditions = [eq(user.leaderboardOptOut, false)];
-    const tripConditions = periodStart
-      ? [gte(trips.startedAt, periodStart)]
-      : [];
 
     const joinCondition = periodStart
       ? and(eq(user.id, trips.userId), gte(trips.startedAt, periodStart))
       : eq(user.id, trips.userId);
 
-    const entries = await db
+    if (category === "co2") {
+      const entries = await db
+        .select({
+          userId: user.id,
+          name: user.name,
+          image: user.image,
+          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+        })
+        .from(user)
+        .leftJoin(trips, joinCondition)
+        .where(and(...conditions))
+        .groupBy(user.id, user.name, user.image)
+        .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`), asc(user.name))
+        .limit(limit);
+
+      const ranked = denseRank(entries, (e) => e.totalCo2SavedKg ?? 0);
+      const mapped = ranked.map((e) => ({ ...e, value: e.totalCo2SavedKg }));
+
+      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+      return c.json({ ok: true, data: { entries: mapped, userRank } });
+    }
+
+    if (category === "trips") {
+      const entries = await db
+        .select({
+          userId: user.id,
+          name: user.name,
+          image: user.image,
+          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+          tripCount: count(trips.id).mapWith(Number),
+        })
+        .from(user)
+        .leftJoin(trips, joinCondition)
+        .where(and(...conditions))
+        .groupBy(user.id, user.name, user.image)
+        .orderBy(desc(count(trips.id)), asc(user.name))
+        .limit(limit);
+
+      const ranked = denseRank(entries, (e) => e.tripCount);
+      const mapped = ranked.map((e) => ({ ...e, value: e.tripCount }));
+
+      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+      return c.json({ ok: true, data: { entries: mapped, userRank } });
+    }
+
+    if (category === "speed") {
+      const entries = await db
+        .select({
+          userId: user.id,
+          name: user.name,
+          image: user.image,
+          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+          totalDistanceKm: sql<number>`coalesce(${sum(trips.distanceKm)}, 0)`.mapWith(Number),
+          totalDurationSec: sql<number>`coalesce(${sum(trips.durationSec)}, 0)`.mapWith(Number),
+          tripCount: count(trips.id).mapWith(Number),
+        })
+        .from(user)
+        .leftJoin(trips, joinCondition)
+        .where(and(...conditions))
+        .groupBy(user.id, user.name, user.image)
+        .limit(limit * 2); // fetch extra since we filter
+
+      // Filter users with at least 1 trip, compute avg speed
+      const withSpeed = entries
+        .filter((e) => e.tripCount > 0)
+        .map((e) => ({
+          userId: e.userId,
+          name: e.name,
+          image: e.image,
+          totalCo2SavedKg: e.totalCo2SavedKg,
+          avgSpeedKmh: computeAvgSpeedKmh(e.totalDistanceKm, e.totalDurationSec),
+        }))
+        .sort((a, b) => b.avgSpeedKmh - a.avgSpeedKmh || a.name.localeCompare(b.name))
+        .slice(0, limit);
+
+      const ranked = denseRank(withSpeed, (e) => e.avgSpeedKmh);
+      const mapped = ranked.map((e) => ({ ...e, value: e.avgSpeedKmh }));
+
+      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+      return c.json({ ok: true, data: { entries: mapped, userRank } });
+    }
+
+    // category === "streak"
+    // Fetch all opted-in users
+    const optedInUsers = await db
       .select({
         userId: user.id,
         name: user.name,
         image: user.image,
+      })
+      .from(user)
+      .where(and(...conditions));
+
+    if (optedInUsers.length === 0) {
+      return c.json({ ok: true, data: { entries: [], userRank: null } });
+    }
+
+    // Fetch all trip dates for opted-in users in a single query
+    const userIds = optedInUsers.map((u) => u.userId);
+    const tripDateConditions = periodStart
+      ? and(sql`${trips.userId} IN ${userIds}`, gte(trips.startedAt, periodStart))
+      : sql`${trips.userId} IN ${userIds}`;
+
+    const tripRows = await db
+      .select({
+        userId: trips.userId,
+        startedAt: trips.startedAt,
+      })
+      .from(trips)
+      .where(tripDateConditions);
+
+    // Also get co2 totals for opted-in users
+    const co2Rows = await db
+      .select({
+        userId: user.id,
         totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
       })
       .from(user)
       .leftJoin(trips, joinCondition)
       .where(and(...conditions))
-      .groupBy(user.id, user.name, user.image)
-      .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`), asc(user.name))
-      .limit(limit);
+      .groupBy(user.id);
 
-    // Dense ranking: tied users share the same rank
-    let currentRank = 1;
-    const ranked = entries.map((entry, idx) => {
-      const co2 = entry.totalCo2SavedKg ?? 0;
-      if (idx > 0 && co2 !== (entries[idx - 1]!.totalCo2SavedKg ?? 0)) {
-        currentRank = idx + 1;
+    const co2Map = new Map(co2Rows.map((r) => [r.userId, r.totalCo2SavedKg]));
+
+    // Group trip dates by user
+    const userTripDates = new Map<string, string[]>();
+    for (const row of tripRows) {
+      const day = dateToDay(row.startedAt);
+      const existing = userTripDates.get(row.userId);
+      if (existing) {
+        existing.push(day);
+      } else {
+        userTripDates.set(row.userId, [day]);
       }
-      return { ...entry, totalCo2SavedKg: co2, rank: currentRank };
-    });
+    }
 
-    // Find current user's rank
-    const userRank = ranked.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    // Compute streaks for each user
+    const withStreak = optedInUsers
+      .map((u) => ({
+        userId: u.userId,
+        name: u.name,
+        image: u.image,
+        totalCo2SavedKg: co2Map.get(u.userId) ?? 0,
+        streak: computeStreakFromDates(userTripDates.get(u.userId) ?? []),
+      }))
+      .sort((a, b) => b.streak - a.streak || a.name.localeCompare(b.name))
+      .slice(0, limit);
 
-    return c.json({ ok: true, data: { entries: ranked, userRank } });
+    const ranked = denseRank(withStreak, (e) => e.streak);
+    const mapped = ranked.map((e) => ({ ...e, value: e.streak }));
+
+    const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    return c.json({ ok: true, data: { entries: mapped, userRank } });
   },
 );
+
+/**
+ * Assign dense ranks based on a value extractor.
+ * Entries with the same value get the same rank.
+ */
+function denseRank<T>(entries: T[], getValue: (entry: T) => number): (T & { rank: number })[] {
+  let currentRank = 1;
+  return entries.map((entry, idx) => {
+    const val = getValue(entry);
+    if (idx > 0 && val !== getValue(entries[idx - 1]!)) {
+      currentRank = idx + 1;
+    }
+    return { ...entry, rank: currentRank };
+  });
+}
 
 export { leaderboardRouter };

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -71,6 +71,8 @@ export interface FuelPriceQuery {
 
 export type StatsPeriod = "day" | "week" | "month" | "year" | "all";
 
+export type LeaderboardCategory = "co2" | "streak" | "trips" | "speed";
+
 // ---- Response payloads ----
 
 export interface TripListResponse {
@@ -97,6 +99,7 @@ export interface LeaderboardEntry {
   name: string;
   image: string | null;
   totalCo2SavedKg: number;
+  value: number;
   rank: number;
 }
 


### PR DESCRIPTION
## Summary
- Add `category` query param to the leaderboard endpoint supporting `co2` (default), `streak`, `trips`, and `speed`
- `streak` category computes current streak per user via trip dates fetched in a single bulk query, then sorted in JS
- `trips` category counts trips per user, `speed` computes avg speed (distance/duration) with a 1-trip minimum filter
- All categories return a generic `value` field alongside `totalCo2SavedKg` for backward compatibility
- Updated `LeaderboardEntry` shared type, `useLeaderboard` client hook, and mock data
- Added `computeAvgSpeedKmh` utility to client calculations module with vitest regression tests (7 test cases)

## Test plan
- [x] `bun run typecheck` passes (both server and client)
- [x] All 74 client unit tests pass, including new `avg-speed.test.ts`
- [ ] Manual: `GET /api/stats/leaderboard?category=co2` returns same results as before
- [ ] Manual: `GET /api/stats/leaderboard?category=streak` returns users sorted by current streak
- [ ] Manual: `GET /api/stats/leaderboard?category=trips` returns users sorted by trip count
- [ ] Manual: `GET /api/stats/leaderboard?category=speed` returns users sorted by avg speed (km/h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)