### PR TITLE
feat: add period filter to leaderboard

### DIFF
--- a/client/e2e/leaderboard-period.spec.ts
+++ b/client/e2e/leaderboard-period.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for the leaderboard period filter feature.
+ *
+ * Verifies that:
+ * 1. The leaderboard page loads without crashing
+ * 2. The period switcher buttons (Semaine, Mois, Tout) are visible
+ * 3. Clicking a period button updates the active state
+ */
+
+test.describe("Leaderboard period filter", () => {
+  test.beforeEach(async ({ page }) => {
+    // Unregister any existing service workers so they don't intercept API stubs
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+    });
+
+    // Prevent re-registration of the service worker
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    // Stub all API calls
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      // Return a proper session for auth endpoints
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session: {
+              id: "test-session",
+              userId: "test-user",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "test-user",
+              name: "Test User",
+              email: "test@example.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        });
+      }
+
+      // Return empty leaderboard for all other API calls
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { entries: [], userRank: null } }),
+      });
+    });
+  });
+
+  test("shows period switcher buttons", async ({ page }) => {
+    await page.goto("/leaderboard", { waitUntil: "networkidle" });
+
+    // Page should NOT show the error boundary
+    const errorBoundary = page.getByText("Une erreur est survenue");
+    await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
+
+    // Period switcher should be visible with all 3 buttons
+    const switcher = page.getByTestId("period-switcher");
+    await expect(switcher).toBeVisible();
+
+    await expect(switcher.getByText("Semaine")).toBeVisible();
+    await expect(switcher.getByText("Mois")).toBeVisible();
+    await expect(switcher.getByText("Tout")).toBeVisible();
+  });
+
+  test("clicking a period button updates active state", async ({ page }) => {
+    await page.goto("/leaderboard", { waitUntil: "networkidle" });
+
+    const switcher = page.getByTestId("period-switcher");
+    await expect(switcher).toBeVisible();
+
+    // "Tout" should be active by default (has primary color class)
+    const toutBtn = switcher.getByText("Tout");
+    await expect(toutBtn).toHaveClass(/bg-primary/);
+
+    // Click "Semaine" and verify it becomes active
+    const semaineBtn = switcher.getByText("Semaine");
+    await semaineBtn.click();
+    await expect(semaineBtn).toHaveClass(/bg-primary/);
+
+    // "Tout" should no longer have the active style
+    await expect(toutBtn).toHaveClass(/bg-surface-high/);
+  });
+});

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -1,10 +1,25 @@
+import { useState } from "react";
 import { Trophy } from "lucide-react";
 import { useLeaderboard } from "@/hooks/queries";
 import { useSession } from "@/lib/auth";
+import type { StatsPeriod } from "@ecoride/shared/api-contracts";
+
+const periodOptions = [
+  { label: "Semaine", value: "week" as StatsPeriod },
+  { label: "Mois", value: "month" as StatsPeriod },
+  { label: "Tout", value: "all" as StatsPeriod },
+];
+
+const periodSubtitles: Record<string, string> = {
+  week: "L'impact écologique cette semaine",
+  month: "L'impact écologique ce mois-ci",
+  all: "L'impact écologique global",
+};
 
 export function LeaderboardPage() {
   const { data: session } = useSession();
-  const { data, isPending } = useLeaderboard();
+  const [period, setPeriod] = useState<StatsPeriod>("all");
+  const { data, isPending } = useLeaderboard(period);
 
   if (isPending || !data) {
     return (
@@ -35,8 +50,25 @@ export function LeaderboardPage() {
             Classement
           </h2>
           <p className="text-sm font-medium text-text-dim">
-            L'impact écologique ce mois-ci
+            {periodSubtitles[period]}
           </p>
+
+          {/* Period switcher */}
+          <div className="mt-4 flex gap-2" data-testid="period-switcher">
+            {periodOptions.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setPeriod(opt.value)}
+                className={`rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                  opt.value === period
+                    ? "bg-primary/20 text-primary-light"
+                    : "bg-surface-high text-text-muted"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </section>
 
         {entries.length === 0 ? (


### PR DESCRIPTION
## Summary
- Add period filter (Semaine/Mois/Tout) to the leaderboard page, using inline button switcher styled like the StatsPage metric switcher
- Pass the selected period to `useLeaderboard(period)` which maps to the existing backend `?period=week|month|all` query param
- Subtitle text dynamically updates to reflect the selected period

## Test plan
- [x] TypeScript type check passes (`bun run typecheck`)
- [x] Client builds without errors (`bun run build`)
- [x] All 11 Playwright e2e tests pass, including 2 new regression tests:
  - `shows period switcher buttons` — verifies the 3 period buttons render on the leaderboard page
  - `clicking a period button updates active state` — verifies clicking a button toggles the active styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)