### PR TITLE
feat: add ESLint + Prettier + husky pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run lint
+      - run: bun run format:check
+
   typecheck:
     name: TypeScript check
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.claude
+design
+bun.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/AUDIT-v1.2.md
+++ b/AUDIT-v1.2.md
@@ -9,66 +9,77 @@
 ## 1. GPS & Tracking
 
 ### 1.1 Filtrage silencieux de la precision GPS
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:6,93`
 **Probleme :** Les points GPS avec une precision > 50m sont ignores silencieusement (`MAX_ACCURACY_M = 50`). L'utilisateur ne voit aucun feedback — le timer tourne, la distance reste a 0.
 **Impact :** Un trajet en zone urbaine dense peut produire 0 points GPS sans que l'utilisateur comprenne pourquoi.
 **Fix :** Afficher un indicateur de qualite GPS (ex: barre de signal) et un avertissement si aucun point n'est enregistre apres 30 secondes.
 
 ### 1.2 Pas de recovery apres perte GPS (tunnel)
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:91-108`
 **Probleme :** `watchPosition` a un timeout de 15s. Apres un timeout (ex: tunnel), l'erreur est dispatchee mais `watchPosition` n'est pas relance. Le tracking meurt silencieusement.
 **Impact :** Sortie de tunnel = plus de GPS, l'utilisateur doit arreter et relancer manuellement.
 **Fix :** Relancer automatiquement `watchPosition` apres une erreur de timeout avec un backoff de 2-5 secondes.
 
 ### 1.3 Background kill Android = perte de donnees
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:64-68`, `client/src/pages/TripPage.tsx:29`
 **Probleme :** Tous les points GPS sont stockes en memoire React (useReducer + useRef). Si Android tue la PWA en arriere-plan, toutes les donnees sont perdues. Pas de backup periodique.
 **Impact :** CRITIQUE — l'utilisateur perd son trajet entier si l'OS recycle la PWA.
 **Fix :** Sauvegarder les GPS points dans localStorage toutes les 30 secondes pendant le tracking. Implementer un mecanisme de recovery au remontage du composant.
 
 ### 1.4 Wake lock non relache sur navigation
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:135`
 **Probleme :** Le useEffect cleanup (demontage du composant) clear le watchPosition et le timer, mais ne release PAS le wake lock. Si l'utilisateur navigue vers une autre page pendant le tracking, le wake lock reste actif indefiniment.
 **Impact :** Drain batterie (250-400 mA/hr) jusqu'a fermeture de l'app.
 **Fix :** Ajouter `wakeLock.release()` dans la fonction cleanup du useEffect.
 
 ### 1.5 Wake lock non relache sur erreur GPS
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:99-106`
 **Probleme :** Quand une erreur GPS survient (timeout, permission), le wake lock n'est pas relache.
 **Impact :** Meme apres une erreur fatale, l'ecran reste allume.
 **Fix :** Appeler `wakeLock.release()` dans le handler d'erreur GPS.
 
 ### 1.6 Pas de protection double-tap sur Demarrer
+
 **Fichier :** `client/src/pages/TripPage.tsx:320-327`, `client/src/hooks/useGpsTracking.ts:87`
 **Probleme :** Le bouton "Demarrer" n'a pas de `disabled` state. Un double-tap rapide appelle `startTracking()` deux fois. Le second appel dispatche `START` qui reset l'etat (wipe les GPS points du premier appel).
 **Impact :** Faible en pratique (race condition courte) mais peut perdre des points GPS.
 **Fix :** Desactiver le bouton quand `uiState !== "idle"` ou utiliser un debounce.
 
 ### 1.7 Pas de garde de navigation pendant le tracking
+
 **Fichier :** `client/src/components/layout/AppShell.tsx`, `client/src/pages/TripPage.tsx`
 **Probleme :** Aucun `beforeunload` ni router guard. L'utilisateur peut quitter la page Trajet pendant un tracking actif sans avertissement.
 **Impact :** Perte du trajet en cours + fuite du wake lock (cf 1.4).
 **Fix :** Ajouter un guard React Router qui affiche "Vous avez un trajet en cours. Quitter ?" si `uiState === "tracking"`.
 
 ### 1.8 Pas de limite de duree de trajet
+
 **Fichier :** `server/src/validators/trips.ts:11`
 **Probleme :** `durationSec: z.number().int().min(1)` sans max. Un trajet de 24h+ est accepte.
 **Impact :** Si l'utilisateur oublie d'arreter, le timer tourne indefiniment. A 10K+ points GPS, la polyline Leaflet provoque du lag (cf 1.10).
 **Fix :** Ajouter `.max(86400)` (24h) ou un auto-stop apres N heures d'inactivite.
 
 ### 1.9 Pas d'indicateur de qualite GPS
+
 **Fichier :** `client/src/pages/TripPage.tsx`
 **Probleme :** L'utilisateur ne voit jamais la precision GPS. Le chip CO2 montre la distance mais pas la qualite du signal.
 **Impact :** L'utilisateur ne sait pas si ses donnees sont fiables.
 **Fix :** Ajouter un indicateur compact (icone + couleur) montrant la precision GPS (vert < 10m, jaune < 30m, rouge < 50m, gris = pas de signal).
 
 ### 1.10 Polyline non optimisee pour longs trajets
+
 **Fichier :** `client/src/pages/TripPage.tsx:146-150`
 **Probleme :** Tous les points GPS sont passes a `<Polyline positions={positions}>` sans simplification. A 5000+ points, Leaflet genere un SVG path complexe → frame drops.
 **Impact :** Lag visible sur mobile apres ~30 min de tracking continu.
 **Fix :** Implementer Douglas-Peucker ou simplement limiter l'affichage aux N derniers points + un polyline simplifie pour l'historique.
 
 ### 1.11 Consommation batterie
+
 **Probleme :** `enableHighAccuracy: true` + wake lock screen + interval 1s = 250-400 mA/hr.
 **Impact :** ~50% de batterie en 4-6 heures de tracking.
 **Fix :** Pas de fix technique simple. Documenter l'impact batterie pour l'utilisateur. Optionnellement proposer un mode "eco" avec `enableHighAccuracy: false` et interval plus long.
@@ -78,42 +89,49 @@
 ## 2. Securite
 
 ### 2.1 GPS points array sans limite de taille
+
 **Fichier :** `server/src/validators/trips.ts:14`
 **Probleme :** `z.array(gpsPointSchema).nullable().optional()` sans `.max()`. Un attaquant peut envoyer 1M de points GPS → memoire serveur saturee.
 **Impact :** Vecteur de DoS. Un seul POST peut consommer des centaines de MB.
 **Fix :** Ajouter `.max(10000)` a la validation du tableau gpsPoints.
 
 ### 2.2 Rate limiting contournable par IP spoofing
+
 **Fichier :** `server/src/lib/rate-limit.ts:27-34`
 **Probleme :** Le rate limiter extrait l'IP depuis `x-forwarded-for` sans valider la chaine de proxies. Un attaquant peut envoyer un header `x-forwarded-for: 1.2.3.4` pour contourner le rate limit.
 **Impact :** Le rate limiting (100 req/min, 10/min trips) devient inefficace.
 **Fix :** Utiliser le header Cloudflare `CF-Connecting-IP` (fiable car set par le reverse proxy) au lieu de `x-forwarded-for`. Ou whitelist les IPs de proxies connus.
 
 ### 2.3 Headers HTTP de securite manquants
+
 **Fichier :** `server/src/index.ts`
 **Probleme :** Aucun de ces headers n'est set : `Strict-Transport-Security`, `X-Frame-Options`, `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`.
 **Impact :** Vulnerable au clickjacking, MIME sniffing. Pas de HSTS.
 **Fix :** Ajouter un middleware Hono qui set ces headers sur toutes les reponses. Ou configurer dans Cloudflare.
 
 ### 2.4 sameSite cookie = "lax" au lieu de "strict"
+
 **Fichier :** `server/src/auth.ts:33`
 **Probleme :** `sameSite: "lax"` permet certaines attaques CSRF via navigation cross-site.
 **Impact :** Risque moyen — les mutations POST sont partiellement exposees.
 **Fix :** Passer a `sameSite: "strict"` en production.
 
 ### 2.5 Pas de politique de mot de passe
+
 **Fichier :** `server/src/auth.ts:15`
 **Probleme :** Better Auth `emailAndPassword` n'impose aucune complexite de mot de passe. Un mot de passe d'un caractere est accepte.
 **Impact :** Comptes facilement compromis par brute force (mitige par le rate limiting, lui-meme bypassable).
 **Fix :** Configurer `minPasswordLength: 8` dans Better Auth, ou ajouter une validation Zod sur le signup.
 
 ### 2.6 Pas de validation que la fuel price API retourne > 0
+
 **Fichier :** `server/src/lib/fuel-price.ts:76-87`
 **Probleme :** Si l'API retourne `prix_valeur: 0` ou negatif, la valeur est stockee telle quelle. `moneySavedEur` sera 0 ou negatif.
 **Impact :** Faible — le fallback couvre la plupart des cas, mais un 0 de l'API passerait.
 **Fix :** Ajouter `if (!record.prix_valeur || record.prix_valeur <= 0) throw new Error(...)` pour forcer le fallback.
 
 ### 2.7 Account linking via OAuth
+
 **Fichier :** `server/src/auth.ts:18-20`
 **Probleme :** `accountLinking: { enabled: true, trustedProviders: ["google"] }` — un compte Google avec le meme email peut etre lie a un compte email/password existant.
 **Impact :** Faible si l'email est verifie, mais a surveiller.
@@ -123,75 +141,88 @@
 ## 3. UX Mobile
 
 ### 3.1 Touch targets sous le minimum (44x44px)
+
 **Fichiers :** `client/src/components/layout/BottomNav.tsx:20-37`, `client/src/pages/StatsPage.tsx:244-256`, `client/src/pages/ProfilePage.tsx:425-438`
 **Probleme :**
+
 - Bottom nav : icones 22px + texte 10px, hauteur totale ~30px (minimum 44px)
 - Metric switcher (Stats) : `px-3 py-1.5` → ~24x28px
 - Toggle notifications (Profil) : `h-7 w-12` → 28x48px
 - Boutons X de fermeture : `p-1` → ~20px
-**Impact :** Difficile a tapper sur mobile, surtout pour les gros doigts.
-**Fix :** Augmenter le padding/taille minimum de tous les elements interactifs a 44x44px.
+  **Impact :** Difficile a tapper sur mobile, surtout pour les gros doigts.
+  **Fix :** Augmenter le padding/taille minimum de tous les elements interactifs a 44x44px.
 
 ### 3.2 Texte trop petit (10px)
+
 **Fichiers :** Tous les pages — `text-[10px]` utilise pour labels bottom nav, badges, stats, formulaires.
 **Probleme :** 10px est sous le minimum WCAG AA (12px pour le texte secondaire). Illisible sur petits ecrans.
 **Impact :** Accessibilite degradee, effort de lecture.
 **Fix :** Remplacer `text-[10px]` par `text-xs` (12px) minimum partout.
 
 ### 3.3 Contraste insuffisant pour text-dim
+
 **Fichier :** `client/src/app.css:23`
 **Probleme :** `--color-text-dim: #566a78` sur fond charcoal `#1e272e` → ratio ~2.8:1. WCAG AA exige 4.5:1.
 **Impact :** Texte dim illisible dans certaines conditions (soleil, ecran bas de gamme).
 **Fix :** Eclaircir `text-dim` a au moins `#7a8e9e` pour atteindre 4.5:1.
 
 ### 3.4 Status bar verte sur fond charcoal
+
 **Fichier :** `client/index.html:6`, `client/vite.config.ts:34`
 **Probleme :** `theme-color: "#2ecc71"` → status bar Android vert vif. Le reste de l'app est charcoal fonce. Contraste visuel choquant.
 **Impact :** L'app parait moins polie, impression de deux apps differentes.
 **Fix :** Changer `theme-color` a `#1e272e` (charcoal) pour une status bar sombre coherente.
 
 ### 3.5 Safe area (notch) non appliquee sur BottomNav
+
 **Fichier :** `client/src/components/layout/BottomNav.tsx:20`
 **Probleme :** `pb-8` (32px fixe) au lieu de `pb-safe` ou `pb-[calc(2rem+env(safe-area-inset-bottom))]`. Sur les telephones avec barre de gestes/notch, le contenu peut etre cache derriere le home indicator.
 **Impact :** Boutons de navigation inaccessibles sur certains appareils.
 **Fix :** Utiliser `env(safe-area-inset-bottom)` dans le padding.
 
 ### 3.6 Scroll position perdu entre onglets
+
 **Fichier :** `client/src/components/layout/AppShell.tsx`, `client/src/components/ui/PullToRefresh.tsx`
 **Probleme :** Changer d'onglet (Stats → Profil → Stats) remonte le scroll en haut. React Router remonte le composant, PullToRefresh ne preserve pas la position.
 **Impact :** Frustrant si l'utilisateur scrollait dans une longue liste de trajets.
 **Fix :** Stocker le scrollTop par route dans sessionStorage, le restaurer au montage.
 
 ### 3.7 Bouton retour Android non gere
+
 **Fichier :** Aucun handler explicite.
 **Probleme :** Comportement du bouton retour Android imprevisible en PWA standalone. Peut fermer l'app au lieu de naviguer en arriere. Le bottom sheet ne se ferme pas avec le bouton retour.
 **Impact :** UX confuse sur Android.
 **Fix :** Intercepter `popstate` pour fermer les modals/bottom sheets avant de naviguer. Ajouter un `history.pushState` a l'ouverture du bottom sheet.
 
 ### 3.8 Bottom sheet coupe sur petits ecrans
+
 **Fichier :** `client/src/pages/StatsPage.tsx:391-392`
 **Probleme :** Le bottom sheet (detail trajet + carte + stats + bouton supprimer) n'a pas de scroll interne. Sur iPhone SE (667px hauteur), le contenu depasse le viewport.
 **Impact :** Le bouton "Supprimer" peut etre invisible.
 **Fix :** Ajouter `overflow-y-auto max-h-[80vh]` sur le contenu du sheet.
 
 ### 3.9 Formulaire saisie manuelle pas dans un <form>
+
 **Fichier :** `client/src/pages/TripPage.tsx:260-310`
 **Probleme :** Les inputs de saisie manuelle ne sont pas dans un `<form>`. La touche Return/Enter du clavier ne soumet pas le formulaire.
 **Impact :** L'utilisateur doit tapper le bouton manuellement.
 **Fix :** Wrapper les inputs dans `<form onSubmit={...}>`.
 
 ### 3.10 Pull-to-refresh peut conflicter avec la carte Leaflet
+
 **Fichier :** `client/src/components/ui/PullToRefresh.tsx`, `client/src/pages/TripPage.tsx`
 **Probleme :** Le pull-to-refresh utilise les events touch. Sur la page Trajet, la carte Leaflet capture aussi les touch events. Le pull-to-refresh peut ne pas fonctionner sur cette page.
 **Impact :** Pas de refresh possible sur la page la plus importante.
 **Fix :** Tester sur appareil reel. Si conflit, desactiver le pull-to-refresh sur TripPage.
 
 ### 3.11 Pas de haptic feedback
+
 **Probleme :** Aucun `navigator.vibrate()` dans l'app. Les boutons ont un feedback visuel (`active:scale-95`) mais pas tactile.
 **Impact :** L'app se sent moins "native" sur Android.
 **Fix :** Ajouter `navigator.vibrate(10)` sur les actions principales (demarrer trajet, sauvegarder, supprimer).
 
 ### 3.12 Pas de prefers-reduced-motion
+
 **Fichier :** `client/src/app.css`
 **Probleme :** Les animations (slideUp bottom sheet, active:scale, pull-to-refresh) ne respectent pas `@media (prefers-reduced-motion: reduce)`.
 **Impact :** Accessibilite — certains utilisateurs avec des troubles vestibulaires peuvent etre genes.
@@ -202,60 +233,70 @@
 ## 4. Performance
 
 ### 4.1 Fuel price API bloque la creation de trajet
+
 **Fichier :** `server/src/lib/fuel-price.ts:62`, `server/src/routes/trips.routes.ts:44`
 **Probleme :** `getFuelPrice()` a un timeout de 5s et est appele de facon synchrone dans le handler de creation de trajet. Si l'API est lente, l'utilisateur attend 5s.
 **Impact :** UX degradee. Si l'API est down, le fallback est utilise mais apres 5s d'attente.
 **Fix :** Utiliser le dernier prix en cache immediatement, rafraichir en arriere-plan. Ou deplacer le fetch fuel price dans un job asynchrone.
 
 ### 4.2 Map re-center sans debounce
+
 **Fichier :** `client/src/pages/TripPage.tsx:15-20`
 **Probleme :** `RecenterMap` appelle `map.setView(position, zoom, { animate: true })` a chaque update GPS. Certains appareils envoient des positions toutes les 100ms.
 **Impact :** Frame drops sur mobile. Animations Leaflet concurrentes.
 **Fix :** Debouncer `setView` a 500ms minimum. Ou `{ animate: false }` pour les updates frequentes.
 
 ### 4.3 StatsPage weeklyData recalcule a chaque render
+
 **Fichier :** `client/src/pages/StatsPage.tsx:109-117`
 **Probleme :** La construction du tableau `weeklyData` (boucle sur chartTrips, accumulation par jour) est faite a chaque render sans `useMemo`. Changer le period ou le metric trigger un recalcul inutile.
 **Impact :** Frame drops possibles si beaucoup de trajets.
 **Fix :** `const weeklyData = useMemo(() => { ... }, [chartTrips])`.
 
 ### 4.4 Splash screen 656 KB
+
 **Fichier :** `client/public/splash-screen.png`
 **Probleme :** 656 KB pour une image 768x1376. Pas de version WebP/AVIF.
 **Impact :** Chargement initial lent sur connexion mobile.
 **Fix :** Compresser (pngquant/oxipng), ou convertir en WebP (~50 KB), ou generer un splash screen CSS.
 
 ### 4.5 Pas de WebP pour les icones PWA
+
 **Fichier :** `client/public/pwa-*.png`
 **Probleme :** pwa-512x512.png = 117 KB, pwa-192x192.png = 20 KB. Pas d'alternative WebP.
 **Impact :** Mineur — ces images sont chargees une seule fois.
 **Fix :** Generer des versions WebP et mettre a jour le manifest.
 
 ### 4.6 React Query staleTime uniforme
+
 **Fichier :** `client/src/main.tsx:42`
 **Probleme :** `staleTime: 60_000` (1 min) pour toutes les queries. Le fuel price a un override a 1h, mais stats, profile, leaderboard utilisent le defaut de 1 min.
 **Impact :** Requetes API inutiles a chaque changement d'onglet (apres 1 min).
 **Fix :** Configurer par query : stats = 5 min, profil = 10 min, leaderboard = 30s, fuel price = 1h.
 
 ### 4.7 Leaflet CSS importe globalement
+
 **Fichier :** `client/src/app.css:1`
 **Probleme :** `@import "leaflet/dist/leaflet.css"` charge tout le CSS Leaflet meme sur les pages sans carte.
 **Impact :** ~30 KB CSS supplementaire dans le bundle critique.
 **Fix :** Deplacer l'import dans TripPage et StatsPage (les seules pages avec carte). Ou accepter le cout (faible).
 
 ### 4.8 Query invalidation cascade
+
 **Fichier :** `client/src/hooks/queries.ts:143-146`
 **Probleme :** Apres creation d'un trajet, 4 queries sont invalidees simultanement (trips, stats, achievements, profile) → 4 appels API.
 **Impact :** Burst de requetes apres chaque action.
 **Fix :** Combiner en un seul endpoint de refresh, ou utiliser `setQueryData` pour update optimiste.
 
 ### 4.9 Dockerfile copie tous les node_modules
+
 **Fichier :** `Dockerfile:36`
 **Probleme :** `COPY --from=build /app/node_modules node_modules/` copie les devDependencies (typescript, vitest, etc.) dans l'image runtime.
 **Impact :** Image Docker plus lourde (~200 MB de deps inutiles).
 **Fix :** Installer les deps de production separement : `bun install --production` dans le stage runtime.
 
 ### 4.10 Pas de cache headers sur index.html
+
 **Fichier :** `server/src/index.ts:96-99`
 **Probleme :** Le SPA fallback sert `index.html` sans header `Cache-Control`. Si Cloudflare cache index.html, les clients ne recevront pas les nouvelles versions.
 **Impact :** Mise a jour bloquee pour certains utilisateurs.
@@ -266,42 +307,49 @@
 ## 5. Data Integrity
 
 ### 5.1 Trips chevauchants acceptes
+
 **Fichier :** `server/src/validators/trips.ts`
 **Probleme :** Aucune verification que le nouveau trajet ne chevauche pas un trajet existant du meme utilisateur. Deux trajets 10:00-11:00 et 10:30-11:30 sont acceptes.
 **Impact :** Inflation artificielle des stats. Possible exploitation pour les badges.
 **Fix :** Ajouter une verification SQL : `SELECT EXISTS(SELECT 1 FROM trips WHERE userId = $1 AND startedAt < $3 AND endedAt > $2)` avant insert.
 
 ### 5.2 Offline queue sans idempotence
+
 **Fichier :** `client/src/lib/offline-queue.ts`, `client/src/hooks/useOfflineSync.ts`
 **Probleme :** Pas d'identifiant unique par trajet dans la queue. Si la sync echoue partiellement (requete envoyee mais reponse perdue), le trajet peut etre resoumis.
 **Impact :** Trajets en double dans la base.
 **Fix :** Generer un UUID cote client pour chaque trajet. Ajouter un champ `idempotencyKey` dans la table trips avec contrainte unique. Le serveur ignore les doublons.
 
 ### 5.3 Leaderboard sans tie-breaking
+
 **Fichier :** `server/src/routes/leaderboard.routes.ts:65-69`
 **Probleme :** Deux utilisateurs avec le meme CO2 recoivent des rangs consecutifs (5 et 6 au lieu de 5 et 5). L'ordre depend de la base de donnees (non deterministe).
 **Impact :** Perception d'injustice dans le classement.
 **Fix :** Ajouter un tri secondaire : `.orderBy(desc(co2), asc(user.name))` et utiliser `DENSE_RANK()` pour les egalites.
 
 ### 5.4 Float precision pour les calculs financiers
+
 **Fichier :** `server/src/db/schema/trips.ts:11-14`
 **Probleme :** `co2SavedKg`, `moneySavedEur`, `fuelSavedL` utilisent `real` (float 32-bit PostgreSQL). Les operations d'agregation (SUM) sur des floats accumulent les erreurs d'arrondi.
 **Impact :** Apres des centaines de trajets, les totaux peuvent diverger de quelques centimes.
 **Fix :** Migrer vers `numeric(10, 3)` pour CO2 et fuel, `numeric(10, 2)` pour money. Ou accepter la precision actuelle (suffisante pour un tracker velo).
 
 ### 5.5 Timezone utilisateur non persistee
+
 **Fichier :** `server/src/db/schema/auth.ts`
 **Probleme :** Le timezone est envoye a chaque requete depuis le navigateur (`Intl.DateTimeFormat().resolvedOptions().timeZone`) mais n'est pas stocke dans le profil utilisateur. Si l'utilisateur voyage, le timezone change.
 **Impact :** Les streaks peuvent etre incorrectes si l'utilisateur change de fuseau horaire.
 **Fix :** Ajouter un champ `timezone` dans la table user, le mettre a jour a chaque requete, l'utiliser pour les calculs de streaks cote serveur.
 
 ### 5.6 Export de donnees incomplet
+
 **Fichier :** `server/src/routes/users.routes.ts:70-93`
 **Probleme :** L'export contient le profil, les trajets et les achievements, mais pas les push subscriptions ni les preferences de rappels detaillees.
 **Impact :** RGPD strict exige l'export de TOUTES les donnees personnelles.
 **Fix :** Inclure `pushSubscriptions` et `reminderDays`/`reminderTime` dans l'export.
 
 ### 5.7 Horodatage dependant de l'horloge du telephone
+
 **Fichier :** `client/src/hooks/useGpsTracking.ts:88,123`
 **Probleme :** `startedAt` et `endedAt` utilisent `new Date().toISOString()` qui depend de l'horloge du telephone. Si l'horloge est decalee, les timestamps sont faux. Si l'horloge saute en arriere pendant un trajet, `startedAt > endedAt` → le serveur rejette le trajet.
 **Impact :** Perte silencieuse de trajet si l'horloge du telephone est instable.
@@ -312,27 +360,32 @@
 ## 6. PWA & Android
 
 ### 6.1 Icone maskable absente du manifest built
+
 **Fichier :** `client/dist/manifest.webmanifest`
 **Probleme :** Le manifest source (vite.config.ts) declare 3 icones dont une maskable, mais le manifest built n'en contient que 2. `vite-plugin-pwa` n'inclut pas l'icone maskable.
 **Impact :** Sur Android 8+, l'icone de l'app sur l'ecran d'accueil n'utilise pas la version optimisee.
 **Fix :** Verifier la version de vite-plugin-pwa. Ajouter manuellement l'icone maskable au manifest si le plugin la supprime. Ou copier le manifest manuellement dans public/.
 
 ### 6.2 BottomNav safe area
+
 **Cf 3.5** — Le padding fixe `pb-8` ne s'adapte pas aux telephones avec notch/home indicator.
 
 ### 6.3 Pas de shortcuts dans le manifest
+
 **Fichier :** `client/vite.config.ts` (manifest section)
 **Probleme :** Pas de `shortcuts` dans le manifest. Les raccourcis Android (long-press sur l'icone) ne sont pas disponibles.
 **Impact :** Mineur — feature bonus, pas critique.
 **Fix :** Ajouter des shortcuts : "Demarrer un trajet" → /trip, "Voir les stats" → /stats.
 
 ### 6.4 Langue du manifest = "en"
+
 **Fichier :** `client/dist/manifest.webmanifest`
 **Probleme :** Le champ `lang` genere automatiquement est "en" au lieu de "fr".
 **Impact :** Mineur — les navigateurs utilisent ce champ pour la localisation.
 **Fix :** Ajouter `lang: "fr"` dans la config manifest de vite.config.ts.
 
 ### 6.5 Score Lighthouse PWA estime : 75-85/100
+
 **Problemes principaux :** Icone maskable manquante (-10), screenshots manquantes (-5), splash screens non configures (-5).
 **Fix :** Corriger les icones et ajouter des screenshots au manifest pour atteindre 95+.
 
@@ -341,23 +394,27 @@
 ## 7. Code Quality
 
 ### 7.1 Repertoire /frontend/ legacy
+
 **Fichier :** `/frontend/` (racine du projet)
 **Probleme :** Contient des doublons des fichiers de `/client/src/lib/` (memes fonctions, formatage different). Les tests vitest tournent depuis `/frontend/` mais testent du code qui vit maintenant dans `/client/`.
 **Impact :** Confusion, risque de desynchronisation entre code teste et code deploye.
 **Fix :** Migrer les tests vers `client/` et supprimer `/frontend/`. Ou si les tests referencent du code partage, reorganiser en consequence.
 
 ### 7.2 Pas de linter ESLint/Prettier
+
 **Probleme :** Aucune config ESLint, Prettier ou EditorConfig dans le repo.
 **Impact :** Style de code inconsistant entre contributeurs. Pas de pre-commit hook.
 **Fix :** Ajouter ESLint + Prettier + husky pre-commit.
 
 ### 7.3 Zero tests serveur
+
 **Fichier :** `server/src/` — aucun fichier de test.
 **Probleme :** 379 tests client (dans /frontend/), 0 tests serveur. La logique metier critique (badges, streaks, leaderboard, calculs) n'est testee que via les utilitaires client.
 **Impact :** Regressions non detectees sur les routes API, les calculs serveur, les edge cases de la base de donnees.
 **Fix :** Ajouter des tests vitest pour les routes critiques (trips CRUD, badge unlock/revoke, leaderboard, stats aggregation).
 
 ### 7.4 Version poll interval jamais nettoye
+
 **Fichier :** `client/src/main.tsx:28-37`
 **Probleme :** Le `setInterval` pour le version poll (toutes les 5 min) n'est jamais clear. Techniquement un memory leak, bien que mineur.
 **Impact :** Negligeable — l'interval est leger et tourne pour la duree de vie de l'app.
@@ -368,6 +425,7 @@
 ## Resume par priorite
 
 ### P0 — Critiques (securite + perte de donnees)
+
 1. ~~GPS points sans limite de taille (2.1)~~ — **CORRIGE** PR #35 (.max(10000))
 2. ~~Backup GPS en cours de trajet (1.3)~~ — **CORRIGE** PR #39 (localStorage toutes les 30s + recovery)
 3. ~~Wake lock non relache (1.4, 1.5)~~ — **CORRIGE** PR #39 (release sur unmount + erreur fatale)
@@ -376,6 +434,7 @@
 6. ~~Headers HTTP securite (2.3)~~ — **CORRIGE** PR #35 (HSTS, X-Frame, nosniff, Referrer)
 
 ### P1 — Importants (UX + fiabilite)
+
 7. ~~Recovery GPS apres tunnel (1.2)~~ — **CORRIGE** PR #39 (auto-retry 3x apres timeout)
 8. ~~Touch targets < 44px (3.1)~~ — **CORRIGE** PR #38 (min-h-[44px], padding augmente)
 9. ~~Texte 10px (3.2)~~ — **CORRIGE** PR #38 (text-[10px] → text-xs partout)
@@ -387,6 +446,7 @@
 15. Icone maskable manifest (6.1) — **NON CORRIGE** (necessite investigation vite-plugin-pwa)
 
 ### P2 — Ameliorations (polish + perf)
+
 16. ~~Indicateur qualite GPS (1.9)~~ — **CORRIGE** PR #43 (chip couleur avec precision en metres)
 17. ~~Debounce map (4.2)~~ — **CORRIGE** PR #36 (500ms minimum entre setView)
 18. ~~useMemo weeklyData (4.3)~~ — **CORRIGE** PR #36 (useMemo sur chartTrips)
@@ -399,6 +459,7 @@
 25. ~~Dockerfile node_modules (4.9)~~ — **CORRIGE** PR #44 (bun install --production)
 
 ### P3 — Nice to have
+
 26. Haptic feedback (3.11) — non corrige
 27. prefers-reduced-motion (3.12) — non corrige
 28. ~~Leaderboard tie-breaking (5.3)~~ — **CORRIGE** PR #42 (dense ranking + tri alphabetique)
@@ -411,6 +472,7 @@
 35. ~~Lang manifest (6.4)~~ — **CORRIGE** PR #41 (lang: "fr")
 
 ### Egalement corriges (hors liste initiale)
+
 - ~~Trips chevauchants acceptes (5.1)~~ — **CORRIGE** PR #37 (overlap check avant insert)
 - ~~Double-tap Demarrer (1.6)~~ — **CORRIGE** PR #39 (disabled quand tracking)
 - ~~sameSite cookie documente (2.4)~~ — **CORRIGE** PR #35 (commentaire expliquant pourquoi lax)
@@ -421,6 +483,7 @@
 ## Bilan des corrections
 
 **Corriges : 31/35** (89%)
+
 - P0 : 6/6 (100%)
 - P1 : 9/9 (100%)
 - P2 : 10/10 (100%)
@@ -428,6 +491,7 @@
 - Bonus : 5 fixes supplementaires
 
 **Restent non corriges (P3) :**
+
 - 26. Haptic feedback
 - 27. prefers-reduced-motion
 - 29. Float precision (numeric vs real)
@@ -436,6 +500,7 @@
 - 32. ESLint/Prettier
 
 **PRs de correction :**
+
 - PR #35 : Securite (GPS limit, IP fix, headers, duration max, sameSite doc)
 - PR #36 : Performance (fuel price timeout, map debounce, useMemo, cache headers)
 - PR #37 : Data integrity (overlap check, idempotency keys)

--- a/CDC.md
+++ b/CDC.md
@@ -3,7 +3,7 @@
 **Date :** 2026-03-21  
 **Statut :** Validé — prêt pour développement  
 **Dossier projet :** `~/Documents/Obsidian/Lyra/Projets/velo-tracker/`  
-**URL de production :** *(configurable via variables d'environnement)*
+**URL de production :** _(configurable via variables d'environnement)_
 
 ---
 
@@ -18,13 +18,16 @@ L'angle principal est **l'impact environnemental** (CO2 économisé), pas la per
 ## 2. Fonctionnalités v1
 
 ### 2.1 Enregistrement de trajet
+
 - Bouton "Démarrer un trajet" → active le GPS (Wake Lock API pour garder l'écran allumé)
 - Tracking GPS en temps réel → calcul de la distance à l'arrêt
 - Bouton "Terminer" → affichage du résumé immédiat
 - Possibilité de saisie manuelle de distance (si GPS non souhaité)
 
 ### 2.2 Calcul des économies (par trajet et cumulatif)
+
 À chaque trajet, calcul automatique basé sur le profil véhicule de l'utilisateur :
+
 - 🌱 **CO2 économisé** (kg) = distance × conso × 2.31 kg CO2/litre (facteur ADEME)
 - 💶 **Argent économisé** (€) = distance × conso × prix_essence_local / 100
 - 💧 **Litres économisés** (L) = distance × conso / 100
@@ -34,9 +37,11 @@ L'angle principal est **l'impact environnemental** (CO2 économisé), pas la per
 Géolocalisé (stations les plus proches). Fallback : prix moyen national.
 
 ### 2.3 Dashboard principal
+
 Écrans principaux (navigation bottom bar) :
 
 **🏠 Dashboard**
+
 - Résumé du jour / de la semaine / du mois (switcher)
 - Compteurs : km, CO2 (kg), € économisés
 - Comparatif mois N vs mois N-1
@@ -44,28 +49,34 @@ Géolocalisé (stations les plus proches). Fallback : prix moyen national.
 - Streak actuel + objectif mensuel
 
 **🚴 Trajet actif**
+
 - Carte GPS en temps réel
 - Distance + durée + économies en cours
 
 **📊 Stats**
+
 - Graphiques semaine / mois / année
 - Évolution CO2, €, km
 - Badges / achievements débloqués
 
 **🏆 Classement**
+
 - Leaderboard CO2 économisé (opt-out, actif par défaut)
 - Peut être désactivé dans les paramètres
 
 **👤 Profil / Paramètres**
+
 - Véhicule de référence (modèle, carburant, conso mixte, kilométrage)
 - Rappels push (heure + jours de semaine)
 - Préférences classement (opt-out)
 - Compte Google (déconnexion)
 
 ### 2.4 Impact Meter (composant visuel clé)
+
 Pièce maîtresse du dashboard — **distinct du système de gamification**.
 
 Jauge/cercle dynamique qui compare le CO2 économisé cumulatif à des références parlantes :
+
 - 🌳 X arbres plantés (~21 kg CO2/arbre/an)
 - 🚗 Trajet Paris–Lyon en voiture (~45 kg CO2)
 - ✈️ Vol Paris–New York (aller, ~400 kg CO2/passager)
@@ -74,6 +85,7 @@ Jauge/cercle dynamique qui compare le CO2 économisé cumulatif à des référen
 Le visuel se remplit progressivement vers la prochaine référence. Une fois atteint, il se vide et passe à l'étape suivante (progression continue).
 
 ### 2.5 Gamification
+
 - **Streaks** : jours consécutifs avec un trajet (reset si jour manqué)
 - **Badges paliers** (débloqués une seule fois) :
   - Premier trajet, 10 trajets, 50 trajets, 100 trajets
@@ -83,11 +95,13 @@ Le visuel se remplit progressivement vers la prochaine référence. Une fois att
 - **Objectif mensuel** : km ou CO2, configurable, barre de progression sur le dashboard
 
 ### 2.6 Multi-utilisateurs
+
 - Authentification via **Google OAuth** (Better Auth)
 - Chaque utilisateur a son propre profil véhicule et ses propres stats
 - Classement partagé entre tous les utilisateurs (opt-out)
 
 ### 2.7 Rappels
+
 - Push notifications PWA (Web Push API)
 - Configurables : heure + jours de la semaine
 - Message type : "Tu n'as pas encore enregistré de trajet aujourd'hui 🚴"
@@ -96,17 +110,18 @@ Le visuel se remplit progressivement vers la prochaine référence. Une fois att
 
 ## 3. Stack technique
 
-| Couche | Technologie |
-|--------|-------------|
-| Frontend | React + Vite + vite-plugin-pwa |
-| Styles | TailwindCSS |
-| Auth | Better Auth + Google OAuth |
-| Backend | Bun + Hono (ou Fastify) — API REST |
-| Base de données | PostgreSQL |
-| ORM | Drizzle ORM |
-| Déploiement | Docker (auto-hébergé) |
+| Couche          | Technologie                        |
+| --------------- | ---------------------------------- |
+| Frontend        | React + Vite + vite-plugin-pwa     |
+| Styles          | TailwindCSS                        |
+| Auth            | Better Auth + Google OAuth         |
+| Backend         | Bun + Hono (ou Fastify) — API REST |
+| Base de données | PostgreSQL                         |
+| ORM             | Drizzle ORM                        |
+| Déploiement     | Docker (auto-hébergé)              |
 
 ### API externes
+
 - **Prix carburants FR** : `data.economie.gouv.fr` (open data, pas de clé API)
 - **GPS** : Web Geolocation API (navigateur natif)
 - **Push** : Web Push API + VAPID keys (self-hosted)
@@ -126,6 +141,7 @@ Le visuel se remplit progressivement vers la prochaine référence. Une fois att
 - **Mobile-first** — responsive desktop secondaire
 
 ### Génération UI
+
 Utiliser **Google Stitch MCP** pour générer les maquettes de chaque écran, puis exporter HTML/CSS comme base de travail pour Claude Code.
 
 ---
@@ -213,4 +229,4 @@ Si un vrai blocage externe se présente (credentials manquants, accès impossibl
 
 ---
 
-*CDC finalisé le 2026-03-21 avec Vincent. Prêt pour lancement du dev.*
+_CDC finalisé le 2026-03-21 avec Vincent. Prêt pour lancement du dev._

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -3,31 +3,41 @@
 ## 2026-03-21 — Scaffold initial
 
 ### Monorepo Bun workspaces
+
 3 workspaces : `shared/`, `server/`, `client/`. Pas de `packages/` wrapper — chemins courts, rôle évident.
 
 ### IDs : UUID (gen_random_uuid)
+
 Anti-énumération dans les réponses API. Natif PostgreSQL 13+, pas d'extension. Exception : les tables Better Auth utilisent des IDs `text` (format nanoid imposé par la lib).
 
 ### Better Auth : table `user` étendue
+
 Better Auth impose 4 tables : `user`, `session`, `account`, `verification`. La table `user` du CDC est fusionnée avec celle de Better Auth — les champs métier (vehicle, preferences) sont des colonnes additionnelles sur la même table. Total : 7 tables Drizzle.
 
 ### Driver PostgreSQL : postgres.js
+
 `postgres` (postgres.js) plutôt que `pg`. Recommandé par Drizzle, natif Bun, zéro bindings natifs, plus performant.
 
 ### fuel_type : text (pas enum PG)
+
 Permet d'ajouter des types de carburant sans migration. Validation côté application via les types TypeScript partagés.
 
 ### reminder_days : text[] (array PG)
+
 Plus simple qu'une table de jonction. Set fixe de 7 valeurs max.
 
 ### Tailwind v4 : CSS @theme
+
 Pas de `tailwind.config.js`. Tout le theming est dans `client/src/app.css` via `@theme {}`. Plugin Vite `@tailwindcss/vite`.
 
 ### shared/ : exports .ts directs
+
 Pas de build step pour `shared/`. Bun consomme le TS nativement côté serveur, Vite le transpile côté client. Les exports pointent directement vers les `.ts`.
 
 ### Numeric fields : real (float4)
+
 Précision suffisante pour distances (km), consommations (L/100km), et montants (€). Pas besoin de `numeric`/`decimal` pour un tracker vélo.
 
 ### PWA : registerType autoUpdate
+
 Stratégie la plus simple. Le service worker se met à jour automatiquement sans prompt utilisateur.

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ client/     React PWA + Tailwind + Playwright e2e
 
 ## Scripts
 
-| Commande | Description |
-|----------|-------------|
-| `bun run dev` | Lance client + serveur en parallèle |
-| `bun run dev:client` | Client seul (Vite :5173) |
-| `bun run dev:server` | Serveur seul (Hono :3000) |
-| `bun run db:push` | Applique le schéma Drizzle sur la DB |
-| `bun run db:generate` | Génère une migration Drizzle |
-| `bun run db:studio` | Ouvre Drizzle Studio |
-| `bun run typecheck` | Vérifie les types dans tous les workspaces |
-| `cd client && bunx vitest run` | Lance les tests unitaires |
-| `cd client && npx playwright test` | Lance les smoke tests e2e |
+| Commande                           | Description                                |
+| ---------------------------------- | ------------------------------------------ |
+| `bun run dev`                      | Lance client + serveur en parallèle        |
+| `bun run dev:client`               | Client seul (Vite :5173)                   |
+| `bun run dev:server`               | Serveur seul (Hono :3000)                  |
+| `bun run db:push`                  | Applique le schéma Drizzle sur la DB       |
+| `bun run db:generate`              | Génère une migration Drizzle               |
+| `bun run db:studio`                | Ouvre Drizzle Studio                       |
+| `bun run typecheck`                | Vérifie les types dans tous les workspaces |
+| `cd client && bunx vitest run`     | Lance les tests unitaires                  |
+| `cd client && npx playwright test` | Lance les smoke tests e2e                  |
 
 ## CI / CD
 
@@ -107,14 +107,14 @@ docker compose up --build
 
 ### Variables d'environnement (production)
 
-| Variable | Description |
-|----------|-------------|
-| `DATABASE_URL` | Connexion PostgreSQL |
-| `BETTER_AUTH_SECRET` | Secret auth (`openssl rand -hex 32`) |
-| `BETTER_AUTH_URL` | URL publique de l'app (ex: `https://mon-domaine.com`) |
-| `GOOGLE_CLIENT_ID` | Client ID Google OAuth |
-| `GOOGLE_CLIENT_SECRET` | Client Secret Google OAuth |
-| `FRONTEND_URL` | URL publique de l'app (même valeur que `BETTER_AUTH_URL`) |
-| `VAPID_PUBLIC_KEY` | Clé publique push (`bunx web-push generate-vapid-keys`) |
-| `VAPID_PRIVATE_KEY` | Clé privée push |
-| `VAPID_SUBJECT` | `mailto:votre-email@exemple.com` |
+| Variable               | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `DATABASE_URL`         | Connexion PostgreSQL                                      |
+| `BETTER_AUTH_SECRET`   | Secret auth (`openssl rand -hex 32`)                      |
+| `BETTER_AUTH_URL`      | URL publique de l'app (ex: `https://mon-domaine.com`)     |
+| `GOOGLE_CLIENT_ID`     | Client ID Google OAuth                                    |
+| `GOOGLE_CLIENT_SECRET` | Client Secret Google OAuth                                |
+| `FRONTEND_URL`         | URL publique de l'app (même valeur que `BETTER_AUTH_URL`) |
+| `VAPID_PUBLIC_KEY`     | Clé publique push (`bunx web-push generate-vapid-keys`)   |
+| `VAPID_PRIVATE_KEY`    | Clé privée push                                           |
+| `VAPID_SUBJECT`        | `mailto:votre-email@exemple.com`                          |

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,22 @@
     "": {
       "name": "ecoride",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.58.2",
         "@testing-library/react": "^16.3.2",
         "@types/bun": "^1.2.0",
         "client": "workspace:*",
         "drizzle-kit": "^0.30.0",
+        "eslint": "^10.1.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
+        "husky": "^9.1.7",
         "jsdom": "^29.0.1",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.1",
         "typescript": "^5.8.0",
+        "typescript-eslint": "^8.57.1",
         "vitest": "^4.1.0",
       },
     },
@@ -352,9 +361,33 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.3", "", { "dependencies": { "@eslint/object-schema": "^3.0.3", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.3", "", { "dependencies": { "@eslint/core": "^1.1.1" } }, "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw=="],
+
+    "@eslint/core": ["@eslint/core@1.1.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
+
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
@@ -526,9 +559,13 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/leaflet": ["@types/leaflet@1.9.21", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w=="],
 
@@ -545,6 +582,26 @@
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/type-utils": "8.57.1", "@typescript-eslint/utils": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/types": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.1", "@typescript-eslint/types": "^8.57.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1" } }, "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/utils": "8.57.1", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.57.1", "", {}, "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.1", "@typescript-eslint/tsconfig-utils": "8.57.1", "@typescript-eslint/types": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/types": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -564,9 +621,13 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -628,11 +689,17 @@
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+
     "client": ["client@workspace:client"],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
@@ -688,6 +755,8 @@
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -714,11 +783,15 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.321", "", {}, "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ=="],
 
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
 
@@ -742,6 +815,28 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.1.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.3", "@eslint/config-helpers": "^0.5.3", "@eslint/core": "^1.1.1", "@eslint/plugin-kit": "^0.6.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.0.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA=="],
+
+    "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.2", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
@@ -754,11 +849,21 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
     "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -780,6 +885,8 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-own-enumerable-property-symbols": ["get-own-enumerable-property-symbols@3.0.2", "", {}, "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="],
@@ -791,6 +898,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -810,6 +919,10 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
@@ -818,9 +931,15 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -844,9 +963,15 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
@@ -900,9 +1025,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -914,11 +1043,15 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
     "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
 
     "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -944,11 +1077,19 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lint-staged": ["lint-staged@16.4.0", "", { "dependencies": { "commander": "^14.0.3", "listr2": "^9.0.5", "picomatch": "^4.0.3", "string-argv": "^0.3.2", "tinyexec": "^1.0.4", "yaml": "^2.8.2" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw=="],
+
+    "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
@@ -961,6 +1102,8 @@
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
@@ -976,6 +1119,8 @@
 
     "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -986,11 +1131,21 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1013,6 +1168,10 @@
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
@@ -1064,6 +1223,10 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
@@ -1114,6 +1277,8 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
     "smob": ["smob@1.6.1", "", {}, "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g=="],
 
     "source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
@@ -1130,6 +1295,10 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
 
     "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
@@ -1139,6 +1308,8 @@
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
     "stringify-object": ["stringify-object@3.3.0", "", { "dependencies": { "get-own-enumerable-property-symbols": "^3.0.0", "is-obj": "^1.0.1", "is-regexp": "^1.0.0" } }, "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-comments": ["strip-comments@2.0.1", "", {}, "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="],
 
@@ -1174,6 +1345,10 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
     "type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
@@ -1185,6 +1360,8 @@
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.57.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.1", "@typescript-eslint/parser": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/utils": "8.57.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
@@ -1207,6 +1384,8 @@
     "upath": ["upath@1.2.0", "", {}, "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
@@ -1240,6 +1419,8 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
     "workbox-background-sync": ["workbox-background-sync@7.4.0", "", { "dependencies": { "idb": "^7.0.1", "workbox-core": "7.4.0" } }, "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w=="],
 
     "workbox-broadcast-update": ["workbox-broadcast-update@7.4.0", "", { "dependencies": { "workbox-core": "7.4.0" } }, "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA=="],
@@ -1272,13 +1453,23 @@
 
     "workbox-window": ["workbox-window@7.4.0", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.0" } }, "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw=="],
 
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@apideck/better-ajv-errors/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1295,6 +1486,8 @@
     "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
@@ -1328,6 +1521,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -1336,21 +1531,39 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "workbox-build/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "workbox-build/rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1402,6 +1615,8 @@
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "source-map/whatwg-url/tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
     "source-map/whatwg-url/webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
@@ -1451,6 +1666,8 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/client/e2e/tracking.spec.ts
+++ b/client/e2e/tracking.spec.ts
@@ -39,5 +39,5 @@ test("clicking Démarrer starts tracking with counters", async ({ page, context 
   // Timer should have ticked (not 00:00)
   const timeValues = await page.locator("text=/\\d{2}:\\d{2}/").allTextContents();
   console.log("Time values found:", timeValues);
-  expect(timeValues.some(t => t !== "00:00")).toBeTruthy();
+  expect(timeValues.some((t) => t !== "00:00")).toBeTruthy();
 });

--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />

--- a/client/public/sw-api-guard.js
+++ b/client/public/sw-api-guard.js
@@ -2,9 +2,9 @@
 // Loaded via importScripts in the generated sw.js (see vite.config.ts).
 // If the workbox NavigationRoute denylist is correctly configured, this is redundant.
 // If the denylist is missing (e.g., stale Docker cache), this catches the case.
-self.addEventListener('fetch', function(event) {
+self.addEventListener("fetch", function (event) {
   var url = new URL(event.request.url);
-  if (url.pathname.startsWith('/api/')) {
+  if (url.pathname.startsWith("/api/")) {
     event.respondWith(fetch(event.request));
     event.stopImmediatePropagation();
   }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,12 +5,8 @@ import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { LoginPage } from "@/pages/LoginPage";
 import { DashboardPage } from "@/pages/DashboardPage";
 
-const TripPage = lazy(() =>
-  import("@/pages/TripPage").then((m) => ({ default: m.TripPage })),
-);
-const StatsPage = lazy(() =>
-  import("@/pages/StatsPage").then((m) => ({ default: m.StatsPage })),
-);
+const TripPage = lazy(() => import("@/pages/TripPage").then((m) => ({ default: m.TripPage })));
+const StatsPage = lazy(() => import("@/pages/StatsPage").then((m) => ({ default: m.StatsPage })));
 const LeaderboardPage = lazy(() =>
   import("@/pages/LeaderboardPage").then((m) => ({
     default: m.LeaderboardPage,

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -18,7 +18,7 @@
   --color-surface-highest: #3e4851;
 
   /* Text */
-  --color-text: #FFFFFF;
+  --color-text: #ffffff;
   --color-text-muted: #8a9ba8;
   --color-text-dim: #7a8e9e;
   --color-on-surface-variant: #a3b1ba;
@@ -28,15 +28,17 @@
   --color-outline-variant: #3d4a3e;
 
   /* Semantic */
-  --color-danger: #FF4D4D;
-  --color-warning: #FFB800;
+  --color-danger: #ff4d4d;
+  --color-warning: #ffb800;
   --color-error: #ff716c;
 
   /* Font */
   --font-sans: "Inter", system-ui, -apple-system, sans-serif;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   margin: 0;
 }
@@ -59,6 +61,10 @@ body {
 
 /* Bottom sheet slide up */
 @keyframes slideUp {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -32,9 +32,7 @@ export class ErrorBoundary extends Component<Props, State> {
             <Bike size={40} className="text-primary-light" />
           </div>
 
-          <h1 className="mt-8 text-2xl font-bold text-text">
-            Une erreur est survenue
-          </h1>
+          <h1 className="mt-8 text-2xl font-bold text-text">Une erreur est survenue</h1>
 
           <p className="mt-2 text-sm text-text-muted">
             Quelque chose s'est mal passé. Essayez de recharger la page.

--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -1,11 +1,5 @@
 import { NavLink } from "react-router";
-import {
-  LayoutDashboard,
-  Bike,
-  BarChart3,
-  Trophy,
-  User,
-} from "lucide-react";
+import { LayoutDashboard, Bike, BarChart3, Trophy, User } from "lucide-react";
 
 const tabs = [
   { to: "/", icon: LayoutDashboard, label: "Accueil" },
@@ -17,7 +11,10 @@ const tabs = [
 
 export function BottomNav() {
   return (
-    <nav aria-label="Navigation principale" className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-2 sm:px-4 pb-[calc(0.5rem+env(safe-area-inset-bottom,0.5rem))] pt-2 backdrop-blur-2xl border-t border-outline-variant/10">
+    <nav
+      aria-label="Navigation principale"
+      className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around bg-surface/90 px-2 sm:px-4 pb-[calc(0.5rem+env(safe-area-inset-bottom,0.5rem))] pt-2 backdrop-blur-2xl border-t border-outline-variant/10"
+    >
       {tabs.map(({ to, icon: Icon, label }) => (
         <NavLink
           key={to}
@@ -33,7 +30,12 @@ export function BottomNav() {
         >
           {({ isActive }) => (
             <>
-              <Icon size={20} className="sm:w-6 sm:h-6" strokeWidth={isActive ? 2.2 : 1.8} aria-hidden="true" />
+              <Icon
+                size={20}
+                className="sm:w-6 sm:h-6"
+                strokeWidth={isActive ? 2.2 : 1.8}
+                aria-hidden="true"
+              />
               <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider sm:tracking-widest truncate max-w-[56px] sm:max-w-none text-center">
                 {label}
               </span>

--- a/client/src/components/ui/ImpactMeter.tsx
+++ b/client/src/components/ui/ImpactMeter.tsx
@@ -10,23 +10,14 @@ export function ImpactMeter({ co2TotalKg }: ImpactMeterProps) {
   const target = current ?? IMPACT_REFERENCES[IMPACT_REFERENCES.length - 1]!;
   const prevIdx = IMPACT_REFERENCES.indexOf(target) - 1;
   const prevCo2 = prevIdx >= 0 ? IMPACT_REFERENCES[prevIdx]!.co2Kg : 0;
-  const progress = Math.min(
-    ((co2TotalKg - prevCo2) / (target.co2Kg - prevCo2)) * 100,
-    100,
-  );
+  const progress = Math.min(((co2TotalKg - prevCo2) / (target.co2Kg - prevCo2)) * 100, 100);
 
   const radius = 42;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (progress / 100) * circumference;
 
   const emoji =
-    target.co2Kg <= 21
-      ? "🌳"
-      : target.co2Kg <= 45
-        ? "🚗"
-        : target.co2Kg <= 115
-          ? "⛽"
-          : "✈️";
+    target.co2Kg <= 21 ? "🌳" : target.co2Kg <= 45 ? "🚗" : target.co2Kg <= 115 ? "⛽" : "✈️";
 
   return (
     <div className="flex flex-col items-center gap-6 rounded-xl bg-surface-container p-8">

--- a/client/src/components/ui/StatCard.tsx
+++ b/client/src/components/ui/StatCard.tsx
@@ -11,9 +11,7 @@ export function StatCard({ icon: Icon, value, unit }: StatCardProps) {
     <div className="flex aspect-square flex-col justify-between rounded-xl bg-surface-container p-4">
       <Icon size={20} className="text-primary-light" strokeWidth={1.8} />
       <div>
-        <div className="text-lg font-black leading-none tracking-tight">
-          {value}
-        </div>
+        <div className="text-lg font-black leading-none tracking-tight">{value}</div>
         <div className="mt-1 text-xs font-medium uppercase tracking-wider text-text-muted">
           {unit}
         </div>

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -28,9 +28,7 @@ export function useTrip(tripId: string | null) {
   return useQuery({
     queryKey: ["trip", tripId],
     queryFn: () =>
-      apiFetch<{ ok: boolean; data: { trip: Trip } }>(
-        `/trips/${tripId}`,
-      ).then((r) => r.data.trip),
+      apiFetch<{ ok: boolean; data: { trip: Trip } }>(`/trips/${tripId}`).then((r) => r.data.trip),
     enabled: !!tripId,
   });
 }
@@ -183,8 +181,7 @@ export function useUpdateProfile() {
 
 export function useDeleteAccount() {
   return useMutation({
-    mutationFn: () =>
-      apiFetch<{ ok: boolean }>("/user/profile", { method: "DELETE" }),
+    mutationFn: () => apiFetch<{ ok: boolean }>("/user/profile", { method: "DELETE" }),
   });
 }
 

--- a/client/src/hooks/useGpsTracking.ts
+++ b/client/src/hooks/useGpsTracking.ts
@@ -68,7 +68,14 @@ function reducer(state: TrackingState, action: Action): TrackingState {
         if (d >= MIN_DISTANCE_KM) added = d;
       }
       const speedKmh = action.speed != null ? action.speed * 3.6 : state.speedKmh;
-      return { ...state, gpsPoints: points, distanceKm: state.distanceKm + added, error: null, lastAccuracy: action.accuracy, speedKmh };
+      return {
+        ...state,
+        gpsPoints: points,
+        distanceKm: state.distanceKm + added,
+        error: null,
+        lastAccuracy: action.accuracy,
+        speedKmh,
+      };
     }
     case "TICK":
       return { ...state, durationSec: state.durationSec + 1 };
@@ -223,7 +230,7 @@ export function useGpsTracking() {
 
   // Start/stop GPS watch, timer, wake lock, and backup based on isTracking state.
   // Only depends on state.isTracking — other refs are stable across renders.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     if (!state.isTracking) return;
 

--- a/client/src/hooks/usePushNotifications.ts
+++ b/client/src/hooks/usePushNotifications.ts
@@ -8,10 +8,10 @@ import {
 import { useUpdateProfile } from "./queries";
 
 export type PushStatus =
-  | "loading"       // checking current state
-  | "unsupported"   // browser doesn't support push
-  | "denied"        // user denied permission
-  | "subscribed"    // active subscription
+  | "loading" // checking current state
+  | "unsupported" // browser doesn't support push
+  | "denied" // user denied permission
+  | "subscribed" // active subscription
   | "unsubscribed"; // no subscription, can enable
 
 export function usePushNotifications() {

--- a/client/src/lib/__tests__/avg-speed.test.ts
+++ b/client/src/lib/__tests__/avg-speed.test.ts
@@ -1,50 +1,50 @@
-import { describe, expect, it } from 'vitest'
-import { computeAvgSpeedKmh } from '../calculations'
+import { describe, expect, it } from "vitest";
+import { computeAvgSpeedKmh } from "../calculations";
 
-describe('computeAvgSpeedKmh', () => {
-  it('calculates speed as distance / duration in km/h', () => {
+describe("computeAvgSpeedKmh", () => {
+  it("calculates speed as distance / duration in km/h", () => {
     // 20 km in 3600 sec (1 hour) = 20 km/h
-    expect(computeAvgSpeedKmh(20, 3600)).toBe(20)
-  })
+    expect(computeAvgSpeedKmh(20, 3600)).toBe(20);
+  });
 
-  it('rounds to 1 decimal place', () => {
+  it("rounds to 1 decimal place", () => {
     // 10 km in 3600 sec = 10.0 km/h
-    expect(computeAvgSpeedKmh(10, 3600)).toBe(10)
+    expect(computeAvgSpeedKmh(10, 3600)).toBe(10);
     // 10 km in 2400 sec (40 min) = 15.0 km/h
-    expect(computeAvgSpeedKmh(10, 2400)).toBe(15)
+    expect(computeAvgSpeedKmh(10, 2400)).toBe(15);
     // 7 km in 1800 sec (30 min) = 14.0 km/h
-    expect(computeAvgSpeedKmh(7, 1800)).toBe(14)
+    expect(computeAvgSpeedKmh(7, 1800)).toBe(14);
     // 5 km in 720 sec (12 min) = 25.0 km/h
-    expect(computeAvgSpeedKmh(5, 720)).toBe(25)
+    expect(computeAvgSpeedKmh(5, 720)).toBe(25);
     // 12.5 km in 2700 sec (45 min) = 16.666... -> 16.7 km/h
-    expect(computeAvgSpeedKmh(12.5, 2700)).toBe(16.7)
-  })
+    expect(computeAvgSpeedKmh(12.5, 2700)).toBe(16.7);
+  });
 
-  it('returns 0 for 0 duration', () => {
-    expect(computeAvgSpeedKmh(10, 0)).toBe(0)
-  })
+  it("returns 0 for 0 duration", () => {
+    expect(computeAvgSpeedKmh(10, 0)).toBe(0);
+  });
 
-  it('returns 0 for negative duration', () => {
-    expect(computeAvgSpeedKmh(10, -100)).toBe(0)
-  })
+  it("returns 0 for negative duration", () => {
+    expect(computeAvgSpeedKmh(10, -100)).toBe(0);
+  });
 
-  it('returns 0 for 0 distance with valid duration', () => {
-    expect(computeAvgSpeedKmh(0, 3600)).toBe(0)
-  })
+  it("returns 0 for 0 distance with valid duration", () => {
+    expect(computeAvgSpeedKmh(0, 3600)).toBe(0);
+  });
 
-  it('handles typical cycling speeds', () => {
+  it("handles typical cycling speeds", () => {
     // Casual: 8 km in 30 min = 16 km/h
-    expect(computeAvgSpeedKmh(8, 1800)).toBeCloseTo(16)
+    expect(computeAvgSpeedKmh(8, 1800)).toBeCloseTo(16);
     // Fast commuter: 15 km in 35 min (2100s) = ~25.7 km/h
-    expect(computeAvgSpeedKmh(15, 2100)).toBe(25.7)
+    expect(computeAvgSpeedKmh(15, 2100)).toBe(25.7);
     // Sprint: 2 km in 180 sec (3 min) = 40 km/h
-    expect(computeAvgSpeedKmh(2, 180)).toBe(40)
-  })
+    expect(computeAvgSpeedKmh(2, 180)).toBe(40);
+  });
 
-  it('handles aggregated multi-trip values', () => {
+  it("handles aggregated multi-trip values", () => {
     // Total: 45 km over 9000 sec (2.5 hours) = 18.0 km/h
-    expect(computeAvgSpeedKmh(45, 9000)).toBe(18)
+    expect(computeAvgSpeedKmh(45, 9000)).toBe(18);
     // Total: 100 km over 18000 sec (5 hours) = 20.0 km/h
-    expect(computeAvgSpeedKmh(100, 18000)).toBe(20)
-  })
-})
+    expect(computeAvgSpeedKmh(100, 18000)).toBe(20);
+  });
+});

--- a/client/src/lib/__tests__/badges.test.ts
+++ b/client/src/lib/__tests__/badges.test.ts
@@ -1,37 +1,46 @@
-import { describe, expect, it } from 'vitest'
-import { evaluateBadges } from '../badges'
+import { describe, expect, it } from "vitest";
+import { evaluateBadges } from "../badges";
 
-describe('evaluateBadges', () => {
-  it('all badges locked at zero stats', () => {
-    const badges = evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 })
-    expect(badges.every((b) => !b.unlocked)).toBe(true)
-    expect(badges.every((b) => b.progressRatio === 0)).toBe(true)
-  })
-  it('unlocks first trip badge at 1 trip', () => {
-    const badges = evaluateBadges({ totalTrips: 1, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 })
-    const first = badges.find((b) => b.id === 'first_trip')
-    expect(first?.unlocked).toBe(true)
-    expect(first?.progressRatio).toBe(1)
-  })
-  it('shows progress toward 10 trips at 5 trips', () => {
-    const b = evaluateBadges({ totalTrips: 5, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 })
-      .find((b) => b.id === 'trips_10')
-    expect(b?.unlocked).toBe(false)
-    expect(b?.progressRatio).toBeCloseTo(0.5)
-  })
-  it('unlocks badge at exact threshold', () => {
-    const badges = evaluateBadges({ totalTrips: 10, totalKm: 100, totalCo2Kg: 10, currentStreak: 7 })
-    expect(badges.find((b) => b.id === 'trips_10')?.unlocked).toBe(true)
-    expect(badges.find((b) => b.id === 'km_100')?.unlocked).toBe(true)
-    expect(badges.find((b) => b.id === 'co2_10kg')?.unlocked).toBe(true)
-    expect(badges.find((b) => b.id === 'streak_7')?.unlocked).toBe(true)
-  })
-  it('caps progress_ratio at 1', () => {
-    const b = evaluateBadges({ totalTrips: 200, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 })
-      .find((b) => b.id === 'trips_100')
-    expect(b?.progressRatio).toBe(1)
-  })
-  it('returns all 12 badge definitions', () => {
-    expect(evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 })).toHaveLength(12)
-  })
-})
+describe("evaluateBadges", () => {
+  it("all badges locked at zero stats", () => {
+    const badges = evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 });
+    expect(badges.every((b) => !b.unlocked)).toBe(true);
+    expect(badges.every((b) => b.progressRatio === 0)).toBe(true);
+  });
+  it("unlocks first trip badge at 1 trip", () => {
+    const badges = evaluateBadges({ totalTrips: 1, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 });
+    const first = badges.find((b) => b.id === "first_trip");
+    expect(first?.unlocked).toBe(true);
+    expect(first?.progressRatio).toBe(1);
+  });
+  it("shows progress toward 10 trips at 5 trips", () => {
+    const b = evaluateBadges({ totalTrips: 5, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }).find(
+      (b) => b.id === "trips_10",
+    );
+    expect(b?.unlocked).toBe(false);
+    expect(b?.progressRatio).toBeCloseTo(0.5);
+  });
+  it("unlocks badge at exact threshold", () => {
+    const badges = evaluateBadges({
+      totalTrips: 10,
+      totalKm: 100,
+      totalCo2Kg: 10,
+      currentStreak: 7,
+    });
+    expect(badges.find((b) => b.id === "trips_10")?.unlocked).toBe(true);
+    expect(badges.find((b) => b.id === "km_100")?.unlocked).toBe(true);
+    expect(badges.find((b) => b.id === "co2_10kg")?.unlocked).toBe(true);
+    expect(badges.find((b) => b.id === "streak_7")?.unlocked).toBe(true);
+  });
+  it("caps progress_ratio at 1", () => {
+    const b = evaluateBadges({ totalTrips: 200, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }).find(
+      (b) => b.id === "trips_100",
+    );
+    expect(b?.progressRatio).toBe(1);
+  });
+  it("returns all 12 badge definitions", () => {
+    expect(
+      evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }),
+    ).toHaveLength(12);
+  });
+});

--- a/client/src/lib/__tests__/calculations.test.ts
+++ b/client/src/lib/__tests__/calculations.test.ts
@@ -1,83 +1,83 @@
-import { describe, expect, it } from 'vitest'
-import { co2Saved, computeSavings, fuelSaved, moneySaved } from '../calculations'
+import { describe, expect, it } from "vitest";
+import { co2Saved, computeSavings, fuelSaved, moneySaved } from "../calculations";
 
-describe('fuelSaved', () => {
-  it('calculates fuel saved for standard trip', () => {
-    expect(fuelSaved(10, 6.5)).toBeCloseTo(0.65)
-  })
-  it('returns 0 for 0 distance', () => {
-    expect(fuelSaved(0, 6.5)).toBe(0)
-  })
-  it('returns 0 for 0 consumption', () => {
-    expect(fuelSaved(10, 0)).toBe(0)
-  })
-  it('clamps negative distance to 0', () => {
-    expect(fuelSaved(-5, 6.5)).toBe(0)
-  })
-  it('clamps negative consumption to 0', () => {
-    expect(fuelSaved(10, -3)).toBe(0)
-  })
-  it('handles large values', () => {
-    expect(fuelSaved(10000, 15)).toBeCloseTo(1500)
-  })
-  it('handles fractional values', () => {
-    expect(fuelSaved(3.7, 5.2)).toBeCloseTo(0.1924)
-  })
-})
+describe("fuelSaved", () => {
+  it("calculates fuel saved for standard trip", () => {
+    expect(fuelSaved(10, 6.5)).toBeCloseTo(0.65);
+  });
+  it("returns 0 for 0 distance", () => {
+    expect(fuelSaved(0, 6.5)).toBe(0);
+  });
+  it("returns 0 for 0 consumption", () => {
+    expect(fuelSaved(10, 0)).toBe(0);
+  });
+  it("clamps negative distance to 0", () => {
+    expect(fuelSaved(-5, 6.5)).toBe(0);
+  });
+  it("clamps negative consumption to 0", () => {
+    expect(fuelSaved(10, -3)).toBe(0);
+  });
+  it("handles large values", () => {
+    expect(fuelSaved(10000, 15)).toBeCloseTo(1500);
+  });
+  it("handles fractional values", () => {
+    expect(fuelSaved(3.7, 5.2)).toBeCloseTo(0.1924);
+  });
+});
 
-describe('co2Saved', () => {
-  it('calculates CO2 using ADEME factor 2.31', () => {
-    expect(co2Saved(10, 6.5)).toBeCloseTo(1.5015)
-  })
-  it('returns 0 for 0 distance', () => {
-    expect(co2Saved(0, 6.5)).toBe(0)
-  })
-  it('returns 0 for negative values', () => {
-    expect(co2Saved(-10, 6.5)).toBe(0)
-    expect(co2Saved(10, -6.5)).toBe(0)
-  })
-  it('is consistent with fuelSaved * 2.31', () => {
-    const fuel = fuelSaved(25, 7.8)
-    expect(co2Saved(25, 7.8)).toBeCloseTo(fuel * 2.31)
-  })
-})
+describe("co2Saved", () => {
+  it("calculates CO2 using ADEME factor 2.31", () => {
+    expect(co2Saved(10, 6.5)).toBeCloseTo(1.5015);
+  });
+  it("returns 0 for 0 distance", () => {
+    expect(co2Saved(0, 6.5)).toBe(0);
+  });
+  it("returns 0 for negative values", () => {
+    expect(co2Saved(-10, 6.5)).toBe(0);
+    expect(co2Saved(10, -6.5)).toBe(0);
+  });
+  it("is consistent with fuelSaved * 2.31", () => {
+    const fuel = fuelSaved(25, 7.8);
+    expect(co2Saved(25, 7.8)).toBeCloseTo(fuel * 2.31);
+  });
+});
 
-describe('moneySaved', () => {
-  it('calculates money saved for standard trip', () => {
-    expect(moneySaved(10, 6.5, 1.99)).toBeCloseTo(1.2935)
-  })
-  it('returns 0 for 0 fuel price', () => {
-    expect(moneySaved(10, 6.5, 0)).toBe(0)
-  })
-  it('clamps negative fuel price to 0', () => {
-    expect(moneySaved(10, 6.5, -1.5)).toBe(0)
-  })
-  it('returns 0 for 0 distance', () => {
-    expect(moneySaved(0, 6.5, 1.99)).toBe(0)
-  })
-})
+describe("moneySaved", () => {
+  it("calculates money saved for standard trip", () => {
+    expect(moneySaved(10, 6.5, 1.99)).toBeCloseTo(1.2935);
+  });
+  it("returns 0 for 0 fuel price", () => {
+    expect(moneySaved(10, 6.5, 0)).toBe(0);
+  });
+  it("clamps negative fuel price to 0", () => {
+    expect(moneySaved(10, 6.5, -1.5)).toBe(0);
+  });
+  it("returns 0 for 0 distance", () => {
+    expect(moneySaved(0, 6.5, 1.99)).toBe(0);
+  });
+});
 
-describe('computeSavings', () => {
-  it('returns all three savings values', () => {
-    const r = computeSavings(10, 6.5, 1.99)
-    expect(r.fuelSavedL).toBeCloseTo(0.65)
-    expect(r.co2SavedKg).toBeCloseTo(1.5015)
-    expect(r.moneySavedEur).toBeCloseTo(1.2935)
-  })
-  it('maintains consistency: co2 = fuel * 2.31', () => {
-    const r = computeSavings(42, 8.3, 1.85)
-    expect(r.co2SavedKg).toBeCloseTo(r.fuelSavedL * 2.31)
-  })
-  it('handles all zeros', () => {
-    const r = computeSavings(0, 0, 0)
-    expect(r.fuelSavedL).toBe(0)
-    expect(r.co2SavedKg).toBe(0)
-    expect(r.moneySavedEur).toBe(0)
-  })
-  it('handles negative inputs by clamping', () => {
-    const r = computeSavings(-5, -3, -1)
-    expect(r.fuelSavedL).toBe(0)
-    expect(r.co2SavedKg).toBe(0)
-    expect(r.moneySavedEur).toBe(0)
-  })
-})
+describe("computeSavings", () => {
+  it("returns all three savings values", () => {
+    const r = computeSavings(10, 6.5, 1.99);
+    expect(r.fuelSavedL).toBeCloseTo(0.65);
+    expect(r.co2SavedKg).toBeCloseTo(1.5015);
+    expect(r.moneySavedEur).toBeCloseTo(1.2935);
+  });
+  it("maintains consistency: co2 = fuel * 2.31", () => {
+    const r = computeSavings(42, 8.3, 1.85);
+    expect(r.co2SavedKg).toBeCloseTo(r.fuelSavedL * 2.31);
+  });
+  it("handles all zeros", () => {
+    const r = computeSavings(0, 0, 0);
+    expect(r.fuelSavedL).toBe(0);
+    expect(r.co2SavedKg).toBe(0);
+    expect(r.moneySavedEur).toBe(0);
+  });
+  it("handles negative inputs by clamping", () => {
+    const r = computeSavings(-5, -3, -1);
+    expect(r.fuelSavedL).toBe(0);
+    expect(r.co2SavedKg).toBe(0);
+    expect(r.moneySavedEur).toBe(0);
+  });
+});

--- a/client/src/lib/__tests__/fuel-price.test.ts
+++ b/client/src/lib/__tests__/fuel-price.test.ts
@@ -1,87 +1,89 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { clearFuelPriceCache, fetchFuelPrice } from '../fuel-price'
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearFuelPriceCache, fetchFuelPrice } from "../fuel-price";
 
-const mockFetch = vi.fn()
+const mockFetch = vi.fn();
 
 beforeEach(() => {
-  mockFetch.mockReset()
-  vi.stubGlobal('fetch', mockFetch)
-  clearFuelPriceCache()
-})
+  mockFetch.mockReset();
+  vi.stubGlobal("fetch", mockFetch);
+  clearFuelPriceCache();
+});
 
 afterEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 function jsonResponse(data: unknown, status = 200) {
   return Promise.resolve({
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(data),
-  })
+  });
 }
 
-describe('fetchFuelPrice', () => {
-  it('returns geolocated price from nearest station', async () => {
+describe("fetchFuelPrice", () => {
+  it("returns geolocated price from nearest station", async () => {
     mockFetch.mockReturnValueOnce(
-      jsonResponse({ results: [{ adresse: '12 rue du Test', ville: 'Paris', sp95_prix: 1.879 }] }),
-    )
-    const result = await fetchFuelPrice('sp95', { lat: 48.85, lng: 2.35 })
-    expect(result.source).toBe('geolocated')
-    expect(result.priceEur).toBe(1.879)
-    expect(result.stationName).toContain('Paris')
-  })
+      jsonResponse({ results: [{ adresse: "12 rue du Test", ville: "Paris", sp95_prix: 1.879 }] }),
+    );
+    const result = await fetchFuelPrice("sp95", { lat: 48.85, lng: 2.35 });
+    expect(result.source).toBe("geolocated");
+    expect(result.priceEur).toBe(1.879);
+    expect(result.stationName).toContain("Paris");
+  });
 
-  it('falls back to national average when no nearby stations', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [] }))
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.85 }] }))
-    const result = await fetchFuelPrice('sp95', { lat: 48.85, lng: 2.35 })
-    expect(result.source).toBe('national_average')
-    expect(result.priceEur).toBe(1.85)
-  })
+  it("falls back to national average when no nearby stations", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [] }));
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.85 }] }));
+    const result = await fetchFuelPrice("sp95", { lat: 48.85, lng: 2.35 });
+    expect(result.source).toBe("national_average");
+    expect(result.priceEur).toBe(1.85);
+  });
 
-  it('falls back to national average on network error', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network error'))
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.92 }] }))
-    const result = await fetchFuelPrice('sp95', { lat: 48.85, lng: 2.35 })
-    expect(result.source).toBe('national_average')
-    expect(result.priceEur).toBe(1.92)
-  })
+  it("falls back to national average on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.92 }] }));
+    const result = await fetchFuelPrice("sp95", { lat: 48.85, lng: 2.35 });
+    expect(result.source).toBe("national_average");
+    expect(result.priceEur).toBe(1.92);
+  });
 
-  it('returns national average when no coords', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.88 }] }))
-    const result = await fetchFuelPrice('diesel')
-    expect(result.source).toBe('national_average')
-    expect(result.priceEur).toBe(1.88)
-    expect(mockFetch).toHaveBeenCalledTimes(1)
-  })
+  it("returns national average when no coords", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.88 }] }));
+    const result = await fetchFuelPrice("diesel");
+    expect(result.source).toBe("national_average");
+    expect(result.priceEur).toBe(1.88);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 
-  it('returns hardcoded fallback when everything fails', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('fail'))
-    mockFetch.mockRejectedValueOnce(new Error('fail'))
-    const result = await fetchFuelPrice('sp95', { lat: 48.85, lng: 2.35 })
-    expect(result.priceEur).toBe(1.85)
-  })
+  it("returns hardcoded fallback when everything fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    const result = await fetchFuelPrice("sp95", { lat: 48.85, lng: 2.35 });
+    expect(result.priceEur).toBe(1.85);
+  });
 
-  it('filters stations with 0 price', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ adresse: 'x', ville: 'x', sp95_prix: 0 }] }))
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.90 }] }))
-    const result = await fetchFuelPrice('sp95', { lat: 48.85, lng: 2.35 })
-    expect(result.source).toBe('national_average')
-  })
+  it("filters stations with 0 price", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ results: [{ adresse: "x", ville: "x", sp95_prix: 0 }] }),
+    );
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.9 }] }));
+    const result = await fetchFuelPrice("sp95", { lat: 48.85, lng: 2.35 });
+    expect(result.source).toBe("national_average");
+  });
 
-  it('uses cache on repeated calls', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.88 }] }))
-    const r1 = await fetchFuelPrice('sp95')
-    const r2 = await fetchFuelPrice('sp95')
-    expect(r1).toEqual(r2)
-    expect(mockFetch).toHaveBeenCalledTimes(1)
-  })
+  it("uses cache on repeated calls", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.88 }] }));
+    const r1 = await fetchFuelPrice("sp95");
+    const r2 = await fetchFuelPrice("sp95");
+    expect(r1).toEqual(r2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 
-  it('uses correct API field for diesel', async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.55 }] }))
-    await fetchFuelPrice('diesel')
-    const url = mockFetch.mock.calls[0]![0] as string
-    expect(url).toContain('gazole_prix')
-  })
-})
+  it("uses correct API field for diesel", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ results: [{ avg_price: 1.55 }] }));
+    await fetchFuelPrice("diesel");
+    const url = mockFetch.mock.calls[0]![0] as string;
+    expect(url).toContain("gazole_prix");
+  });
+});

--- a/client/src/lib/__tests__/haversine.test.ts
+++ b/client/src/lib/__tests__/haversine.test.ts
@@ -1,33 +1,33 @@
-import { describe, expect, it } from 'vitest'
-import { haversineDistance } from '../haversine'
+import { describe, expect, it } from "vitest";
+import { haversineDistance } from "../haversine";
 
-describe('haversineDistance', () => {
-  it('returns 0 for the same point', () => {
-    expect(haversineDistance(48.8566, 2.3522, 48.8566, 2.3522)).toBe(0)
-  })
-  it('calculates Paris to Lyon (~392 km)', () => {
-    const d = haversineDistance(48.8566, 2.3522, 45.764, 4.8357)
-    expect(d).toBeGreaterThan(390)
-    expect(d).toBeLessThan(395)
-  })
-  it('calculates a short cycling distance (~1 km)', () => {
-    const d = haversineDistance(48.8566, 2.3522, 48.8656, 2.3522)
-    expect(d).toBeGreaterThan(0.9)
-    expect(d).toBeLessThan(1.1)
-  })
-  it('handles antipodal points (~20000 km)', () => {
-    const d = haversineDistance(0, 0, 0, 180)
-    expect(d).toBeGreaterThan(20000)
-    expect(d).toBeLessThan(20100)
-  })
-  it('handles very small distances (< 100m)', () => {
-    const d = haversineDistance(48.8566, 2.3522, 48.85705, 2.3522)
-    expect(d).toBeGreaterThan(0.04)
-    expect(d).toBeLessThan(0.06)
-  })
-  it('is symmetric', () => {
-    const d1 = haversineDistance(48.8566, 2.3522, 45.764, 4.8357)
-    const d2 = haversineDistance(45.764, 4.8357, 48.8566, 2.3522)
-    expect(d1).toBeCloseTo(d2, 10)
-  })
-})
+describe("haversineDistance", () => {
+  it("returns 0 for the same point", () => {
+    expect(haversineDistance(48.8566, 2.3522, 48.8566, 2.3522)).toBe(0);
+  });
+  it("calculates Paris to Lyon (~392 km)", () => {
+    const d = haversineDistance(48.8566, 2.3522, 45.764, 4.8357);
+    expect(d).toBeGreaterThan(390);
+    expect(d).toBeLessThan(395);
+  });
+  it("calculates a short cycling distance (~1 km)", () => {
+    const d = haversineDistance(48.8566, 2.3522, 48.8656, 2.3522);
+    expect(d).toBeGreaterThan(0.9);
+    expect(d).toBeLessThan(1.1);
+  });
+  it("handles antipodal points (~20000 km)", () => {
+    const d = haversineDistance(0, 0, 0, 180);
+    expect(d).toBeGreaterThan(20000);
+    expect(d).toBeLessThan(20100);
+  });
+  it("handles very small distances (< 100m)", () => {
+    const d = haversineDistance(48.8566, 2.3522, 48.85705, 2.3522);
+    expect(d).toBeGreaterThan(0.04);
+    expect(d).toBeLessThan(0.06);
+  });
+  it("is symmetric", () => {
+    const d1 = haversineDistance(48.8566, 2.3522, 45.764, 4.8357);
+    const d2 = haversineDistance(45.764, 4.8357, 48.8566, 2.3522);
+    expect(d1).toBeCloseTo(d2, 10);
+  });
+});

--- a/client/src/lib/__tests__/impact-meter.test.ts
+++ b/client/src/lib/__tests__/impact-meter.test.ts
@@ -1,54 +1,54 @@
-import { describe, expect, it } from 'vitest'
-import { computeImpactLevel, IMPACT_REFERENCES } from '../impact-meter'
+import { describe, expect, it } from "vitest";
+import { computeImpactLevel, IMPACT_REFERENCES } from "../impact-meter";
 
-describe('computeImpactLevel', () => {
-  it('returns first reference at 0 kg', () => {
-    const level = computeImpactLevel(0)
-    expect(level.currentRef.co2Kg).toBe(21)
-    expect(level.progressRatio).toBe(0)
-    expect(level.completedRefs).toHaveLength(0)
-  })
-  it('shows progress toward tree at 10 kg', () => {
-    const level = computeImpactLevel(10)
-    expect(level.currentRef.co2Kg).toBe(21)
-    expect(level.progressRatio).toBeCloseTo(10 / 21)
-  })
-  it('transitions after completing tree (21 kg)', () => {
-    const level = computeImpactLevel(21)
-    expect(level.currentRef.co2Kg).toBe(45)
-    expect(level.progressRatio).toBe(0)
-    expect(level.completedRefs).toHaveLength(1)
-  })
-  it('shows progress within Paris-Lyon at 30 kg', () => {
-    const level = computeImpactLevel(30)
-    expect(level.currentRef.co2Kg).toBe(45)
-    expect(level.progressRatio).toBeCloseTo(9 / 45)
-  })
-  it('transitions to gas tank at 66 kg', () => {
-    const level = computeImpactLevel(66)
-    expect(level.currentRef.co2Kg).toBe(115)
-    expect(level.completedRefs).toHaveLength(2)
-  })
-  it('transitions to flight at 181 kg', () => {
-    const level = computeImpactLevel(181)
-    expect(level.currentRef.co2Kg).toBe(400)
-    expect(level.completedRefs).toHaveLength(3)
-  })
-  it('maxes out beyond all references', () => {
-    const level = computeImpactLevel(600)
-    expect(level.nextRef).toBeNull()
-    expect(level.progressRatio).toBe(1)
-    expect(level.completedRefs).toHaveLength(4)
-  })
-  it('handles negative input', () => {
-    expect(computeImpactLevel(-5).progressRatio).toBe(0)
-  })
-  it('includes nextRef correctly', () => {
-    expect(computeImpactLevel(10).nextRef?.co2Kg).toBe(45)
-  })
-  it('references are ordered ascending', () => {
+describe("computeImpactLevel", () => {
+  it("returns first reference at 0 kg", () => {
+    const level = computeImpactLevel(0);
+    expect(level.currentRef.co2Kg).toBe(21);
+    expect(level.progressRatio).toBe(0);
+    expect(level.completedRefs).toHaveLength(0);
+  });
+  it("shows progress toward tree at 10 kg", () => {
+    const level = computeImpactLevel(10);
+    expect(level.currentRef.co2Kg).toBe(21);
+    expect(level.progressRatio).toBeCloseTo(10 / 21);
+  });
+  it("transitions after completing tree (21 kg)", () => {
+    const level = computeImpactLevel(21);
+    expect(level.currentRef.co2Kg).toBe(45);
+    expect(level.progressRatio).toBe(0);
+    expect(level.completedRefs).toHaveLength(1);
+  });
+  it("shows progress within Paris-Lyon at 30 kg", () => {
+    const level = computeImpactLevel(30);
+    expect(level.currentRef.co2Kg).toBe(45);
+    expect(level.progressRatio).toBeCloseTo(9 / 45);
+  });
+  it("transitions to gas tank at 66 kg", () => {
+    const level = computeImpactLevel(66);
+    expect(level.currentRef.co2Kg).toBe(115);
+    expect(level.completedRefs).toHaveLength(2);
+  });
+  it("transitions to flight at 181 kg", () => {
+    const level = computeImpactLevel(181);
+    expect(level.currentRef.co2Kg).toBe(400);
+    expect(level.completedRefs).toHaveLength(3);
+  });
+  it("maxes out beyond all references", () => {
+    const level = computeImpactLevel(600);
+    expect(level.nextRef).toBeNull();
+    expect(level.progressRatio).toBe(1);
+    expect(level.completedRefs).toHaveLength(4);
+  });
+  it("handles negative input", () => {
+    expect(computeImpactLevel(-5).progressRatio).toBe(0);
+  });
+  it("includes nextRef correctly", () => {
+    expect(computeImpactLevel(10).nextRef?.co2Kg).toBe(45);
+  });
+  it("references are ordered ascending", () => {
     for (let i = 1; i < IMPACT_REFERENCES.length; i++) {
-      expect(IMPACT_REFERENCES[i]!.co2Kg).toBeGreaterThan(IMPACT_REFERENCES[i - 1]!.co2Kg)
+      expect(IMPACT_REFERENCES[i]!.co2Kg).toBeGreaterThan(IMPACT_REFERENCES[i - 1]!.co2Kg);
     }
-  })
-})
+  });
+});

--- a/client/src/lib/__tests__/monthly-goal.test.ts
+++ b/client/src/lib/__tests__/monthly-goal.test.ts
@@ -1,34 +1,34 @@
-import { describe, expect, it } from 'vitest'
-import { computeMonthlyGoal } from '../monthly-goal'
+import { describe, expect, it } from "vitest";
+import { computeMonthlyGoal } from "../monthly-goal";
 
 const trips = [
-  { distanceKm: 10, co2SavedKg: 1.5, startedAt: '2026-03-05T08:00:00Z' },
-  { distanceKm: 15, co2SavedKg: 2.25, startedAt: '2026-03-10T17:30:00Z' },
-  { distanceKm: 8, co2SavedKg: 1.2, startedAt: '2026-03-15T09:00:00Z' },
-  { distanceKm: 20, co2SavedKg: 3.0, startedAt: '2026-02-20T08:00:00Z' },
-]
+  { distanceKm: 10, co2SavedKg: 1.5, startedAt: "2026-03-05T08:00:00Z" },
+  { distanceKm: 15, co2SavedKg: 2.25, startedAt: "2026-03-10T17:30:00Z" },
+  { distanceKm: 8, co2SavedKg: 1.2, startedAt: "2026-03-15T09:00:00Z" },
+  { distanceKm: 20, co2SavedKg: 3.0, startedAt: "2026-02-20T08:00:00Z" },
+];
 
-describe('computeMonthlyGoal', () => {
-  it('calculates km goal progress', () => {
-    const goal = computeMonthlyGoal('km', 50, trips, '2026-03')
-    expect(goal.currentValue).toBeCloseTo(33)
-    expect(goal.progressRatio).toBeCloseTo(33 / 50)
-  })
-  it('calculates co2 goal progress', () => {
-    expect(computeMonthlyGoal('co2', 10, trips, '2026-03').currentValue).toBeCloseTo(4.95)
-  })
-  it('excludes trips from other months', () => {
-    expect(computeMonthlyGoal('km', 50, trips, '2026-02').currentValue).toBe(20)
-  })
-  it('returns 0 progress with no trips', () => {
-    const goal = computeMonthlyGoal('km', 100, [], '2026-03')
-    expect(goal.currentValue).toBe(0)
-    expect(goal.progressRatio).toBe(0)
-  })
-  it('caps progress_ratio at 1.0', () => {
-    expect(computeMonthlyGoal('km', 20, trips, '2026-03').progressRatio).toBe(1)
-  })
-  it('handles 0 target value', () => {
-    expect(computeMonthlyGoal('km', 0, trips, '2026-03').progressRatio).toBe(0)
-  })
-})
+describe("computeMonthlyGoal", () => {
+  it("calculates km goal progress", () => {
+    const goal = computeMonthlyGoal("km", 50, trips, "2026-03");
+    expect(goal.currentValue).toBeCloseTo(33);
+    expect(goal.progressRatio).toBeCloseTo(33 / 50);
+  });
+  it("calculates co2 goal progress", () => {
+    expect(computeMonthlyGoal("co2", 10, trips, "2026-03").currentValue).toBeCloseTo(4.95);
+  });
+  it("excludes trips from other months", () => {
+    expect(computeMonthlyGoal("km", 50, trips, "2026-02").currentValue).toBe(20);
+  });
+  it("returns 0 progress with no trips", () => {
+    const goal = computeMonthlyGoal("km", 100, [], "2026-03");
+    expect(goal.currentValue).toBe(0);
+    expect(goal.progressRatio).toBe(0);
+  });
+  it("caps progress_ratio at 1.0", () => {
+    expect(computeMonthlyGoal("km", 20, trips, "2026-03").progressRatio).toBe(1);
+  });
+  it("handles 0 target value", () => {
+    expect(computeMonthlyGoal("km", 0, trips, "2026-03").progressRatio).toBe(0);
+  });
+});

--- a/client/src/lib/__tests__/push.test.ts
+++ b/client/src/lib/__tests__/push.test.ts
@@ -3,7 +3,8 @@ import { urlBase64ToUint8Array } from "../push";
 
 describe("urlBase64ToUint8Array", () => {
   it("converts a valid VAPID key to Uint8Array", () => {
-    const key = "BNGNvPNmn6BuBQG3_nvuAO-wngOKDhXHsZ2Eieav73pAY2h6ko_mNPzolDDJK3iItk9Pb5eOBmc5Z9L2ZLghk7g";
+    const key =
+      "BNGNvPNmn6BuBQG3_nvuAO-wngOKDhXHsZ2Eieav73pAY2h6ko_mNPzolDDJK3iItk9Pb5eOBmc5Z9L2ZLghk7g";
     const result = urlBase64ToUint8Array(key);
     expect(result).toBeInstanceOf(Uint8Array);
     expect(result.length).toBe(65); // P-256 public key = 65 bytes

--- a/client/src/lib/__tests__/streaks.test.ts
+++ b/client/src/lib/__tests__/streaks.test.ts
@@ -1,48 +1,69 @@
-import { describe, expect, it } from 'vitest'
-import { computeStreak } from '../streaks'
+import { describe, expect, it } from "vitest";
+import { computeStreak } from "../streaks";
 
-describe('computeStreak', () => {
-  it('returns 0 for empty trips', () => {
-    const info = computeStreak([], '2026-03-21')
-    expect(info.currentStreak).toBe(0)
-    expect(info.longestStreak).toBe(0)
-    expect(info.lastTripDate).toBeNull()
-    expect(info.isActiveToday).toBe(false)
-  })
-  it('returns streak 1 for single trip today', () => {
-    const info = computeStreak(['2026-03-21'], '2026-03-21')
-    expect(info.currentStreak).toBe(1)
-    expect(info.isActiveToday).toBe(true)
-  })
-  it('counts 7 consecutive days ending today', () => {
-    const dates = ['2026-03-15', '2026-03-16', '2026-03-17', '2026-03-18',
-      '2026-03-19', '2026-03-20', '2026-03-21']
-    expect(computeStreak(dates, '2026-03-21').currentStreak).toBe(7)
-  })
-  it('keeps streak alive if last trip was yesterday', () => {
-    const info = computeStreak(['2026-03-18', '2026-03-19', '2026-03-20'], '2026-03-21')
-    expect(info.currentStreak).toBe(3)
-    expect(info.isActiveToday).toBe(false)
-  })
-  it('resets streak after a gap', () => {
-    expect(computeStreak(
-      ['2026-03-17', '2026-03-18', '2026-03-20', '2026-03-21'], '2026-03-21',
-    ).currentStreak).toBe(2)
-  })
-  it('deduplicates multiple trips on same day', () => {
-    expect(computeStreak(['2026-03-21', '2026-03-21', '2026-03-21'], '2026-03-21').currentStreak).toBe(1)
-  })
-  it('streak is broken if last trip was 2+ days ago', () => {
-    expect(computeStreak(['2026-03-15', '2026-03-16', '2026-03-17'], '2026-03-21').currentStreak).toBe(0)
-  })
-  it('tracks longest streak separately', () => {
-    const dates = ['2026-03-10', '2026-03-11', '2026-03-12', '2026-03-13', '2026-03-14',
-      '2026-03-20', '2026-03-21']
-    const info = computeStreak(dates, '2026-03-21')
-    expect(info.currentStreak).toBe(2)
-    expect(info.longestStreak).toBe(5)
-  })
-  it('handles unsorted input', () => {
-    expect(computeStreak(['2026-03-21', '2026-03-19', '2026-03-20'], '2026-03-21').currentStreak).toBe(3)
-  })
-})
+describe("computeStreak", () => {
+  it("returns 0 for empty trips", () => {
+    const info = computeStreak([], "2026-03-21");
+    expect(info.currentStreak).toBe(0);
+    expect(info.longestStreak).toBe(0);
+    expect(info.lastTripDate).toBeNull();
+    expect(info.isActiveToday).toBe(false);
+  });
+  it("returns streak 1 for single trip today", () => {
+    const info = computeStreak(["2026-03-21"], "2026-03-21");
+    expect(info.currentStreak).toBe(1);
+    expect(info.isActiveToday).toBe(true);
+  });
+  it("counts 7 consecutive days ending today", () => {
+    const dates = [
+      "2026-03-15",
+      "2026-03-16",
+      "2026-03-17",
+      "2026-03-18",
+      "2026-03-19",
+      "2026-03-20",
+      "2026-03-21",
+    ];
+    expect(computeStreak(dates, "2026-03-21").currentStreak).toBe(7);
+  });
+  it("keeps streak alive if last trip was yesterday", () => {
+    const info = computeStreak(["2026-03-18", "2026-03-19", "2026-03-20"], "2026-03-21");
+    expect(info.currentStreak).toBe(3);
+    expect(info.isActiveToday).toBe(false);
+  });
+  it("resets streak after a gap", () => {
+    expect(
+      computeStreak(["2026-03-17", "2026-03-18", "2026-03-20", "2026-03-21"], "2026-03-21")
+        .currentStreak,
+    ).toBe(2);
+  });
+  it("deduplicates multiple trips on same day", () => {
+    expect(
+      computeStreak(["2026-03-21", "2026-03-21", "2026-03-21"], "2026-03-21").currentStreak,
+    ).toBe(1);
+  });
+  it("streak is broken if last trip was 2+ days ago", () => {
+    expect(
+      computeStreak(["2026-03-15", "2026-03-16", "2026-03-17"], "2026-03-21").currentStreak,
+    ).toBe(0);
+  });
+  it("tracks longest streak separately", () => {
+    const dates = [
+      "2026-03-10",
+      "2026-03-11",
+      "2026-03-12",
+      "2026-03-13",
+      "2026-03-14",
+      "2026-03-20",
+      "2026-03-21",
+    ];
+    const info = computeStreak(dates, "2026-03-21");
+    expect(info.currentStreak).toBe(2);
+    expect(info.longestStreak).toBe(5);
+  });
+  it("handles unsorted input", () => {
+    expect(
+      computeStreak(["2026-03-21", "2026-03-19", "2026-03-20"], "2026-03-21").currentStreak,
+    ).toBe(3);
+  });
+});

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -12,10 +12,7 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiFetch<T>(
-  path: string,
-  options?: RequestInit,
-): Promise<T> {
+export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     credentials: "include",
     headers: {

--- a/client/src/lib/badges.ts
+++ b/client/src/lib/badges.ts
@@ -1,77 +1,88 @@
 type BadgeId =
-  | 'first_trip' | 'trips_10' | 'trips_50' | 'trips_100'
-  | 'km_100' | 'km_500' | 'km_1000'
-  | 'co2_10kg' | 'co2_100kg' | 'co2_1t'
-  | 'streak_7' | 'streak_30'
+  | "first_trip"
+  | "trips_10"
+  | "trips_50"
+  | "trips_100"
+  | "km_100"
+  | "km_500"
+  | "km_1000"
+  | "co2_10kg"
+  | "co2_100kg"
+  | "co2_1t"
+  | "streak_7"
+  | "streak_30";
 
-interface BadgeMeta { label: string; icon: string }
-
-const BADGES: Record<BadgeId, BadgeMeta> = {
-  first_trip:  { label: 'Premier trajet',             icon: '🚴' },
-  trips_10:    { label: '10 trajets',                 icon: '🔟' },
-  trips_50:    { label: '50 trajets',                 icon: '🏅' },
-  trips_100:   { label: '100 trajets',                icon: '💯' },
-  km_100:      { label: '100 km',                     icon: '🛤️' },
-  km_500:      { label: '500 km',                     icon: '🗺️' },
-  km_1000:     { label: '1 000 km',                   icon: '🌍' },
-  co2_10kg:    { label: '10 kg CO₂ économisés',       icon: '🌱' },
-  co2_100kg:   { label: '100 kg CO₂ économisés',      icon: '🌳' },
-  co2_1t:      { label: '1 tonne CO₂ économisée',     icon: '🌲' },
-  streak_7:    { label: '7 jours de streak',          icon: '🔥' },
-  streak_30:   { label: '30 jours de streak',         icon: '⚡' },
+interface BadgeMeta {
+  label: string;
+  icon: string;
 }
 
+const BADGES: Record<BadgeId, BadgeMeta> = {
+  first_trip: { label: "Premier trajet", icon: "🚴" },
+  trips_10: { label: "10 trajets", icon: "🔟" },
+  trips_50: { label: "50 trajets", icon: "🏅" },
+  trips_100: { label: "100 trajets", icon: "💯" },
+  km_100: { label: "100 km", icon: "🛤️" },
+  km_500: { label: "500 km", icon: "🗺️" },
+  km_1000: { label: "1 000 km", icon: "🌍" },
+  co2_10kg: { label: "10 kg CO₂ économisés", icon: "🌱" },
+  co2_100kg: { label: "100 kg CO₂ économisés", icon: "🌳" },
+  co2_1t: { label: "1 tonne CO₂ économisée", icon: "🌲" },
+  streak_7: { label: "7 jours de streak", icon: "🔥" },
+  streak_30: { label: "30 jours de streak", icon: "⚡" },
+};
+
 export interface BadgeStatus {
-  id: BadgeId
-  label: string
-  icon: string
-  threshold: number
-  unlocked: boolean
-  currentValue: number
-  progressRatio: number
+  id: BadgeId;
+  label: string;
+  icon: string;
+  threshold: number;
+  unlocked: boolean;
+  currentValue: number;
+  progressRatio: number;
 }
 
 interface BadgeThreshold {
-  id: BadgeId
-  category: 'trips' | 'distance' | 'co2' | 'streak'
-  threshold: number
+  id: BadgeId;
+  category: "trips" | "distance" | "co2" | "streak";
+  threshold: number;
 }
 
 const BADGE_THRESHOLDS: BadgeThreshold[] = [
-  { id: 'first_trip', category: 'trips', threshold: 1 },
-  { id: 'trips_10', category: 'trips', threshold: 10 },
-  { id: 'trips_50', category: 'trips', threshold: 50 },
-  { id: 'trips_100', category: 'trips', threshold: 100 },
-  { id: 'km_100', category: 'distance', threshold: 100 },
-  { id: 'km_500', category: 'distance', threshold: 500 },
-  { id: 'km_1000', category: 'distance', threshold: 1000 },
-  { id: 'co2_10kg', category: 'co2', threshold: 10 },
-  { id: 'co2_100kg', category: 'co2', threshold: 100 },
-  { id: 'co2_1t', category: 'co2', threshold: 1000 },
-  { id: 'streak_7', category: 'streak', threshold: 7 },
-  { id: 'streak_30', category: 'streak', threshold: 30 },
-]
+  { id: "first_trip", category: "trips", threshold: 1 },
+  { id: "trips_10", category: "trips", threshold: 10 },
+  { id: "trips_50", category: "trips", threshold: 50 },
+  { id: "trips_100", category: "trips", threshold: 100 },
+  { id: "km_100", category: "distance", threshold: 100 },
+  { id: "km_500", category: "distance", threshold: 500 },
+  { id: "km_1000", category: "distance", threshold: 1000 },
+  { id: "co2_10kg", category: "co2", threshold: 10 },
+  { id: "co2_100kg", category: "co2", threshold: 100 },
+  { id: "co2_1t", category: "co2", threshold: 1000 },
+  { id: "streak_7", category: "streak", threshold: 7 },
+  { id: "streak_30", category: "streak", threshold: 30 },
+];
 
 export interface UserStats {
-  totalTrips: number
-  totalKm: number
-  totalCo2Kg: number
-  currentStreak: number
+  totalTrips: number;
+  totalKm: number;
+  totalCo2Kg: number;
+  currentStreak: number;
 }
 
 const CATEGORY_TO_STAT: Record<string, keyof UserStats> = {
-  trips: 'totalTrips',
-  distance: 'totalKm',
-  co2: 'totalCo2Kg',
-  streak: 'currentStreak',
-}
+  trips: "totalTrips",
+  distance: "totalKm",
+  co2: "totalCo2Kg",
+  streak: "currentStreak",
+};
 
 export function evaluateBadges(stats: UserStats): BadgeStatus[] {
   return BADGE_THRESHOLDS.map((bt) => {
-    const badge = BADGES[bt.id]
-    const statKey = CATEGORY_TO_STAT[bt.category]
-    if (!statKey) return null as never
-    const value = stats[statKey]
+    const badge = BADGES[bt.id];
+    const statKey = CATEGORY_TO_STAT[bt.category];
+    if (!statKey) return null as never;
+    const value = stats[statKey];
     return {
       id: bt.id,
       label: badge.label,
@@ -80,6 +91,6 @@ export function evaluateBadges(stats: UserStats): BadgeStatus[] {
       unlocked: value >= bt.threshold,
       currentValue: value,
       progressRatio: Math.min(1, value / bt.threshold),
-    }
-  })
+    };
+  });
 }

--- a/client/src/lib/calculations.ts
+++ b/client/src/lib/calculations.ts
@@ -1,15 +1,15 @@
-const CO2_PER_LITER = 2.31 // kg CO2 per liter (ADEME)
+const CO2_PER_LITER = 2.31; // kg CO2 per liter (ADEME)
 
 function clamp(value: number): number {
-  return value > 0 ? value : 0
+  return value > 0 ? value : 0;
 }
 
 export function fuelSaved(distanceKm: number, consumptionL100: number): number {
-  return (clamp(distanceKm) * clamp(consumptionL100)) / 100
+  return (clamp(distanceKm) * clamp(consumptionL100)) / 100;
 }
 
 export function co2Saved(distanceKm: number, consumptionL100: number): number {
-  return fuelSaved(distanceKm, consumptionL100) * CO2_PER_LITER
+  return fuelSaved(distanceKm, consumptionL100) * CO2_PER_LITER;
 }
 
 export function moneySaved(
@@ -17,13 +17,13 @@ export function moneySaved(
   consumptionL100: number,
   fuelPriceEur: number,
 ): number {
-  return fuelSaved(distanceKm, consumptionL100) * clamp(fuelPriceEur)
+  return fuelSaved(distanceKm, consumptionL100) * clamp(fuelPriceEur);
 }
 
 export interface SavingsResult {
-  co2SavedKg: number
-  moneySavedEur: number
-  fuelSavedL: number
+  co2SavedKg: number;
+  moneySavedEur: number;
+  fuelSavedL: number;
 }
 
 export function computeSavings(
@@ -31,12 +31,12 @@ export function computeSavings(
   consumptionL100: number,
   fuelPriceEur: number,
 ): SavingsResult {
-  const fuel = fuelSaved(distanceKm, consumptionL100)
+  const fuel = fuelSaved(distanceKm, consumptionL100);
   return {
     co2SavedKg: fuel * CO2_PER_LITER,
     moneySavedEur: fuel * clamp(fuelPriceEur),
     fuelSavedL: fuel,
-  }
+  };
 }
 
 /**
@@ -44,7 +44,7 @@ export function computeSavings(
  * Returns 0 if duration is 0 or negative. Result is rounded to 1 decimal place.
  */
 export function computeAvgSpeedKmh(totalDistanceKm: number, totalDurationSec: number): number {
-  if (totalDurationSec <= 0) return 0
-  const hours = totalDurationSec / 3600
-  return Math.round((totalDistanceKm / hours) * 10) / 10
+  if (totalDurationSec <= 0) return 0;
+  const hours = totalDurationSec / 3600;
+  return Math.round((totalDistanceKm / hours) * 10) / 10;
 }

--- a/client/src/lib/fuel-price.ts
+++ b/client/src/lib/fuel-price.ts
@@ -1,49 +1,49 @@
-type FuelType = 'sp95' | 'sp98' | 'diesel' | 'e85' | 'gpl'
+type FuelType = "sp95" | "sp98" | "diesel" | "e85" | "gpl";
 
 const BASE_URL =
-  'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-des-carburants-en-france-flux-instantane-v2/records'
+  "https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-des-carburants-en-france-flux-instantane-v2/records";
 
 const FUEL_PRICE_FIELDS: Record<FuelType, string> = {
-  sp95: 'sp95_prix',
-  sp98: 'sp98_prix',
-  diesel: 'gazole_prix',
-  e85: 'e85_prix',
-  gpl: 'gplc_prix',
-}
+  sp95: "sp95_prix",
+  sp98: "sp98_prix",
+  diesel: "gazole_prix",
+  e85: "e85_prix",
+  gpl: "gplc_prix",
+};
 
-const CACHE_TTL_MS = 30 * 60 * 1000
+const CACHE_TTL_MS = 30 * 60 * 1000;
 
 export interface FuelPriceResult {
-  priceEur: number
-  source: 'geolocated' | 'national_average'
-  stationName?: string
+  priceEur: number;
+  source: "geolocated" | "national_average";
+  stationName?: string;
 }
 
 interface CacheEntry {
-  result: FuelPriceResult
-  timestamp: number
+  result: FuelPriceResult;
+  timestamp: number;
 }
 
-const cache = new Map<string, CacheEntry>()
+const cache = new Map<string, CacheEntry>();
 
 function cacheKey(fuelType: FuelType, lat?: number, lng?: number): string {
   if (lat !== undefined && lng !== undefined) {
-    return `${fuelType}:${lat.toFixed(2)}:${lng.toFixed(2)}`
+    return `${fuelType}:${lat.toFixed(2)}:${lng.toFixed(2)}`;
   }
-  return `${fuelType}:national`
+  return `${fuelType}:national`;
 }
 
 function getCached(key: string): FuelPriceResult | null {
-  const entry = cache.get(key)
+  const entry = cache.get(key);
   if (entry && Date.now() - entry.timestamp < CACHE_TTL_MS) {
-    return entry.result
+    return entry.result;
   }
-  cache.delete(key)
-  return null
+  cache.delete(key);
+  return null;
 }
 
 function setCache(key: string, result: FuelPriceResult): void {
-  cache.set(key, { result, timestamp: Date.now() })
+  cache.set(key, { result, timestamp: Date.now() });
 }
 
 async function fetchNearestStation(
@@ -51,60 +51,60 @@ async function fetchNearestStation(
   lat: number,
   lng: number,
 ): Promise<FuelPriceResult | null> {
-  const priceField = FUEL_PRICE_FIELDS[fuelType]
+  const priceField = FUEL_PRICE_FIELDS[fuelType];
   const params = new URLSearchParams({
     where: `within_distance(geom,geom'POINT(${lng} ${lat})',10km) AND ${priceField} is not null`,
     select: `adresse,ville,${priceField}`,
     order_by: `distance(geom,geom'POINT(${lng} ${lat})')`,
-    limit: '1',
-  })
+    limit: "1",
+  });
 
-  const res = await fetch(`${BASE_URL}?${params}`)
-  if (!res.ok) return null
+  const res = await fetch(`${BASE_URL}?${params}`);
+  if (!res.ok) return null;
 
-  const data = await res.json()
-  const record = data.results?.[0]
-  if (!record) return null
+  const data = await res.json();
+  const record = data.results?.[0];
+  if (!record) return null;
 
-  const price = Number(record[priceField])
-  if (!price || price <= 0) return null
+  const price = Number(record[priceField]);
+  if (!price || price <= 0) return null;
 
   return {
     priceEur: price,
-    source: 'geolocated',
-    stationName: `${record.adresse ?? ''}, ${record.ville ?? ''}`.trim(),
-  }
+    source: "geolocated",
+    stationName: `${record.adresse ?? ""}, ${record.ville ?? ""}`.trim(),
+  };
 }
 
 async function fetchNationalAverage(fuelType: FuelType): Promise<number | null> {
-  const priceField = FUEL_PRICE_FIELDS[fuelType]
+  const priceField = FUEL_PRICE_FIELDS[fuelType];
   const params = new URLSearchParams({
     select: `avg(${priceField}) as avg_price`,
     where: `${priceField} is not null`,
-  })
+  });
 
-  const res = await fetch(`${BASE_URL}?${params}`)
-  if (!res.ok) return null
+  const res = await fetch(`${BASE_URL}?${params}`);
+  if (!res.ok) return null;
 
-  const data = await res.json()
-  const avg = data.results?.[0]?.avg_price
-  return typeof avg === 'number' && avg > 0 ? avg : null
+  const data = await res.json();
+  const avg = data.results?.[0]?.avg_price;
+  return typeof avg === "number" && avg > 0 ? avg : null;
 }
 
 export async function fetchFuelPrice(
   fuelType: FuelType,
   coords?: { lat: number; lng: number },
 ): Promise<FuelPriceResult> {
-  const key = cacheKey(fuelType, coords?.lat, coords?.lng)
-  const cached = getCached(key)
-  if (cached) return cached
+  const key = cacheKey(fuelType, coords?.lat, coords?.lng);
+  const cached = getCached(key);
+  if (cached) return cached;
 
   if (coords) {
     try {
-      const result = await fetchNearestStation(fuelType, coords.lat, coords.lng)
+      const result = await fetchNearestStation(fuelType, coords.lat, coords.lng);
       if (result) {
-        setCache(key, result)
-        return result
+        setCache(key, result);
+        return result;
       }
     } catch {
       // Fall through to national average
@@ -112,19 +112,19 @@ export async function fetchFuelPrice(
   }
 
   try {
-    const avg = await fetchNationalAverage(fuelType)
+    const avg = await fetchNationalAverage(fuelType);
     if (avg) {
-      const result: FuelPriceResult = { priceEur: avg, source: 'national_average' }
-      setCache(key, result)
-      return result
+      const result: FuelPriceResult = { priceEur: avg, source: "national_average" };
+      setCache(key, result);
+      return result;
     }
   } catch {
     // Fall through to hardcoded fallback
   }
 
-  return { priceEur: 1.85, source: 'national_average' }
+  return { priceEur: 1.85, source: "national_average" };
 }
 
 export function clearFuelPriceCache(): void {
-  cache.clear()
+  cache.clear();
 }

--- a/client/src/lib/haversine.ts
+++ b/client/src/lib/haversine.ts
@@ -5,20 +5,13 @@ function toRadians(degrees: number): number {
 }
 
 /** Haversine distance between two GPS coordinates, in kilometers */
-export function haversineDistance(
-  lat1: number,
-  lng1: number,
-  lat2: number,
-  lng2: number,
-): number {
+export function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
   const dLat = toRadians(lat2 - lat1);
   const dLng = toRadians(lng2 - lng1);
 
   const a =
     Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRadians(lat1)) *
-      Math.cos(toRadians(lat2)) *
-      Math.sin(dLng / 2) ** 2;
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLng / 2) ** 2;
 
   return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }

--- a/client/src/lib/impact-meter.ts
+++ b/client/src/lib/impact-meter.ts
@@ -1,31 +1,31 @@
 export interface ImpactReference {
-  label: string
-  co2Kg: number
+  label: string;
+  co2Kg: number;
 }
 
 export const IMPACT_REFERENCES: readonly ImpactReference[] = [
-  { label: 'arbre planté (absorption annuelle)', co2Kg: 21 },
-  { label: 'trajet Paris–Lyon en voiture', co2Kg: 45 },
+  { label: "arbre planté (absorption annuelle)", co2Kg: 21 },
+  { label: "trajet Paris–Lyon en voiture", co2Kg: 45 },
   { label: "plein d'essence (50L SP95)", co2Kg: 115 },
-  { label: 'vol Paris–New York (aller)', co2Kg: 400 },
-]
+  { label: "vol Paris–New York (aller)", co2Kg: 400 },
+];
 
 export interface ImpactLevel {
-  currentRef: ImpactReference
-  nextRef: ImpactReference | null
-  progressRatio: number
-  totalCo2Kg: number
-  completedRefs: ImpactReference[]
+  currentRef: ImpactReference;
+  nextRef: ImpactReference | null;
+  progressRatio: number;
+  totalCo2Kg: number;
+  completedRefs: ImpactReference[];
 }
 
 export function computeImpactLevel(totalCo2Kg: number): ImpactLevel {
-  const co2 = Math.max(0, totalCo2Kg)
-  const completed: ImpactReference[] = []
+  const co2 = Math.max(0, totalCo2Kg);
+  const completed: ImpactReference[] = [];
 
-  let remaining = co2
+  let remaining = co2;
 
   for (let i = 0; i < IMPACT_REFERENCES.length; i++) {
-    const ref = IMPACT_REFERENCES[i]!
+    const ref = IMPACT_REFERENCES[i]!;
 
     if (remaining < ref.co2Kg) {
       return {
@@ -34,19 +34,19 @@ export function computeImpactLevel(totalCo2Kg: number): ImpactLevel {
         progressRatio: remaining / ref.co2Kg,
         totalCo2Kg: co2,
         completedRefs: completed,
-      }
+      };
     }
 
-    remaining -= ref.co2Kg
-    completed.push(ref)
+    remaining -= ref.co2Kg;
+    completed.push(ref);
   }
 
-  const lastRef = IMPACT_REFERENCES[IMPACT_REFERENCES.length - 1]!
+  const lastRef = IMPACT_REFERENCES[IMPACT_REFERENCES.length - 1]!;
   return {
     currentRef: lastRef,
     nextRef: null,
     progressRatio: 1,
     totalCo2Kg: co2,
     completedRefs: completed,
-  }
+  };
 }

--- a/client/src/lib/mock-data.ts
+++ b/client/src/lib/mock-data.ts
@@ -1,13 +1,5 @@
-import type {
-  User,
-  Trip,
-  Achievement,
-  BadgeId,
-} from "@ecoride/shared/types";
-import type {
-  StatsSummaryResponse,
-  LeaderboardResponse,
-} from "@ecoride/shared/api-contracts";
+import type { User, Trip, Achievement, BadgeId } from "@ecoride/shared/types";
+import type { StatsSummaryResponse, LeaderboardResponse } from "@ecoride/shared/api-contracts";
 
 export const mockUser: User = {
   id: "user-1",
@@ -79,10 +71,31 @@ export const mockLeaderboard: LeaderboardResponse = {
     { userId: "u-1", name: "Thomas D.", image: null, totalCo2SavedKg: 42.5, value: 42.5, rank: 1 },
     { userId: "u-2", name: "Sarah L.", image: null, totalCo2SavedKg: 38.2, value: 38.2, rank: 2 },
     { userId: "u-3", name: "Julien R.", image: null, totalCo2SavedKg: 31.8, value: 31.8, rank: 3 },
-    { userId: "user-1", name: "Alex Chen", image: null, totalCo2SavedKg: 28.4, value: 28.4, rank: 4 },
+    {
+      userId: "user-1",
+      name: "Alex Chen",
+      image: null,
+      totalCo2SavedKg: 28.4,
+      value: 28.4,
+      rank: 4,
+    },
     { userId: "u-5", name: "Léa Martin", image: null, totalCo2SavedKg: 25.1, value: 25.1, rank: 5 },
-    { userId: "u-6", name: "Marc Antoine", image: null, totalCo2SavedKg: 22.9, value: 22.9, rank: 6 },
-    { userId: "u-7", name: "Chloé Petit", image: null, totalCo2SavedKg: 19.4, value: 19.4, rank: 7 },
+    {
+      userId: "u-6",
+      name: "Marc Antoine",
+      image: null,
+      totalCo2SavedKg: 22.9,
+      value: 22.9,
+      rank: 6,
+    },
+    {
+      userId: "u-7",
+      name: "Chloé Petit",
+      image: null,
+      totalCo2SavedKg: 19.4,
+      value: 19.4,
+      rank: 7,
+    },
   ],
   userRank: 4,
 };
@@ -96,8 +109,16 @@ export const mockAchievements: Achievement[] = [
 ];
 
 export const allBadgeIds: BadgeId[] = [
-  "first_trip", "trips_10", "trips_50", "trips_100",
-  "km_100", "km_500", "km_1000",
-  "co2_10kg", "co2_100kg", "co2_1t",
-  "streak_7", "streak_30",
+  "first_trip",
+  "trips_10",
+  "trips_50",
+  "trips_100",
+  "km_100",
+  "km_500",
+  "km_1000",
+  "co2_10kg",
+  "co2_100kg",
+  "co2_1t",
+  "streak_7",
+  "streak_30",
 ];

--- a/client/src/lib/monthly-goal.ts
+++ b/client/src/lib/monthly-goal.ts
@@ -1,31 +1,31 @@
 export interface MonthlyGoal {
-  targetType: 'km' | 'co2'
-  targetValue: number
-  currentValue: number
-  progressRatio: number
-  month: string
+  targetType: "km" | "co2";
+  targetValue: number;
+  currentValue: number;
+  progressRatio: number;
+  month: string;
 }
 
 interface TripSummary {
-  distanceKm: number
-  co2SavedKg: number
-  startedAt: string
+  distanceKm: number;
+  co2SavedKg: number;
+  startedAt: string;
 }
 
 export function computeMonthlyGoal(
-  targetType: 'km' | 'co2',
+  targetType: "km" | "co2",
   targetValue: number,
   trips: TripSummary[],
   month?: string,
 ): MonthlyGoal {
-  const m = month ?? new Date().toISOString().slice(0, 7)
-  const target = Math.max(0, targetValue)
+  const m = month ?? new Date().toISOString().slice(0, 7);
+  const target = Math.max(0, targetValue);
 
-  const monthTrips = trips.filter((t) => t.startedAt.slice(0, 7) === m)
+  const monthTrips = trips.filter((t) => t.startedAt.slice(0, 7) === m);
 
   const currentValue = monthTrips.reduce((sum, t) => {
-    return sum + (targetType === 'km' ? t.distanceKm : t.co2SavedKg)
-  }, 0)
+    return sum + (targetType === "km" ? t.distanceKm : t.co2SavedKg);
+  }, 0);
 
   return {
     targetType,
@@ -33,5 +33,5 @@ export function computeMonthlyGoal(
     currentValue,
     progressRatio: target > 0 ? Math.min(1, currentValue / target) : 0,
     month: m,
-  }
+  };
 }

--- a/client/src/lib/push.ts
+++ b/client/src/lib/push.ts
@@ -22,9 +22,7 @@ export function isPushSupported(): boolean {
 
 /** Fetch the VAPID public key from the server. */
 async function getVapidPublicKey(): Promise<string> {
-  const res = await apiFetch<{ ok: boolean; data: { publicKey: string } }>(
-    "/push/vapid-key",
-  );
+  const res = await apiFetch<{ ok: boolean; data: { publicKey: string } }>("/push/vapid-key");
   return res.data.publicKey;
 }
 

--- a/client/src/lib/streaks.ts
+++ b/client/src/lib/streaks.ts
@@ -1,46 +1,46 @@
 export interface StreakInfo {
-  currentStreak: number
-  longestStreak: number
-  lastTripDate: string | null
-  isActiveToday: boolean
+  currentStreak: number;
+  longestStreak: number;
+  lastTripDate: string | null;
+  isActiveToday: boolean;
 }
 
 function toDateStr(date: Date): string {
-  return date.toISOString().slice(0, 10)
+  return date.toISOString().slice(0, 10);
 }
 
 function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + 'T00:00:00Z')
-  d.setUTCDate(d.getUTCDate() + days)
-  return toDateStr(d)
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return toDateStr(d);
 }
 
 function longestRun(sortedDesc: string[]): number {
-  if (sortedDesc.length === 0) return 0
-  let max = 1
-  let run = 1
+  if (sortedDesc.length === 0) return 0;
+  let max = 1;
+  let run = 1;
   for (let i = 1; i < sortedDesc.length; i++) {
     if (sortedDesc[i] === addDays(sortedDesc[i - 1]!, -1)) {
-      run++
-      if (run > max) max = run
+      run++;
+      if (run > max) max = run;
     } else {
-      run = 1
+      run = 1;
     }
   }
-  return max
+  return max;
 }
 
 export function computeStreak(tripDates: string[], today?: string): StreakInfo {
   if (tripDates.length === 0) {
-    return { currentStreak: 0, longestStreak: 0, lastTripDate: null, isActiveToday: false }
+    return { currentStreak: 0, longestStreak: 0, lastTripDate: null, isActiveToday: false };
   }
 
-  const unique = [...new Set(tripDates)].sort().reverse()
-  const todayStr = today ?? toDateStr(new Date())
-  const last = unique[0]!
+  const unique = [...new Set(tripDates)].sort().reverse();
+  const todayStr = today ?? toDateStr(new Date());
+  const last = unique[0]!;
 
-  const isActiveToday = last === todayStr
-  const isYesterday = last === addDays(todayStr, -1)
+  const isActiveToday = last === todayStr;
+  const isYesterday = last === addDays(todayStr, -1);
 
   if (!isActiveToday && !isYesterday) {
     return {
@@ -48,24 +48,24 @@ export function computeStreak(tripDates: string[], today?: string): StreakInfo {
       longestStreak: longestRun(unique),
       lastTripDate: last,
       isActiveToday: false,
-    }
+    };
   }
 
-  let current = 1
+  let current = 1;
   for (let i = 1; i < unique.length; i++) {
     if (unique[i] === addDays(unique[i - 1]!, -1)) {
-      current++
+      current++;
     } else {
-      break
+      break;
     }
   }
 
-  const longest = longestRun(unique)
+  const longest = longestRun(unique);
 
   return {
     currentStreak: current,
     longestStreak: Math.max(current, longest),
     lastTripDate: last,
     isActiveToday,
-  }
+  };
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -26,17 +26,22 @@ async function purgeAndReload() {
 
 // Poll server for new version every 5 minutes (catches updates while app stays open)
 // Skip reload if a GPS trip is being tracked (backup key present = active tracking)
-setInterval(async () => {
-  try {
-    if (localStorage.getItem("ecoride-tracking-backup")) return; // Don't interrupt active tracking
-    const res = await fetch("/api/health");
-    const data = await res.json();
-    if (data.version && data.version !== __APP_VERSION__) {
-      localStorage.setItem("ecoride-version", data.version);
-      await purgeAndReload();
+setInterval(
+  async () => {
+    try {
+      if (localStorage.getItem("ecoride-tracking-backup")) return; // Don't interrupt active tracking
+      const res = await fetch("/api/health");
+      const data = await res.json();
+      if (data.version && data.version !== __APP_VERSION__) {
+        localStorage.setItem("ecoride-version", data.version);
+        await purgeAndReload();
+      }
+    } catch {
+      /* offline or error — ignore */
     }
-  } catch { /* offline or error — ignore */ }
-}, 5 * 60 * 1000);
+  },
+  5 * 60 * 1000,
+);
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -17,7 +17,11 @@ export function DashboardPage() {
 
   if (isPending || !today || !allTime) {
     return (
-      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
+      <div
+        className="flex flex-1 items-center justify-center"
+        role="status"
+        aria-label="Chargement"
+      >
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -28,7 +32,10 @@ export function DashboardPage() {
   return (
     <>
       {/* Header */}
-      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
         <span className="text-2xl font-black tracking-tighter">
           <span className="text-text">eco</span>
           <span className="text-primary-light">Ride</span>
@@ -40,7 +47,8 @@ export function DashboardPage() {
         <div className="mx-6 flex items-center gap-3 rounded-xl border border-primary/20 bg-primary/10 px-4 py-3">
           <CloudOff size={18} className="shrink-0 text-primary-light" />
           <span className="flex-1 text-xs font-medium text-text">
-            {pendingTrips.length} trajet{pendingTrips.length > 1 ? "s" : ""} en attente de synchronisation
+            {pendingTrips.length} trajet{pendingTrips.length > 1 ? "s" : ""} en attente de
+            synchronisation
           </span>
         </div>
       )}
@@ -51,13 +59,11 @@ export function DashboardPage() {
           <img src={appLogo} alt="ecoRide" className="h-20 w-20 rounded-2xl" />
           <div className="flex flex-col items-center gap-2 text-center">
             <h2 className="text-2xl font-bold">
-              Bienvenue sur{" "}
-              <span className="text-text">eco</span>
+              Bienvenue sur <span className="text-text">eco</span>
               <span className="text-primary-light">Ride</span> !
             </h2>
             <p className="max-w-xs text-sm text-text-muted">
-              Enregistrez votre premier trajet vélo pour commencer à suivre vos
-              économies CO₂.
+              Enregistrez votre premier trajet vélo pour commencer à suivre vos économies CO₂.
             </p>
           </div>
           <Link
@@ -81,12 +87,8 @@ export function DashboardPage() {
                 <Bike size={28} className="text-bg" />
               </div>
               <div>
-                <span className="block text-lg font-black text-bg">
-                  Démarrer un trajet
-                </span>
-                <span className="block text-sm font-medium text-bg/70">
-                  GPS ou saisie manuelle
-                </span>
+                <span className="block text-lg font-black text-bg">Démarrer un trajet</span>
+                <span className="block text-sm font-medium text-bg/70">GPS ou saisie manuelle</span>
               </div>
             </div>
             <ChevronRight
@@ -101,12 +103,8 @@ export function DashboardPage() {
             allTime.tripCount > 0 && (
               <div className="flex items-center gap-3 rounded-xl border border-warning/20 bg-warning/10 px-4 py-3">
                 <Car size={18} className="shrink-0 text-warning" />
-                <Link
-                  to="/profile"
-                  className="flex-1 text-xs font-medium text-text"
-                >
-                  Configurez votre véhicule de référence pour des calculs CO₂
-                  plus précis
+                <Link to="/profile" className="flex-1 text-xs font-medium text-text">
+                  Configurez votre véhicule de référence pour des calculs CO₂ plus précis
                 </Link>
                 <button
                   onClick={() => setVehiclePromptDismissed(true)}
@@ -128,9 +126,7 @@ export function DashboardPage() {
                 <div>
                   <div className="flex items-center justify-center gap-1">
                     <MapPin size={14} className="text-primary-light" />
-                    <span className="text-2xl font-black text-text">
-                      {today.tripCount}
-                    </span>
+                    <span className="text-2xl font-black text-text">{today.tripCount}</span>
                   </div>
                   <span className="text-xs font-bold uppercase text-text-muted">
                     {today.tripCount > 1 ? "trajets" : "trajet"}
@@ -143,9 +139,7 @@ export function DashboardPage() {
                       {today.totalDistanceKm.toFixed(1)}
                     </span>
                   </div>
-                  <span className="text-xs font-bold uppercase text-text-muted">
-                    km
-                  </span>
+                  <span className="text-xs font-bold uppercase text-text-muted">km</span>
                 </div>
                 <div>
                   <div className="flex items-center justify-center gap-1">
@@ -154,9 +148,7 @@ export function DashboardPage() {
                       {today.totalCo2SavedKg.toFixed(1)}
                     </span>
                   </div>
-                  <span className="text-xs font-bold uppercase text-text-muted">
-                    kg CO₂
-                  </span>
+                  <span className="text-xs font-bold uppercase text-text-muted">kg CO₂</span>
                 </div>
               </div>
             ) : (

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -52,7 +52,11 @@ export function LeaderboardPage() {
 
   if (isPending || !data) {
     return (
-      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
+      <div
+        className="flex flex-1 items-center justify-center"
+        role="status"
+        aria-label="Chargement"
+      >
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -66,20 +70,23 @@ export function LeaderboardPage() {
   return (
     <>
       {/* Header */}
-      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
         <span className="text-lg font-bold tracking-tight">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </span>
       </header>
 
       <div className="px-6 pb-6">
         {/* Title */}
         <section className="mb-10">
-          <h2 className="mb-2 text-4xl font-extrabold tracking-tighter">
-            Classement
-          </h2>
+          <h2 className="mb-2 text-4xl font-extrabold tracking-tighter">Classement</h2>
           <p className="text-sm font-medium text-text-dim">
-            {categorySubtitles[category]}{periodSuffixes[period] ?? ""}
+            {categorySubtitles[category]}
+            {periodSuffixes[period] ?? ""}
           </p>
 
           {/* Period switcher */}
@@ -134,123 +141,119 @@ export function LeaderboardPage() {
             </div>
           </div>
         ) : (
-        <>
-        {/* Podium */}
-        <section className="mb-12 grid grid-cols-3 items-end gap-4">
-          {/* Rank 2 */}
-          {top3[1] && (
-            <div className="flex flex-col items-center">
-              <div className="relative mb-3">
-                <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-2 border-text-dim bg-surface-high">
-                  <span className="text-2xl font-bold text-text-muted">
-                    {top3[1].name.charAt(0)}
-                  </span>
-                </div>
-                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-high text-xs font-bold text-text">
-                  2
-                </div>
-              </div>
-              <span className="w-full truncate text-center text-xs font-bold">
-                {top3[1].name}
-              </span>
-              <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                {top3[1].value} {unit}
-              </span>
-            </div>
-          )}
-
-          {/* Rank 1 */}
-          {top3[0] && (
-            <div className="flex flex-col items-center">
-              <div className="relative mb-4 scale-125">
-                <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-4 border-primary shadow-[0_0_30px_rgba(84,233,138,0.3)] bg-surface-high">
-                  <span className="text-3xl font-bold text-primary-light">
-                    {top3[0].name.charAt(0)}
-                  </span>
-                </div>
-                <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-full border-2 border-surface bg-primary text-xs font-black text-bg">
-                  1
-                </div>
-              </div>
-              <span className="mt-4 text-sm font-bold text-text">
-                {top3[0].name}
-              </span>
-              <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                {top3[0].value} {unit}
-              </span>
-            </div>
-          )}
-
-          {/* Rank 3 */}
-          {top3[2] && (
-            <div className="flex flex-col items-center">
-              <div className="relative mb-3">
-                <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-2 border-surface-highest bg-surface-high">
-                  <span className="text-2xl font-bold text-text-muted">
-                    {top3[2].name.charAt(0)}
-                  </span>
-                </div>
-                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-highest text-xs font-bold text-text-muted">
-                  3
-                </div>
-              </div>
-              <span className="w-full truncate text-center text-xs font-bold">
-                {top3[2].name}
-              </span>
-              <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                {top3[2].value} {unit}
-              </span>
-            </div>
-          )}
-        </section>
-
-        {/* Leaderboard List */}
-        <div className="space-y-3">
-          {rest.map((entry) => {
-            const isMe = entry.userId === currentUserId;
-            return (
-              <div
-                key={entry.userId}
-                className={`flex items-center gap-4 rounded-xl p-4 ${
-                  isMe
-                    ? "border-2 border-primary bg-surface-low shadow-[0_10px_30px_rgba(46,204,113,0.1)]"
-                    : "bg-surface-low hover:bg-surface-container"
-                } transition-colors`}
-              >
-                <span
-                  className={`w-6 text-sm font-black ${
-                    isMe ? "text-primary-light" : "text-text-dim"
-                  }`}
-                >
-                  {String(entry.rank).padStart(2, "0")}
-                </span>
-                <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg bg-surface-high">
-                  <span className="text-lg font-bold text-text-muted">
-                    {entry.name.charAt(0)}
-                  </span>
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <h4 className="text-sm font-bold">
-                      {isMe ? "Vous" : entry.name}
-                    </h4>
-                    {isMe && (
-                      <span className="rounded bg-primary/20 px-2 py-0.5 text-[9px] font-black uppercase tracking-wider text-primary-light">
-                        Moi
+          <>
+            {/* Podium */}
+            <section className="mb-12 grid grid-cols-3 items-end gap-4">
+              {/* Rank 2 */}
+              {top3[1] && (
+                <div className="flex flex-col items-center">
+                  <div className="relative mb-3">
+                    <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-2 border-text-dim bg-surface-high">
+                      <span className="text-2xl font-bold text-text-muted">
+                        {top3[1].name.charAt(0)}
                       </span>
-                    )}
+                    </div>
+                    <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-high text-xs font-bold text-text">
+                      2
+                    </div>
                   </div>
-                </div>
-                <div className="text-right">
-                  <span className="block text-sm font-black text-text">
-                    {entry.value} {unit.toLowerCase()}
+                  <span className="w-full truncate text-center text-xs font-bold">
+                    {top3[1].name}
+                  </span>
+                  <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
+                    {top3[1].value} {unit}
                   </span>
                 </div>
-              </div>
-            );
-          })}
-        </div>
-        </>
+              )}
+
+              {/* Rank 1 */}
+              {top3[0] && (
+                <div className="flex flex-col items-center">
+                  <div className="relative mb-4 scale-125">
+                    <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-4 border-primary shadow-[0_0_30px_rgba(84,233,138,0.3)] bg-surface-high">
+                      <span className="text-3xl font-bold text-primary-light">
+                        {top3[0].name.charAt(0)}
+                      </span>
+                    </div>
+                    <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-full border-2 border-surface bg-primary text-xs font-black text-bg">
+                      1
+                    </div>
+                  </div>
+                  <span className="mt-4 text-sm font-bold text-text">{top3[0].name}</span>
+                  <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
+                    {top3[0].value} {unit}
+                  </span>
+                </div>
+              )}
+
+              {/* Rank 3 */}
+              {top3[2] && (
+                <div className="flex flex-col items-center">
+                  <div className="relative mb-3">
+                    <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-2 border-surface-highest bg-surface-high">
+                      <span className="text-2xl font-bold text-text-muted">
+                        {top3[2].name.charAt(0)}
+                      </span>
+                    </div>
+                    <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full border-2 border-surface bg-surface-highest text-xs font-bold text-text-muted">
+                      3
+                    </div>
+                  </div>
+                  <span className="w-full truncate text-center text-xs font-bold">
+                    {top3[2].name}
+                  </span>
+                  <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
+                    {top3[2].value} {unit}
+                  </span>
+                </div>
+              )}
+            </section>
+
+            {/* Leaderboard List */}
+            <div className="space-y-3">
+              {rest.map((entry) => {
+                const isMe = entry.userId === currentUserId;
+                return (
+                  <div
+                    key={entry.userId}
+                    className={`flex items-center gap-4 rounded-xl p-4 ${
+                      isMe
+                        ? "border-2 border-primary bg-surface-low shadow-[0_10px_30px_rgba(46,204,113,0.1)]"
+                        : "bg-surface-low hover:bg-surface-container"
+                    } transition-colors`}
+                  >
+                    <span
+                      className={`w-6 text-sm font-black ${
+                        isMe ? "text-primary-light" : "text-text-dim"
+                      }`}
+                    >
+                      {String(entry.rank).padStart(2, "0")}
+                    </span>
+                    <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg bg-surface-high">
+                      <span className="text-lg font-bold text-text-muted">
+                        {entry.name.charAt(0)}
+                      </span>
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <h4 className="text-sm font-bold">{isMe ? "Vous" : entry.name}</h4>
+                        {isMe && (
+                          <span className="rounded bg-primary/20 px-2 py-0.5 text-[9px] font-black uppercase tracking-wider text-primary-light">
+                            Moi
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <span className="block text-sm font-black text-text">
+                        {entry.value} {unit.toLowerCase()}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
         )}
       </div>
     </>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -58,7 +58,8 @@ export function LoginPage() {
       <div className="mb-12 flex flex-col items-center gap-4">
         <img src={appLogo} alt="ecoRide" className="h-20 w-20 rounded-2xl" />
         <h1 className="text-4xl font-black tracking-tighter">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </h1>
         <p className="text-center text-sm text-text-muted">
           Suivez vos trajets vélo et vos économies CO₂
@@ -143,7 +144,9 @@ export function LoginPage() {
           </label>
 
           {error && (
-            <p role="alert" className="text-sm text-red-400">{error}</p>
+            <p role="alert" className="text-sm text-red-400">
+              {error}
+            </p>
           )}
 
           <button
@@ -151,11 +154,7 @@ export function LoginPage() {
             disabled={loading}
             className="mt-1 rounded-xl bg-primary py-3 font-bold text-black active:scale-95 disabled:opacity-50"
           >
-            {loading
-              ? "Chargement..."
-              : isRegister
-                ? "Créer un compte"
-                : "Se connecter"}
+            {loading ? "Chargement..." : isRegister ? "Créer un compte" : "Se connecter"}
           </button>
         </form>
 

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -8,13 +8,9 @@ export function NotFoundPage() {
         <Bike size={40} className="text-primary-light" />
       </div>
 
-      <p className="mt-8 text-8xl font-black tracking-tighter text-text-muted">
-        404
-      </p>
+      <p className="mt-8 text-8xl font-black tracking-tighter text-text-muted">404</p>
 
-      <h1 className="mt-4 text-2xl font-bold text-text">
-        Page introuvable
-      </h1>
+      <h1 className="mt-4 text-2xl font-bold text-text">Page introuvable</h1>
 
       <p className="mt-2 text-sm text-text-muted">
         La page que vous recherchez n'existe pas ou a été déplacée.
@@ -24,8 +20,7 @@ export function NotFoundPage() {
         to="/"
         className="mt-8 rounded-xl bg-primary px-8 py-3 font-bold text-black active:scale-95"
       >
-        Retour à{" "}
-        <span className="text-black/70">eco</span>
+        Retour à <span className="text-black/70">eco</span>
         <span className="text-black/90">Ride</span>
       </Link>
     </div>

--- a/client/src/pages/PrivacyPage.tsx
+++ b/client/src/pages/PrivacyPage.tsx
@@ -19,9 +19,7 @@ export function PrivacyPage() {
           <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15">
             <Shield size={24} className="text-primary-light" />
           </div>
-          <h1 className="text-2xl font-bold text-text">
-            Politique de confidentialit&eacute;
-          </h1>
+          <h1 className="text-2xl font-bold text-text">Politique de confidentialit&eacute;</h1>
         </div>
 
         <p className="mb-6 text-sm text-text-muted">
@@ -30,22 +28,23 @@ export function PrivacyPage() {
 
         {/* Sections */}
         <section className="mb-6">
-          <h2 className="mb-2 text-lg font-semibold text-text">
-            Donn&eacute;es collect&eacute;es
-          </h2>
+          <h2 className="mb-2 text-lg font-semibold text-text">Donn&eacute;es collect&eacute;es</h2>
           <ul className="list-inside list-disc space-y-1 text-sm text-text-muted">
             <li>Email et nom (via Google OAuth ou inscription par email)</li>
             <li>Traces GPS pendant les trajets enregistr&eacute;s</li>
-            <li>Pr&eacute;f&eacute;rences de v&eacute;hicule (type de v&eacute;lo, v&eacute;hicule de comparaison)</li>
+            <li>
+              Pr&eacute;f&eacute;rences de v&eacute;hicule (type de v&eacute;lo, v&eacute;hicule de
+              comparaison)
+            </li>
           </ul>
         </section>
 
         <section className="mb-6">
-          <h2 className="mb-2 text-lg font-semibold text-text">
-            H&eacute;bergement et partage
-          </h2>
+          <h2 className="mb-2 text-lg font-semibold text-text">H&eacute;bergement et partage</h2>
           <ul className="list-inside list-disc space-y-1 text-sm text-text-muted">
-            <li>Les donn&eacute;es sont stock&eacute;es sur un serveur auto-h&eacute;berg&eacute;</li>
+            <li>
+              Les donn&eacute;es sont stock&eacute;es sur un serveur auto-h&eacute;berg&eacute;
+            </li>
             <li>Aucune donn&eacute;e n'est partag&eacute;e avec des tiers</li>
           </ul>
         </section>
@@ -62,19 +61,19 @@ export function PrivacyPage() {
         </section>
 
         <section className="mb-6">
-          <h2 className="mb-2 text-lg font-semibold text-text">
-            Vos droits
-          </h2>
+          <h2 className="mb-2 text-lg font-semibold text-text">Vos droits</h2>
           <ul className="list-inside list-disc space-y-1 text-sm text-text-muted">
-            <li>Vous pouvez exporter vos donn&eacute;es &agrave; tout moment depuis votre profil</li>
-            <li>Vous pouvez supprimer votre compte et toutes vos donn&eacute;es depuis votre profil</li>
+            <li>
+              Vous pouvez exporter vos donn&eacute;es &agrave; tout moment depuis votre profil
+            </li>
+            <li>
+              Vous pouvez supprimer votre compte et toutes vos donn&eacute;es depuis votre profil
+            </li>
           </ul>
         </section>
 
         <section className="mb-6">
-          <h2 className="mb-2 text-lg font-semibold text-text">
-            Cookies
-          </h2>
+          <h2 className="mb-2 text-lg font-semibold text-text">Cookies</h2>
           <ul className="list-inside list-disc space-y-1 text-sm text-text-muted">
             <li>Cookies de session uniquement (Better Auth)</li>
             <li>Aucun cookie d'analyse ou de publicit&eacute;</li>
@@ -82,9 +81,7 @@ export function PrivacyPage() {
         </section>
 
         <section className="mb-8">
-          <h2 className="mb-2 text-lg font-semibold text-text">
-            Contact
-          </h2>
+          <h2 className="mb-2 text-lg font-semibold text-text">Contact</h2>
           <p className="text-sm text-text-muted">
             Pour toute question, ouvrez une{" "}
             <a

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -16,7 +16,14 @@ import {
 } from "lucide-react";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
-import { useProfile, useAchievements, useUpdateProfile, useFuelPrice, useDeleteAccount, useExportData } from "@/hooks/queries";
+import {
+  useProfile,
+  useAchievements,
+  useUpdateProfile,
+  useFuelPrice,
+  useDeleteAccount,
+  useExportData,
+} from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { signOut } from "@/lib/auth";
 
@@ -56,7 +63,11 @@ export function ProfilePage() {
 
   if (profileLoading || achievementsLoading || !user || !stats) {
     return (
-      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
+      <div
+        className="flex flex-1 items-center justify-center"
+        role="status"
+        aria-label="Chargement"
+      >
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -103,9 +114,13 @@ export function ProfilePage() {
   return (
     <>
       {/* Header */}
-      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
         <span className="text-xl font-bold tracking-tighter">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </span>
       </header>
 
@@ -126,9 +141,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-text">
-              {user.name}
-            </h1>
+            <h1 className="text-3xl font-bold tracking-tight text-text">{user.name}</h1>
             <div className="mt-1 inline-flex items-center rounded-full bg-primary/15 px-3 py-1 text-xs font-bold uppercase tracking-widest text-primary-light">
               Eco Rider
             </div>
@@ -145,58 +158,40 @@ export function ProfilePage() {
               <span className="text-5xl font-extrabold tracking-tighter text-text">
                 {stats.totalCo2SavedKg.toFixed(1)}
               </span>
-              <span className="text-xl font-bold uppercase text-text-dim">
-                kg
-              </span>
+              <span className="text-xl font-bold uppercase text-text-dim">kg</span>
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              Distance
-            </p>
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">Distance</p>
             <div className="mt-1 flex items-baseline gap-1">
               <span className="text-3xl font-bold text-text">
                 {Math.round(stats.totalDistanceKm)}
               </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                km
-              </span>
+              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">km</span>
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              Trajets
-            </p>
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">Trajets</p>
             <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-3xl font-bold text-text">
-                {stats.tripCount}
-              </span>
+              <span className="text-3xl font-bold text-text">{stats.tripCount}</span>
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              Carburant
-            </p>
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">Carburant</p>
             <div className="mt-1 flex items-baseline gap-1">
               <span className="text-3xl font-bold text-text">
                 {stats.totalFuelSavedL.toFixed(1)}
               </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                L
-              </span>
+              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">L</span>
             </div>
           </div>
           <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              Economisé
-            </p>
+            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">Economisé</p>
             <div className="mt-1 flex items-baseline gap-1">
               <span className="text-3xl font-bold text-text">
                 {stats.totalMoneySavedEur.toFixed(0)}
               </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                EUR
-              </span>
+              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">EUR</span>
             </div>
           </div>
         </section>
@@ -240,9 +235,7 @@ export function ProfilePage() {
               return (
                 <div
                   key={id}
-                  className={`flex flex-col items-center gap-2 ${
-                    !unlocked ? "opacity-40" : ""
-                  }`}
+                  className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
                 >
                   <div
                     className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
@@ -265,9 +258,7 @@ export function ProfilePage() {
         {/* Vehicle Form (collapsible) */}
         {showVehicle && (
           <section className="space-y-4 rounded-xl bg-surface-low p-6">
-            <h2 className="text-lg font-bold tracking-tight">
-              Véhicule de référence
-            </h2>
+            <h2 className="text-lg font-bold tracking-tight">Véhicule de référence</h2>
             <div className="space-y-3">
               <div>
                 <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
@@ -410,7 +401,9 @@ export function ProfilePage() {
                     <span className="text-xs text-text-dim">Non supporté par ce navigateur</span>
                   )}
                   {push.status === "denied" && (
-                    <span className="text-xs text-text-dim">Autorisation refusée dans les paramètres du navigateur</span>
+                    <span className="text-xs text-text-dim">
+                      Autorisation refusée dans les paramètres du navigateur
+                    </span>
                   )}
                   {push.status === "subscribed" && (
                     <span className="text-xs text-primary/70">Activées</span>
@@ -421,7 +414,11 @@ export function ProfilePage() {
                 <button
                   onClick={push.toggle}
                   disabled={push.busy}
-                  aria-label={push.status === "subscribed" ? "Désactiver les notifications" : "Activer les notifications"}
+                  aria-label={
+                    push.status === "subscribed"
+                      ? "Désactiver les notifications"
+                      : "Activer les notifications"
+                  }
                   className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
                     push.status === "subscribed" ? "bg-primary" : "bg-surface-high"
                   }`}
@@ -438,7 +435,6 @@ export function ProfilePage() {
                 </button>
               )}
             </div>
-
           </div>
 
           <button
@@ -473,9 +469,7 @@ export function ProfilePage() {
             </div>
           </button>
 
-          <p className="mt-4 text-center text-xs text-text-dim">
-            v{__APP_VERSION__}
-          </p>
+          <p className="mt-4 text-center text-xs text-text-dim">v{__APP_VERSION__}</p>
         </section>
       </div>
     </>

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -1,20 +1,20 @@
 import { useState, useMemo, useEffect } from "react";
 import { Bike, BarChart3, Trash2, X } from "lucide-react";
 import type { Trip } from "@ecoride/shared/types";
-import {
-  LineChart,
-  Line,
-  XAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { LineChart, Line, XAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { MapContainer, TileLayer, Polyline, useMap } from "react-leaflet";
 import type { LatLngTuple, LatLngBoundsExpression } from "leaflet";
 import L from "leaflet";
 import { BADGES } from "@ecoride/shared/types";
 import type { BadgeId } from "@ecoride/shared/types";
-import { useDashboardSummary, useTrips, useTrip, useWeeklyTrips, useAchievements, useDeleteTrip } from "@/hooks/queries";
+import {
+  useDashboardSummary,
+  useTrips,
+  useTrip,
+  useWeeklyTrips,
+  useAchievements,
+  useDeleteTrip,
+} from "@/hooks/queries";
 import { tripLabel } from "@/lib/trip-utils";
 
 type Period = "week" | "month" | "year";
@@ -132,7 +132,11 @@ export function StatsPage() {
 
   if (isPending || !s) {
     return (
-      <div className="flex flex-1 items-center justify-center" role="status" aria-label="Chargement">
+      <div
+        className="flex flex-1 items-center justify-center"
+        role="status"
+        aria-label="Chargement"
+      >
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
@@ -141,12 +145,14 @@ export function StatsPage() {
   return (
     <>
       {/* Header */}
-      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
-        <span className="text-lg font-bold tracking-tight text-primary-light">
-          Stats
-        </span>
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
+        <span className="text-lg font-bold tracking-tight text-primary-light">Stats</span>
         <span className="text-xl font-bold tracking-tighter">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </span>
       </header>
 
@@ -164,193 +170,185 @@ export function StatsPage() {
             </div>
           </div>
         ) : (
-        <>
-        {/* Monthly Totals */}
-        <section className="space-y-6">
-          <div className="flex items-end justify-between">
-            <div>
-              <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
-                Ce mois
-              </span>
-              <h2 className="text-3xl font-extrabold tracking-tight">
-                {new Date().toLocaleDateString("fr-FR", { month: "long", year: "numeric" })}
-              </h2>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            {/* Distance highlight */}
-            <div className="col-span-1 flex min-h-[160px] flex-col justify-between rounded-xl border border-outline-variant/10 bg-surface-low p-6 md:col-span-2">
-              <div className="flex items-start justify-between">
-                <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
-                  Distance Totale
-                </span>
-                <Bike size={22} className="text-primary-light" />
+          <>
+            {/* Monthly Totals */}
+            <section className="space-y-6">
+              <div className="flex items-end justify-between">
+                <div>
+                  <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                    Ce mois
+                  </span>
+                  <h2 className="text-3xl font-extrabold tracking-tight">
+                    {new Date().toLocaleDateString("fr-FR", { month: "long", year: "numeric" })}
+                  </h2>
+                </div>
               </div>
-              <div className="flex items-baseline gap-2">
-                <span className="text-6xl font-bold tracking-tighter">
-                  {Math.round(s.totalDistanceKm)}
-                </span>
-                <span className="text-xl font-bold text-on-surface-variant">
-                  KM
-                </span>
-              </div>
-            </div>
 
-            {/* CO2 */}
-            <div className="flex flex-col gap-4 rounded-xl border border-outline-variant/10 bg-surface-low p-6">
-              <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
-                CO₂ Économisé
-              </span>
-              <div className="flex items-baseline gap-2">
-                <span className="text-4xl font-bold tracking-tighter">
-                  {Math.round(s.totalCo2SavedKg)}
-                </span>
-                <span className="text-base font-bold text-primary-light">
-                  KG
-                </span>
-              </div>
-            </div>
-
-            {/* Money */}
-            <div className="flex flex-col gap-4 rounded-xl border border-outline-variant/10 bg-surface-low p-6">
-              <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
-                Économies
-              </span>
-              <div className="flex items-baseline gap-2">
-                <span className="text-4xl font-bold tracking-tighter">
-                  {Math.round(s.totalMoneySavedEur)}
-                </span>
-                <span className="text-base font-bold text-primary-light">
-                  €
-                </span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Chart Section */}
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
-              Évolution
-            </h3>
-          </div>
-
-          {/* Period switcher */}
-          <nav className="flex items-center border-b border-surface-low">
-            {(Object.keys(periodLabels) as Period[]).map((p) => (
-              <button
-                key={p}
-                onClick={() => setPeriod(p)}
-                className={`flex-1 py-3 text-sm font-medium transition-colors ${
-                  p === period
-                    ? "border-b-2 border-primary-light font-bold text-primary-light"
-                    : "text-text-muted hover:text-text"
-                }`}
-              >
-                {periodLabels[p]}
-              </button>
-            ))}
-          </nav>
-
-          {/* Metric switcher */}
-          <div className="flex gap-2">
-            {(Object.keys(metricLabels) as Metric[]).map((m) => (
-              <button
-                key={m}
-                onClick={() => setMetric(m)}
-                className={`rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
-                  m === metric
-                    ? "bg-primary/20 text-primary-light"
-                    : "bg-surface-high text-text-muted"
-                }`}
-              >
-                {m === "km" ? "KM" : m === "co2" ? "CO₂" : "€"}
-              </button>
-            ))}
-          </div>
-
-          {/* Line Chart */}
-          <div className="rounded-xl border border-outline-variant/10 bg-surface-low p-4">
-            <ResponsiveContainer width="100%" height={200}>
-              <LineChart data={weeklyData}>
-                <CartesianGrid stroke="#2e3842" strokeDasharray="3 3" vertical={false} />
-                <XAxis
-                  dataKey="day"
-                  tick={{ fill: "#8a9ba8", fontSize: 11, fontWeight: 600 }}
-                  axisLine={false}
-                  tickLine={false}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: "#283240",
-                    border: "1px solid #333e47",
-                    borderRadius: 8,
-                    fontSize: 12,
-                  }}
-                  labelStyle={{ color: "#8a9ba8", fontWeight: 600 }}
-                  itemStyle={{ color: "#2ecc71" }}
-                  formatter={(value) => [
-                    `${Number(value).toFixed(1)} ${metric === "km" ? "km" : metric === "co2" ? "kg" : "€"}`,
-                    metricLabels[metric],
-                  ]}
-                />
-                <Line
-                  type="monotone"
-                  dataKey={metric}
-                  stroke="#2ecc71"
-                  strokeWidth={2.5}
-                  dot={{ fill: "#2ecc71", r: 4, strokeWidth: 0 }}
-                  activeDot={{ r: 6, fill: "#54e98a", strokeWidth: 0 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        </section>
-
-        {/* Recent Activity */}
-        <section className="space-y-6">
-          <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
-            Activité récente
-          </h3>
-          <div className="space-y-3">
-            {trips.length === 0 && (
-              <p className="text-center text-sm text-text-muted">Aucun trajet enregistré</p>
-            )}
-            {trips.map((trip) => (
-              <button
-                key={trip.id}
-                onClick={() => setSelectedTrip(trip)}
-                className="flex w-full items-center justify-between rounded-xl border border-outline-variant/5 bg-surface-low p-4 text-left active:scale-[0.98] transition-transform"
-              >
-                <div className="flex items-center gap-4">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-surface-high">
-                    <Bike size={20} className="text-primary-light" />
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {/* Distance highlight */}
+                <div className="col-span-1 flex min-h-[160px] flex-col justify-between rounded-xl border border-outline-variant/10 bg-surface-low p-6 md:col-span-2">
+                  <div className="flex items-start justify-between">
+                    <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
+                      Distance Totale
+                    </span>
+                    <Bike size={22} className="text-primary-light" />
                   </div>
-                  <div>
-                    <p className="text-sm font-bold">{tripLabel(trip.startedAt)}</p>
-                    <p className="text-xs font-medium text-on-surface-variant">
-                      {new Date(trip.startedAt).toLocaleDateString("fr-FR", {
-                        day: "numeric",
-                        month: "short",
-                      })}
-                    </p>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-6xl font-bold tracking-tighter">
+                      {Math.round(s.totalDistanceKm)}
+                    </span>
+                    <span className="text-xl font-bold text-on-surface-variant">KM</span>
                   </div>
                 </div>
-                <div className="text-right">
-                  <p className="text-sm font-bold text-primary-light">
-                    +{trip.distanceKm} KM
-                  </p>
-                  <p className="text-xs font-bold uppercase tracking-tighter text-on-surface-variant">
-                    {trip.co2SavedKg.toFixed(1)} KG CO₂
-                  </p>
+
+                {/* CO2 */}
+                <div className="flex flex-col gap-4 rounded-xl border border-outline-variant/10 bg-surface-low p-6">
+                  <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
+                    CO₂ Économisé
+                  </span>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-4xl font-bold tracking-tighter">
+                      {Math.round(s.totalCo2SavedKg)}
+                    </span>
+                    <span className="text-base font-bold text-primary-light">KG</span>
+                  </div>
                 </div>
-              </button>
-            ))}
-          </div>
-        </section>
-        </>
+
+                {/* Money */}
+                <div className="flex flex-col gap-4 rounded-xl border border-outline-variant/10 bg-surface-low p-6">
+                  <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
+                    Économies
+                  </span>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-4xl font-bold tracking-tighter">
+                      {Math.round(s.totalMoneySavedEur)}
+                    </span>
+                    <span className="text-base font-bold text-primary-light">€</span>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* Chart Section */}
+            <section className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+                  Évolution
+                </h3>
+              </div>
+
+              {/* Period switcher */}
+              <nav className="flex items-center border-b border-surface-low">
+                {(Object.keys(periodLabels) as Period[]).map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setPeriod(p)}
+                    className={`flex-1 py-3 text-sm font-medium transition-colors ${
+                      p === period
+                        ? "border-b-2 border-primary-light font-bold text-primary-light"
+                        : "text-text-muted hover:text-text"
+                    }`}
+                  >
+                    {periodLabels[p]}
+                  </button>
+                ))}
+              </nav>
+
+              {/* Metric switcher */}
+              <div className="flex gap-2">
+                {(Object.keys(metricLabels) as Metric[]).map((m) => (
+                  <button
+                    key={m}
+                    onClick={() => setMetric(m)}
+                    className={`rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                      m === metric
+                        ? "bg-primary/20 text-primary-light"
+                        : "bg-surface-high text-text-muted"
+                    }`}
+                  >
+                    {m === "km" ? "KM" : m === "co2" ? "CO₂" : "€"}
+                  </button>
+                ))}
+              </div>
+
+              {/* Line Chart */}
+              <div className="rounded-xl border border-outline-variant/10 bg-surface-low p-4">
+                <ResponsiveContainer width="100%" height={200}>
+                  <LineChart data={weeklyData}>
+                    <CartesianGrid stroke="#2e3842" strokeDasharray="3 3" vertical={false} />
+                    <XAxis
+                      dataKey="day"
+                      tick={{ fill: "#8a9ba8", fontSize: 11, fontWeight: 600 }}
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: "#283240",
+                        border: "1px solid #333e47",
+                        borderRadius: 8,
+                        fontSize: 12,
+                      }}
+                      labelStyle={{ color: "#8a9ba8", fontWeight: 600 }}
+                      itemStyle={{ color: "#2ecc71" }}
+                      formatter={(value) => [
+                        `${Number(value).toFixed(1)} ${metric === "km" ? "km" : metric === "co2" ? "kg" : "€"}`,
+                        metricLabels[metric],
+                      ]}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey={metric}
+                      stroke="#2ecc71"
+                      strokeWidth={2.5}
+                      dot={{ fill: "#2ecc71", r: 4, strokeWidth: 0 }}
+                      activeDot={{ r: 6, fill: "#54e98a", strokeWidth: 0 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+
+            {/* Recent Activity */}
+            <section className="space-y-6">
+              <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+                Activité récente
+              </h3>
+              <div className="space-y-3">
+                {trips.length === 0 && (
+                  <p className="text-center text-sm text-text-muted">Aucun trajet enregistré</p>
+                )}
+                {trips.map((trip) => (
+                  <button
+                    key={trip.id}
+                    onClick={() => setSelectedTrip(trip)}
+                    className="flex w-full items-center justify-between rounded-xl border border-outline-variant/5 bg-surface-low p-4 text-left active:scale-[0.98] transition-transform"
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-surface-high">
+                        <Bike size={20} className="text-primary-light" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-bold">{tripLabel(trip.startedAt)}</p>
+                        <p className="text-xs font-medium text-on-surface-variant">
+                          {new Date(trip.startedAt).toLocaleDateString("fr-FR", {
+                            day: "numeric",
+                            month: "short",
+                          })}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-sm font-bold text-primary-light">+{trip.distanceKm} KM</p>
+                      <p className="text-xs font-bold uppercase tracking-tighter text-on-surface-variant">
+                        {trip.co2SavedKg.toFixed(1)} KG CO₂
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </section>
+          </>
         )}
 
         {/* Badges */}
@@ -361,15 +359,11 @@ export function StatsPage() {
           <div className="grid grid-cols-4 gap-4">
             {allBadgeIds.map((id) => {
               const badge = BADGES[id];
-              const unlocked = (achievements ?? []).some(
-                (a) => a.badgeId === id,
-              );
+              const unlocked = (achievements ?? []).some((a) => a.badgeId === id);
               return (
                 <div
                   key={id}
-                  className={`flex flex-col items-center gap-2 ${
-                    !unlocked ? "opacity-40" : ""
-                  }`}
+                  className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
                 >
                   <div
                     className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
@@ -446,11 +440,15 @@ export function StatsPage() {
                 <p className="text-xs font-bold uppercase text-text-muted">km</p>
               </div>
               <div>
-                <p className="text-xl font-bold text-primary-light">{selectedTrip.co2SavedKg.toFixed(1)}</p>
+                <p className="text-xl font-bold text-primary-light">
+                  {selectedTrip.co2SavedKg.toFixed(1)}
+                </p>
                 <p className="text-xs font-bold uppercase text-text-muted">kg CO₂</p>
               </div>
               <div>
-                <p className="text-xl font-bold text-primary-light">{selectedTrip.moneySavedEur.toFixed(2)}</p>
+                <p className="text-xl font-bold text-primary-light">
+                  {selectedTrip.moneySavedEur.toFixed(2)}
+                </p>
                 <p className="text-xs font-bold uppercase text-text-muted">€</p>
               </div>
             </div>

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -30,7 +30,9 @@ export function TripPage() {
   const [saveError, setSaveError] = useState("");
   const [manualMinutes, setManualMinutes] = useState("");
   const [initialPos, setInitialPos] = useState<[number, number]>(DEFAULT_CENTER);
-  const [gpsStatus, setGpsStatus] = useState<"waiting" | "active" | "denied" | "unavailable">("waiting");
+  const [gpsStatus, setGpsStatus] = useState<"waiting" | "active" | "denied" | "unavailable">(
+    "waiting",
+  );
   const [idleAccuracy, setIdleAccuracy] = useState<number | null>(null);
   const [pendingBackup, setPendingBackup] = useState<TrackingBackup | null>(null);
   const sessionRef = useRef<TrackingSession | null>(null);
@@ -87,12 +89,14 @@ export function TripPage() {
   const lastPos = positions.length > 0 ? positions[positions.length - 1] : undefined;
   const currentPos: [number, number] = lastPos ?? initialPos;
 
-  const distance = uiState === "stopped" && sessionRef.current
-    ? sessionRef.current.distanceKm
-    : gps.state.distanceKm;
-  const elapsed = uiState === "stopped" && sessionRef.current
-    ? sessionRef.current.durationSec
-    : gps.state.durationSec;
+  const distance =
+    uiState === "stopped" && sessionRef.current
+      ? sessionRef.current.distanceKm
+      : gps.state.distanceKm;
+  const elapsed =
+    uiState === "stopped" && sessionRef.current
+      ? sessionRef.current.durationSec
+      : gps.state.durationSec;
 
   const startTracking = () => {
     sessionRef.current = null;
@@ -131,7 +135,9 @@ export function TripPage() {
   const handleSaveTrip = (km: number, durationSec: number, session?: TrackingSession | null) => {
     setSaveError("");
     const endedAt = session?.endedAt ?? new Date().toISOString();
-    const startedAt = session?.startedAt ?? new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
+    const startedAt =
+      session?.startedAt ??
+      new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
     const tripData = {
       distanceKm: Math.round(km * 100) / 100,
       durationSec,
@@ -139,40 +145,41 @@ export function TripPage() {
       endedAt,
       gpsPoints: session?.gpsPoints?.length ? session.gpsPoints : null,
     };
-    createTrip.mutate(
-      tripData,
-      {
-        onSuccess: () => {
-          setSaveError("");
+    createTrip.mutate(tripData, {
+      onSuccess: () => {
+        setSaveError("");
+        setUiState("idle");
+        setManualKm("");
+        setManualMinutes("");
+        sessionRef.current = null;
+        gps.reset();
+      },
+      onError: () => {
+        queueTrip(tripData);
+        setSaveError("Trajet sauvegardé hors-ligne. Il sera envoyé automatiquement.");
+        // Reset UI to idle after a short delay so the user sees the message
+        setTimeout(() => {
           setUiState("idle");
           setManualKm("");
           setManualMinutes("");
           sessionRef.current = null;
           gps.reset();
-        },
-        onError: () => {
-          queueTrip(tripData);
-          setSaveError("Trajet sauvegardé hors-ligne. Il sera envoyé automatiquement.");
-          // Reset UI to idle after a short delay so the user sees the message
-          setTimeout(() => {
-            setUiState("idle");
-            setManualKm("");
-            setManualMinutes("");
-            sessionRef.current = null;
-            gps.reset();
-            setSaveError("");
-          }, 3000);
-        },
+          setSaveError("");
+        }, 3000);
       },
-    );
+    });
   };
 
   return (
     <div className="relative flex h-full flex-col">
       {/* Header with persistent GPS indicator */}
-      <header role="banner" className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl">
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
         <span className="text-lg font-bold tracking-tight">
-          <span className="text-text">eco</span><span className="text-primary-light">Ride</span>
+          <span className="text-text">eco</span>
+          <span className="text-primary-light">Ride</span>
         </span>
         {(() => {
           // During tracking, use GPS hook state; otherwise use idle watcher
@@ -182,17 +189,18 @@ export function TripPage() {
           const isUnavailable = gpsStatus === "unavailable";
           const isWaiting = gpsStatus === "waiting" && uiState !== "tracking";
 
-          const color = isDenied || isUnavailable
-            ? "#FF4D4D"
-            : isWaiting
-              ? "#9ca3af"
-              : !isActive || accuracy == null
+          const color =
+            isDenied || isUnavailable
+              ? "#FF4D4D"
+              : isWaiting
                 ? "#9ca3af"
-                : accuracy < 10
-                  ? "#2ecc71"
-                  : accuracy < 30
-                    ? "#FFB800"
-                    : "#FF4D4D";
+                : !isActive || accuracy == null
+                  ? "#9ca3af"
+                  : accuracy < 10
+                    ? "#2ecc71"
+                    : accuracy < 30
+                      ? "#FFB800"
+                      : "#FF4D4D";
 
           const label = isDenied
             ? "GPS refusé"
@@ -229,8 +237,8 @@ export function TripPage() {
           <RotateCcw size={16} className="shrink-0 text-primary-light" />
           <div className="flex-1">
             <span className="text-sm font-medium text-primary-light">
-              Un trajet en cours a été interrompu.{" "}
-              {pendingBackup.distanceKm.toFixed(1)} km — {formatTime(pendingBackup.durationSec)}
+              Un trajet en cours a été interrompu. {pendingBackup.distanceKm.toFixed(1)} km —{" "}
+              {formatTime(pendingBackup.durationSec)}
             </span>
           </div>
           <button
@@ -369,26 +377,16 @@ export function TripPage() {
             <h2 className="mb-4 text-lg font-bold">Trajet terminé</h2>
             <div className="grid grid-cols-3 gap-4 text-center">
               <div>
-                <div className="text-2xl font-black text-primary-light">
-                  {distance.toFixed(1)}
-                </div>
+                <div className="text-2xl font-black text-primary-light">{distance.toFixed(1)}</div>
                 <div className="text-xs font-bold uppercase text-text-muted">km</div>
               </div>
               <div>
-                <div className="text-2xl font-black text-primary-light">
-                  {co2Saved.toFixed(1)}
-                </div>
-                <div className="text-xs font-bold uppercase text-text-muted">
-                  kg CO₂
-                </div>
+                <div className="text-2xl font-black text-primary-light">{co2Saved.toFixed(1)}</div>
+                <div className="text-xs font-bold uppercase text-text-muted">kg CO₂</div>
               </div>
               <div>
-                <div className="text-2xl font-black text-primary-light">
-                  {formatTime(elapsed)}
-                </div>
-                <div className="text-xs font-bold uppercase text-text-muted">
-                  durée
-                </div>
+                <div className="text-2xl font-black text-primary-light">{formatTime(elapsed)}</div>
+                <div className="text-xs font-bold uppercase text-text-muted">durée</div>
               </div>
             </div>
             <div className="mt-6 flex gap-3">
@@ -504,18 +502,14 @@ export function TripPage() {
             className="flex w-full items-center justify-center gap-4 rounded-xl bg-primary py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95 disabled:opacity-50"
           >
             <Play size={28} className="text-bg" fill="currentColor" />
-            <span className="text-xl font-black uppercase tracking-widest text-bg">
-              Démarrer
-            </span>
+            <span className="text-xl font-black uppercase tracking-widest text-bg">Démarrer</span>
           </button>
           <button
             onClick={() => setUiState("manual")}
             className="flex w-full items-center justify-center gap-3 rounded-xl bg-surface-container py-4 active:scale-95"
           >
             <Keyboard size={18} className="text-text-muted" />
-            <span className="text-sm font-bold text-text-muted">
-              Saisie manuelle
-            </span>
+            <span className="text-sm font-bold text-text-muted">Saisie manuelle</span>
           </button>
         </div>
       )}
@@ -527,9 +521,7 @@ export function TripPage() {
             className="flex w-full items-center justify-center gap-4 rounded-xl bg-danger py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95"
           >
             <Square size={28} className="text-text" fill="currentColor" />
-            <span className="text-xl font-black uppercase tracking-widest text-text">
-              Terminer
-            </span>
+            <span className="text-xl font-black uppercase tracking-widest text-text">Terminer</span>
           </button>
         </div>
       )}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,8 +4,11 @@ import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
 const pkgVersion = (() => {
-  try { return require("../package.json").version; }
-  catch { return "0.0.0"; }
+  try {
+    return require("../package.json").version;
+  } catch {
+    return "0.0.0";
+  }
 })();
 
 const gitHash = (() => {
@@ -40,11 +43,26 @@ export default defineConfig({
         icons: [
           { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
           { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
-          { src: "pwa-maskable-512x512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
+          {
+            src: "pwa-maskable-512x512.png",
+            sizes: "512x512",
+            type: "image/png",
+            purpose: "maskable",
+          },
         ],
         shortcuts: [
-          { name: "Démarrer un trajet", short_name: "Trajet", url: "/trip", icons: [{ src: "pwa-192x192.png", sizes: "192x192" }] },
-          { name: "Voir les stats", short_name: "Stats", url: "/stats", icons: [{ src: "pwa-192x192.png", sizes: "192x192" }] },
+          {
+            name: "Démarrer un trajet",
+            short_name: "Trajet",
+            url: "/trip",
+            icons: [{ src: "pwa-192x192.png", sizes: "192x192" }],
+          },
+          {
+            name: "Voir les stats",
+            short_name: "Stats",
+            url: "/stats",
+            icons: [{ src: "pwa-192x192.png", sizes: "192x192" }],
+          },
         ],
       },
       workbox: {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'vitest/config'
-import path from 'node:path'
+import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      "@": path.resolve(__dirname, "src"),
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    exclude: ['e2e/**', 'node_modules/**'],
+    exclude: ["e2e/**", "node_modules/**"],
   },
-})
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,83 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import eslintConfigPrettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  // Global ignores
+  {
+    ignores: [
+      "**/node_modules/",
+      "**/dist/",
+      ".claude/",
+      "design/",
+      "**/*.js",
+      "!eslint.config.js",
+    ],
+  },
+
+  // Base JS recommended rules
+  js.configs.recommended,
+
+  // TypeScript recommended (type-aware off — faster)
+  ...tseslint.configs.recommended,
+
+  // Prettier — disables formatting rules that conflict
+  eslintConfigPrettier,
+
+  // Shared rules for all TS files
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/consistent-type-imports": "warn",
+      "no-console": ["warn", { allow: ["warn", "error", "info"] }],
+    },
+  },
+
+  // Server — relax console & require rules
+  {
+    files: ["server/**/*.{ts,tsx}"],
+    rules: {
+      "no-console": "off",
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+
+  // Config files — allow require()
+  {
+    files: ["*.config.{ts,js}", "client/vite.config.ts", "drizzle.config.ts"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+
+  // Test files — relax rules
+  {
+    files: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/e2e/**/*.{ts,tsx}"],
+    rules: {
+      "no-console": "off",
+    },
+  },
+
+  // React-specific rules (client only)
+  {
+    files: ["client/**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/immutability": "warn",
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -15,16 +15,39 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "typecheck": "bun run --filter '*' typecheck"
+    "typecheck": "bun run --filter '*' typecheck",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,css}": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
     "@testing-library/react": "^16.3.2",
     "@types/bun": "^1.2.0",
     "client": "workspace:*",
     "drizzle-kit": "^0.30.0",
+    "eslint": "^10.1.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "husky": "^9.1.7",
     "jsdom": "^29.0.1",
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.8.1",
     "typescript": "^5.8.0",
+    "typescript-eslint": "^8.57.1",
     "vitest": "^4.1.0"
   }
 }

--- a/server/src/cron/index.ts
+++ b/server/src/cron/index.ts
@@ -3,7 +3,7 @@ import { processReminders } from "./push-reminders";
 
 export function initCronJobs(): void {
   // Run push reminder check every minute
-  const reminderJob = new Cron("* * * * *", { protect: true }, async () => {
+  const _reminderJob = new Cron("* * * * *", { protect: true }, async () => {
     try {
       await processReminders();
     } catch (err) {

--- a/server/src/db/schema/achievements.ts
+++ b/server/src/db/schema/achievements.ts
@@ -1,12 +1,20 @@
 import { pgTable, text, timestamp, index, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const achievements = pgTable("achievements", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
-  badgeId: text("badge_id").notNull(),
-  unlockedAt: timestamp("unlocked_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
-}, (table) => [
-  index("achievements_user_id_idx").on(table.userId),
-  uniqueIndex("achievements_user_badge_idx").on(table.userId, table.badgeId),
-]);
+export const achievements = pgTable(
+  "achievements",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    badgeId: text("badge_id").notNull(),
+    unlockedAt: timestamp("unlocked_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("achievements_user_id_idx").on(table.userId),
+    uniqueIndex("achievements_user_badge_idx").on(table.userId, table.badgeId),
+  ],
+);

--- a/server/src/db/schema/auth.ts
+++ b/server/src/db/schema/auth.ts
@@ -30,7 +30,9 @@ export const session = pgTable("session", {
   token: text("token").notNull().unique(),
   ipAddress: text("ip_address"),
   userAgent: text("user_agent"),
-  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
 });
@@ -40,12 +42,17 @@ export const account = pgTable("account", {
   id: text("id").primaryKey(),
   accountId: text("account_id").notNull(),
   providerId: text("provider_id").notNull(),
-  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
   accessToken: text("access_token"),
   refreshToken: text("refresh_token"),
   idToken: text("id_token"),
   accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true, mode: "date" }),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true, mode: "date" }),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+    withTimezone: true,
+    mode: "date",
+  }),
   scope: text("scope"),
   password: text("password"),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),

--- a/server/src/db/schema/push-subscriptions.ts
+++ b/server/src/db/schema/push-subscriptions.ts
@@ -1,13 +1,17 @@
 import { pgTable, text, timestamp, index, uuid } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const pushSubscriptions = pgTable("push_subscriptions", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
-  endpoint: text("endpoint").notNull(),
-  p256dh: text("p256dh").notNull(),
-  auth: text("auth").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
-}, (table) => [
-  index("push_subscriptions_user_id_idx").on(table.userId),
-]);
+export const pushSubscriptions = pgTable(
+  "push_subscriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    endpoint: text("endpoint").notNull(),
+    p256dh: text("p256dh").notNull(),
+    auth: text("auth").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [index("push_subscriptions_user_id_idx").on(table.userId)],
+);

--- a/server/src/db/schema/trips.ts
+++ b/server/src/db/schema/trips.ts
@@ -1,24 +1,30 @@
 import { pgTable, text, real, integer, timestamp, jsonb, index, uuid } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const trips = pgTable("trips", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+export const trips = pgTable(
+  "trips",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
 
-  distanceKm: real("distance_km").notNull(),
-  durationSec: integer("duration_sec").notNull(),
+    distanceKm: real("distance_km").notNull(),
+    durationSec: integer("duration_sec").notNull(),
 
-  co2SavedKg: real("co2_saved_kg").notNull(),
-  moneySavedEur: real("money_saved_eur").notNull(),
-  fuelSavedL: real("fuel_saved_l").notNull(),
-  fuelPriceEur: real("fuel_price_eur"),
+    co2SavedKg: real("co2_saved_kg").notNull(),
+    moneySavedEur: real("money_saved_eur").notNull(),
+    fuelSavedL: real("fuel_saved_l").notNull(),
+    fuelPriceEur: real("fuel_price_eur"),
 
-  startedAt: timestamp("started_at", { withTimezone: true, mode: "date" }).notNull(),
-  endedAt: timestamp("ended_at", { withTimezone: true, mode: "date" }).notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true, mode: "date" }).notNull(),
+    endedAt: timestamp("ended_at", { withTimezone: true, mode: "date" }).notNull(),
 
-  gpsPoints: jsonb("gps_points"), // GpsPoint[] | null
-  idempotencyKey: text("idempotency_key"),
-}, (table) => [
-  index("trips_user_id_idx").on(table.userId),
-  index("trips_started_at_idx").on(table.startedAt),
-]);
+    gpsPoints: jsonb("gps_points"), // GpsPoint[] | null
+    idempotencyKey: text("idempotency_key"),
+  },
+  (table) => [
+    index("trips_user_id_idx").on(table.userId),
+    index("trips_started_at_idx").on(table.startedAt),
+  ],
+);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -30,18 +30,24 @@ app.use("*", async (c, next) => {
 });
 
 // ---- CORS for auth routes (before handler, with explicit methods) ----
-app.use("/api/auth/*", cors({
-  origin: env.FRONTEND_URL,
-  allowHeaders: ["Content-Type", "Authorization"],
-  allowMethods: ["POST", "GET", "OPTIONS"],
-  credentials: true,
-}));
+app.use(
+  "/api/auth/*",
+  cors({
+    origin: env.FRONTEND_URL,
+    allowHeaders: ["Content-Type", "Authorization"],
+    allowMethods: ["POST", "GET", "OPTIONS"],
+    credentials: true,
+  }),
+);
 
 // ---- CORS for other API routes ----
-app.use("/api/*", cors({
-  origin: [env.FRONTEND_URL],
-  credentials: true,
-}));
+app.use(
+  "/api/*",
+  cors({
+    origin: [env.FRONTEND_URL],
+    credentials: true,
+  }),
+);
 
 // ---- Rate limiting for all API routes (100 req/min per IP) ----
 app.use("/api/*", rateLimit({ maxRequests: 100, prefix: "api" }));
@@ -54,8 +60,11 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
 
 // ---- Health check + version (public) ----
 const appVersion = (() => {
-  try { return require("../../package.json").version; }
-  catch { return "unknown"; }
+  try {
+    return require("../../package.json").version;
+  } catch {
+    return "unknown";
+  }
 })();
 app.get("/api/health", (c) => c.json({ ok: true, status: "healthy", version: appVersion }));
 
@@ -68,23 +77,32 @@ app.route("/api", apiRouter);
 // ---- Global error handler ----
 app.onError((err, c) => {
   if (err instanceof AppError) {
-    return c.json({
-      ok: false,
-      error: { code: err.code, message: err.message },
-      ...(err.details ? { details: err.details } : {}),
-    }, err.status);
+    return c.json(
+      {
+        ok: false,
+        error: { code: err.code, message: err.message },
+        ...(err.details ? { details: err.details } : {}),
+      },
+      err.status,
+    );
   }
   if (err instanceof HTTPException) {
-    return c.json({
-      ok: false,
-      error: { code: "INTERNAL_ERROR", message: err.message },
-    }, err.status);
+    return c.json(
+      {
+        ok: false,
+        error: { code: "INTERNAL_ERROR", message: err.message },
+      },
+      err.status,
+    );
   }
   console.error("[UNHANDLED]", err);
-  return c.json({
-    ok: false,
-    error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
-  }, 500);
+  return c.json(
+    {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+    },
+    500,
+  );
 });
 
 // ---- Static files & SPA fallback (production) ----
@@ -113,10 +131,13 @@ if (env.NODE_ENV === "production") {
 
 // ---- 404 handler ----
 app.notFound((c) => {
-  return c.json({
-    ok: false,
-    error: { code: "NOT_FOUND", message: `Route not found: ${c.req.method} ${c.req.path}` },
-  }, 404);
+  return c.json(
+    {
+      ok: false,
+      error: { code: "NOT_FOUND", message: `Route not found: ${c.req.method} ${c.req.path}` },
+    },
+    404,
+  );
 });
 
 // ---- Cron jobs ----

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -16,18 +16,18 @@ interface UserStats {
 }
 
 const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
-  first_trip:  (s) => s.tripCount >= 1,
-  trips_10:    (s) => s.tripCount >= 10,
-  trips_50:    (s) => s.tripCount >= 50,
-  trips_100:   (s) => s.tripCount >= 100,
-  km_100:      (s) => s.totalDistanceKm >= 100,
-  km_500:      (s) => s.totalDistanceKm >= 500,
-  km_1000:     (s) => s.totalDistanceKm >= 1000,
-  co2_10kg:    (s) => s.totalCo2SavedKg >= 10,
-  co2_100kg:   (s) => s.totalCo2SavedKg >= 100,
-  co2_1t:      (s) => s.totalCo2SavedKg >= 1000,
-  streak_7:    (s) => s.currentStreak >= 7,
-  streak_30:   (s) => s.currentStreak >= 30,
+  first_trip: (s) => s.tripCount >= 1,
+  trips_10: (s) => s.tripCount >= 10,
+  trips_50: (s) => s.tripCount >= 50,
+  trips_100: (s) => s.tripCount >= 100,
+  km_100: (s) => s.totalDistanceKm >= 100,
+  km_500: (s) => s.totalDistanceKm >= 500,
+  km_1000: (s) => s.totalDistanceKm >= 1000,
+  co2_10kg: (s) => s.totalCo2SavedKg >= 10,
+  co2_100kg: (s) => s.totalCo2SavedKg >= 100,
+  co2_1t: (s) => s.totalCo2SavedKg >= 1000,
+  streak_7: (s) => s.currentStreak >= 7,
+  streak_30: (s) => s.currentStreak >= 30,
 };
 
 /**
@@ -67,7 +67,10 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
   // 3. Determine which badges are newly earned
   const newlyUnlocked: BadgeId[] = [];
 
-  for (const [badgeId, check] of Object.entries(BADGE_THRESHOLDS) as [BadgeId, (s: UserStats) => boolean][]) {
+  for (const [badgeId, check] of Object.entries(BADGE_THRESHOLDS) as [
+    BadgeId,
+    (s: UserStats) => boolean,
+  ][]) {
     if (!unlockedSet.has(badgeId) && check(userStats)) {
       newlyUnlocked.push(badgeId);
     }
@@ -131,12 +134,7 @@ export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
   if (revoked.length > 0) {
     await db
       .delete(achievements)
-      .where(
-        and(
-          eq(achievements.userId, userId),
-          inArray(achievements.badgeId, revoked),
-        ),
-      );
+      .where(and(eq(achievements.userId, userId), inArray(achievements.badgeId, revoked)));
   }
 
   return revoked;

--- a/server/src/lib/fuel-price.ts
+++ b/server/src/lib/fuel-price.ts
@@ -54,7 +54,10 @@ export async function getFuelPrice(
     });
 
     if (lat !== undefined && lng !== undefined) {
-      params.set("where", `${params.get("where")} AND within_distance(geom, GEOM'POINT(${lng} ${lat})', 20km)`);
+      params.set(
+        "where",
+        `${params.get("where")} AND within_distance(geom, GEOM'POINT(${lng} ${lat})', 20km)`,
+      );
       params.set("order_by", `distance(geom, GEOM'POINT(${lng} ${lat})')`);
     }
 
@@ -65,7 +68,7 @@ export async function getFuelPrice(
       throw new Error(`API responded ${response.status}`);
     }
 
-    const data = await response.json() as {
+    const data = (await response.json()) as {
       results: Array<{
         nom_ev?: string;
         prix_valeur?: number;
@@ -86,7 +89,10 @@ export async function getFuelPrice(
       return result;
     }
   } catch (err) {
-    console.warn("[fuel-price] API fetch failed, using fallback:", err instanceof Error ? err.message : err);
+    console.warn(
+      "[fuel-price] API fetch failed, using fallback:",
+      err instanceof Error ? err.message : err,
+    );
   }
 
   // Fallback to national average

--- a/server/src/lib/rate-limit.ts
+++ b/server/src/lib/rate-limit.ts
@@ -10,14 +10,17 @@ interface RateLimitEntry {
 const store = new Map<string, RateLimitEntry>();
 
 // Clean up expired entries every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of store) {
-    if (entry.resetAt <= now) {
-      store.delete(key);
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (entry.resetAt <= now) {
+        store.delete(key);
+      }
     }
-  }
-}, 5 * 60 * 1000);
+  },
+  5 * 60 * 1000,
+);
 
 /**
  * Extract client IP from request, accounting for reverse proxies.

--- a/server/src/lib/streaks.ts
+++ b/server/src/lib/streaks.ts
@@ -58,9 +58,7 @@ export async function computeStreak(
     const d = dates[i]!;
     if (i === 0) {
       // Streak counts only if the most recent trip was today or yesterday
-      const diffDays = Math.floor(
-        (new Date(today).getTime() - new Date(d).getTime()) / 86400000,
-      );
+      const diffDays = Math.floor((new Date(today).getTime() - new Date(d).getTime()) / 86400000);
       if (diffDays > 1) {
         current = 0;
         streak = 1;

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -10,13 +10,16 @@ export function validationHook(
   c: Context,
 ) {
   if (!result.success) {
-    return c.json({
-      ok: false,
-      error: {
-        code: "VALIDATION_ERROR" as const,
-        message: "Validation failed",
+    return c.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR" as const,
+          message: "Validation failed",
+        },
+        details: result.error!.flatten().fieldErrors,
       },
-      details: result.error!.flatten().fieldErrors,
-    }, 400);
+      400,
+    );
   }
 }

--- a/server/src/routes/fuel-price.routes.ts
+++ b/server/src/routes/fuel-price.routes.ts
@@ -15,23 +15,19 @@ const fuelPriceQuery = z.object({
 const fuelPriceRouter = new Hono<AuthEnv>();
 
 // GET /api/fuel-price
-fuelPriceRouter.get(
-  "/",
-  zValidator("query", fuelPriceQuery, validationHook),
-  async (c) => {
-    const { type, lat, lng } = c.req.valid("query");
-    const result = await getFuelPrice(type as "sp95" | "sp98" | "diesel" | "e85" | "gpl", lat, lng);
+fuelPriceRouter.get("/", zValidator("query", fuelPriceQuery, validationHook), async (c) => {
+  const { type, lat, lng } = c.req.valid("query");
+  const result = await getFuelPrice(type as "sp95" | "sp98" | "diesel" | "e85" | "gpl", lat, lng);
 
-    return c.json({
-      ok: true,
-      data: {
-        priceEur: result.priceEur,
-        fuelType: result.fuelType,
-        stationName: result.stationName,
-        updatedAt: result.updatedAt,
-      },
-    });
-  },
-);
+  return c.json({
+    ok: true,
+    data: {
+      priceEur: result.priceEur,
+      fuelType: result.fuelType,
+      stationName: result.stationName,
+      updatedAt: result.updatedAt,
+    },
+  });
+});
 
 export { fuelPriceRouter };

--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -19,15 +19,18 @@ function getPeriodStart(period: StatsPeriod): Date | null {
   if (period === "all") return null;
   const now = new Date();
   switch (period) {
-    case "day": return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    case "day":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
     case "week": {
       const d = new Date(now);
       d.setDate(d.getDate() - d.getDay() + 1); // Monday
       d.setHours(0, 0, 0, 0);
       return d;
     }
-    case "month": return new Date(now.getFullYear(), now.getMonth(), 1);
-    case "year": return new Date(now.getFullYear(), 0, 1);
+    case "month":
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+    case "year":
+      return new Date(now.getFullYear(), 0, 1);
   }
 }
 
@@ -83,199 +86,198 @@ export function computeAvgSpeedKmh(totalDistanceKm: number, totalDurationSec: nu
 const leaderboardRouter = new Hono<AuthEnv>();
 
 // GET /api/stats/leaderboard
-leaderboardRouter.get(
-  "/",
-  zValidator("query", leaderboardQuery, validationHook),
-  async (c) => {
-    const { period, limit, category } = c.req.valid("query");
-    const currentUser = c.get("user");
+leaderboardRouter.get("/", zValidator("query", leaderboardQuery, validationHook), async (c) => {
+  const { period, limit, category } = c.req.valid("query");
+  const currentUser = c.get("user");
 
-    const periodStart = getPeriodStart(period);
+  const periodStart = getPeriodStart(period);
 
-    const conditions = [eq(user.leaderboardOptOut, false)];
+  const conditions = [eq(user.leaderboardOptOut, false)];
 
-    const joinCondition = periodStart
-      ? and(eq(user.id, trips.userId), gte(trips.startedAt, periodStart))
-      : eq(user.id, trips.userId);
+  const joinCondition = periodStart
+    ? and(eq(user.id, trips.userId), gte(trips.startedAt, periodStart))
+    : eq(user.id, trips.userId);
 
-    if (category === "co2") {
-      const entries = await db
-        .select({
-          userId: user.id,
-          name: user.name,
-          image: user.image,
-          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
-        })
-        .from(user)
-        .leftJoin(trips, joinCondition)
-        .where(and(...conditions))
-        .groupBy(user.id, user.name, user.image)
-        .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`), asc(user.name))
-        .limit(limit);
-
-      const ranked = denseRank(entries, (e) => e.totalCo2SavedKg ?? 0);
-      const mapped = ranked.map((e) => ({ ...e, value: e.totalCo2SavedKg }));
-
-      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
-      return c.json({ ok: true, data: { entries: mapped, userRank } });
-    }
-
-    if (category === "money") {
-      const entries = await db
-        .select({
-          userId: user.id,
-          name: user.name,
-          image: user.image,
-          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
-          totalMoneySaved: sql<number>`coalesce(${sum(trips.moneySavedEur)}, 0)`.mapWith(Number),
-        })
-        .from(user)
-        .leftJoin(trips, joinCondition)
-        .where(and(...conditions))
-        .groupBy(user.id, user.name, user.image)
-        .orderBy(desc(sql`coalesce(${sum(trips.moneySavedEur)}, 0)`), asc(user.name))
-        .limit(limit);
-
-      const ranked = denseRank(entries, (e) => e.totalMoneySaved ?? 0);
-      const mapped = ranked.map((e) => ({ ...e, value: Math.round((e.totalMoneySaved ?? 0) * 100) / 100 }));
-
-      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
-      return c.json({ ok: true, data: { entries: mapped, userRank } });
-    }
-
-    if (category === "trips") {
-      const entries = await db
-        .select({
-          userId: user.id,
-          name: user.name,
-          image: user.image,
-          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
-          tripCount: count(trips.id).mapWith(Number),
-        })
-        .from(user)
-        .leftJoin(trips, joinCondition)
-        .where(and(...conditions))
-        .groupBy(user.id, user.name, user.image)
-        .orderBy(desc(count(trips.id)), asc(user.name))
-        .limit(limit);
-
-      const ranked = denseRank(entries, (e) => e.tripCount);
-      const mapped = ranked.map((e) => ({ ...e, value: e.tripCount }));
-
-      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
-      return c.json({ ok: true, data: { entries: mapped, userRank } });
-    }
-
-    if (category === "speed") {
-      const entries = await db
-        .select({
-          userId: user.id,
-          name: user.name,
-          image: user.image,
-          totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
-          totalDistanceKm: sql<number>`coalesce(${sum(trips.distanceKm)}, 0)`.mapWith(Number),
-          totalDurationSec: sql<number>`coalesce(${sum(trips.durationSec)}, 0)`.mapWith(Number),
-          tripCount: count(trips.id).mapWith(Number),
-        })
-        .from(user)
-        .leftJoin(trips, joinCondition)
-        .where(and(...conditions))
-        .groupBy(user.id, user.name, user.image)
-        .limit(limit * 2); // fetch extra since we filter
-
-      // Filter users with at least 1 trip, compute avg speed
-      const withSpeed = entries
-        .filter((e) => e.tripCount > 0)
-        .map((e) => ({
-          userId: e.userId,
-          name: e.name,
-          image: e.image,
-          totalCo2SavedKg: e.totalCo2SavedKg,
-          avgSpeedKmh: computeAvgSpeedKmh(e.totalDistanceKm, e.totalDurationSec),
-        }))
-        .sort((a, b) => b.avgSpeedKmh - a.avgSpeedKmh || a.name.localeCompare(b.name))
-        .slice(0, limit);
-
-      const ranked = denseRank(withSpeed, (e) => e.avgSpeedKmh);
-      const mapped = ranked.map((e) => ({ ...e, value: e.avgSpeedKmh }));
-
-      const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
-      return c.json({ ok: true, data: { entries: mapped, userRank } });
-    }
-
-    // category === "streak"
-    // Fetch all opted-in users
-    const optedInUsers = await db
+  if (category === "co2") {
+    const entries = await db
       .select({
         userId: user.id,
         name: user.name,
         image: user.image,
-      })
-      .from(user)
-      .where(and(...conditions));
-
-    if (optedInUsers.length === 0) {
-      return c.json({ ok: true, data: { entries: [], userRank: null } });
-    }
-
-    // Fetch all trip dates for opted-in users in a single query
-    const userIds = optedInUsers.map((u) => u.userId);
-    const tripDateConditions = periodStart
-      ? and(sql`${trips.userId} IN ${userIds}`, gte(trips.startedAt, periodStart))
-      : sql`${trips.userId} IN ${userIds}`;
-
-    const tripRows = await db
-      .select({
-        userId: trips.userId,
-        startedAt: trips.startedAt,
-      })
-      .from(trips)
-      .where(tripDateConditions);
-
-    // Also get co2 totals for opted-in users
-    const co2Rows = await db
-      .select({
-        userId: user.id,
         totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
       })
       .from(user)
       .leftJoin(trips, joinCondition)
       .where(and(...conditions))
-      .groupBy(user.id);
+      .groupBy(user.id, user.name, user.image)
+      .orderBy(desc(sql`coalesce(${sum(trips.co2SavedKg)}, 0)`), asc(user.name))
+      .limit(limit);
 
-    const co2Map = new Map(co2Rows.map((r) => [r.userId, r.totalCo2SavedKg]));
-
-    // Group trip dates by user
-    const userTripDates = new Map<string, string[]>();
-    for (const row of tripRows) {
-      const day = dateToDay(row.startedAt);
-      const existing = userTripDates.get(row.userId);
-      if (existing) {
-        existing.push(day);
-      } else {
-        userTripDates.set(row.userId, [day]);
-      }
-    }
-
-    // Compute streaks for each user
-    const withStreak = optedInUsers
-      .map((u) => ({
-        userId: u.userId,
-        name: u.name,
-        image: u.image,
-        totalCo2SavedKg: co2Map.get(u.userId) ?? 0,
-        streak: computeStreakFromDates(userTripDates.get(u.userId) ?? []),
-      }))
-      .sort((a, b) => b.streak - a.streak || a.name.localeCompare(b.name))
-      .slice(0, limit);
-
-    const ranked = denseRank(withStreak, (e) => e.streak);
-    const mapped = ranked.map((e) => ({ ...e, value: e.streak }));
+    const ranked = denseRank(entries, (e) => e.totalCo2SavedKg ?? 0);
+    const mapped = ranked.map((e) => ({ ...e, value: e.totalCo2SavedKg }));
 
     const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
     return c.json({ ok: true, data: { entries: mapped, userRank } });
-  },
-);
+  }
+
+  if (category === "money") {
+    const entries = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        image: user.image,
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+        totalMoneySaved: sql<number>`coalesce(${sum(trips.moneySavedEur)}, 0)`.mapWith(Number),
+      })
+      .from(user)
+      .leftJoin(trips, joinCondition)
+      .where(and(...conditions))
+      .groupBy(user.id, user.name, user.image)
+      .orderBy(desc(sql`coalesce(${sum(trips.moneySavedEur)}, 0)`), asc(user.name))
+      .limit(limit);
+
+    const ranked = denseRank(entries, (e) => e.totalMoneySaved ?? 0);
+    const mapped = ranked.map((e) => ({
+      ...e,
+      value: Math.round((e.totalMoneySaved ?? 0) * 100) / 100,
+    }));
+
+    const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    return c.json({ ok: true, data: { entries: mapped, userRank } });
+  }
+
+  if (category === "trips") {
+    const entries = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        image: user.image,
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+        tripCount: count(trips.id).mapWith(Number),
+      })
+      .from(user)
+      .leftJoin(trips, joinCondition)
+      .where(and(...conditions))
+      .groupBy(user.id, user.name, user.image)
+      .orderBy(desc(count(trips.id)), asc(user.name))
+      .limit(limit);
+
+    const ranked = denseRank(entries, (e) => e.tripCount);
+    const mapped = ranked.map((e) => ({ ...e, value: e.tripCount }));
+
+    const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    return c.json({ ok: true, data: { entries: mapped, userRank } });
+  }
+
+  if (category === "speed") {
+    const entries = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        image: user.image,
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+        totalDistanceKm: sql<number>`coalesce(${sum(trips.distanceKm)}, 0)`.mapWith(Number),
+        totalDurationSec: sql<number>`coalesce(${sum(trips.durationSec)}, 0)`.mapWith(Number),
+        tripCount: count(trips.id).mapWith(Number),
+      })
+      .from(user)
+      .leftJoin(trips, joinCondition)
+      .where(and(...conditions))
+      .groupBy(user.id, user.name, user.image)
+      .limit(limit * 2); // fetch extra since we filter
+
+    // Filter users with at least 1 trip, compute avg speed
+    const withSpeed = entries
+      .filter((e) => e.tripCount > 0)
+      .map((e) => ({
+        userId: e.userId,
+        name: e.name,
+        image: e.image,
+        totalCo2SavedKg: e.totalCo2SavedKg,
+        avgSpeedKmh: computeAvgSpeedKmh(e.totalDistanceKm, e.totalDurationSec),
+      }))
+      .sort((a, b) => b.avgSpeedKmh - a.avgSpeedKmh || a.name.localeCompare(b.name))
+      .slice(0, limit);
+
+    const ranked = denseRank(withSpeed, (e) => e.avgSpeedKmh);
+    const mapped = ranked.map((e) => ({ ...e, value: e.avgSpeedKmh }));
+
+    const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    return c.json({ ok: true, data: { entries: mapped, userRank } });
+  }
+
+  // category === "streak"
+  // Fetch all opted-in users
+  const optedInUsers = await db
+    .select({
+      userId: user.id,
+      name: user.name,
+      image: user.image,
+    })
+    .from(user)
+    .where(and(...conditions));
+
+  if (optedInUsers.length === 0) {
+    return c.json({ ok: true, data: { entries: [], userRank: null } });
+  }
+
+  // Fetch all trip dates for opted-in users in a single query
+  const userIds = optedInUsers.map((u) => u.userId);
+  const tripDateConditions = periodStart
+    ? and(sql`${trips.userId} IN ${userIds}`, gte(trips.startedAt, periodStart))
+    : sql`${trips.userId} IN ${userIds}`;
+
+  const tripRows = await db
+    .select({
+      userId: trips.userId,
+      startedAt: trips.startedAt,
+    })
+    .from(trips)
+    .where(tripDateConditions);
+
+  // Also get co2 totals for opted-in users
+  const co2Rows = await db
+    .select({
+      userId: user.id,
+      totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+    })
+    .from(user)
+    .leftJoin(trips, joinCondition)
+    .where(and(...conditions))
+    .groupBy(user.id);
+
+  const co2Map = new Map(co2Rows.map((r) => [r.userId, r.totalCo2SavedKg]));
+
+  // Group trip dates by user
+  const userTripDates = new Map<string, string[]>();
+  for (const row of tripRows) {
+    const day = dateToDay(row.startedAt);
+    const existing = userTripDates.get(row.userId);
+    if (existing) {
+      existing.push(day);
+    } else {
+      userTripDates.set(row.userId, [day]);
+    }
+  }
+
+  // Compute streaks for each user
+  const withStreak = optedInUsers
+    .map((u) => ({
+      userId: u.userId,
+      name: u.name,
+      image: u.image,
+      totalCo2SavedKg: co2Map.get(u.userId) ?? 0,
+      streak: computeStreakFromDates(userTripDates.get(u.userId) ?? []),
+    }))
+    .sort((a, b) => b.streak - a.streak || a.name.localeCompare(b.name))
+    .slice(0, limit);
+
+  const ranked = denseRank(withStreak, (e) => e.streak);
+  const mapped = ranked.map((e) => ({ ...e, value: e.streak }));
+
+  const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+  return c.json({ ok: true, data: { entries: mapped, userRank } });
+});
 
 /**
  * Assign dense ranks based on a value extractor.

--- a/server/src/routes/push.routes.ts
+++ b/server/src/routes/push.routes.ts
@@ -31,10 +31,9 @@ pushRouter.post(
     const [existing] = await db
       .select()
       .from(pushSubscriptions)
-      .where(and(
-        eq(pushSubscriptions.userId, currentUser.id),
-        eq(pushSubscriptions.endpoint, endpoint),
-      ));
+      .where(
+        and(eq(pushSubscriptions.userId, currentUser.id), eq(pushSubscriptions.endpoint, endpoint)),
+      );
 
     if (existing) {
       // Update keys if changed
@@ -46,12 +45,15 @@ pushRouter.post(
       return c.json({ ok: true, data: { subscriptionId: existing.id } });
     }
 
-    const [sub] = await db.insert(pushSubscriptions).values({
-      userId: currentUser.id,
-      endpoint,
-      p256dh: keys.p256dh,
-      auth: keys.auth,
-    }).returning();
+    const [sub] = await db
+      .insert(pushSubscriptions)
+      .values({
+        userId: currentUser.id,
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      })
+      .returning();
 
     return c.json({ ok: true, data: { subscriptionId: sub!.id } }, 201);
   },
@@ -67,10 +69,9 @@ pushRouter.delete(
 
     await db
       .delete(pushSubscriptions)
-      .where(and(
-        eq(pushSubscriptions.userId, currentUser.id),
-        eq(pushSubscriptions.endpoint, endpoint),
-      ));
+      .where(
+        and(eq(pushSubscriptions.userId, currentUser.id), eq(pushSubscriptions.endpoint, endpoint)),
+      );
 
     return c.json({ ok: true, data: null });
   },

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -18,58 +18,57 @@ function getPeriodStart(period: StatsPeriod): Date | null {
   if (period === "all") return null;
   const now = new Date();
   switch (period) {
-    case "day": return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    case "day":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
     case "week": {
       const d = new Date(now);
       d.setDate(d.getDate() - d.getDay() + 1);
       d.setHours(0, 0, 0, 0);
       return d;
     }
-    case "month": return new Date(now.getFullYear(), now.getMonth(), 1);
-    case "year": return new Date(now.getFullYear(), 0, 1);
+    case "month":
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+    case "year":
+      return new Date(now.getFullYear(), 0, 1);
   }
 }
 
 const statsRouter = new Hono<AuthEnv>();
 
 // GET /api/stats/summary — Aggregated stats for current user
-statsRouter.get(
-  "/summary",
-  zValidator("query", statsQuery, validationHook),
-  async (c) => {
-    const { period, tz } = c.req.valid("query");
-    const currentUser = c.get("user");
+statsRouter.get("/summary", zValidator("query", statsQuery, validationHook), async (c) => {
+  const { period, tz } = c.req.valid("query");
+  const currentUser = c.get("user");
 
-    const periodStart = getPeriodStart(period);
-    const conditions = [eq(trips.userId, currentUser.id)];
-    if (periodStart) conditions.push(gte(trips.startedAt, periodStart));
+  const periodStart = getPeriodStart(period);
+  const conditions = [eq(trips.userId, currentUser.id)];
+  if (periodStart) conditions.push(gte(trips.startedAt, periodStart));
 
-    const [stats] = await db
-      .select({
-        totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
-        totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
-        totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
-        totalFuelSavedL: sum(trips.fuelSavedL).mapWith(Number),
-        tripCount: count(),
-      })
-      .from(trips)
-      .where(and(...conditions));
+  const [stats] = await db
+    .select({
+      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
+      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
+      totalFuelSavedL: sum(trips.fuelSavedL).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(and(...conditions));
 
-    const streaks = await computeStreak(currentUser.id, tz);
+  const streaks = await computeStreak(currentUser.id, tz);
 
-    return c.json({
-      ok: true,
-      data: {
-        totalDistanceKm: stats?.totalDistanceKm ?? 0,
-        totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
-        totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
-        totalFuelSavedL: stats?.totalFuelSavedL ?? 0,
-        tripCount: stats?.tripCount ?? 0,
-        currentStreak: streaks.current,
-        longestStreak: streaks.longest,
-      },
-    });
-  },
-);
+  return c.json({
+    ok: true,
+    data: {
+      totalDistanceKm: stats?.totalDistanceKm ?? 0,
+      totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
+      totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
+      totalFuelSavedL: stats?.totalFuelSavedL ?? 0,
+      tripCount: stats?.tripCount ?? 0,
+      currentStreak: streaks.current,
+      longestStreak: streaks.longest,
+    },
+  });
+});
 
 export { statsRouter };

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { eq, and, desc, gte, lte, lt, gt, count, sql } from "drizzle-orm";
+import { eq, and, desc, gte, lte, lt, gt, count } from "drizzle-orm";
 import { db } from "../db";
 import { trips } from "../db/schema";
 import { user } from "../db/schema/auth";
@@ -35,10 +35,7 @@ tripsRouter.post(
       const [existing] = await db
         .select({ id: trips.id })
         .from(trips)
-        .where(and(
-          eq(trips.userId, currentUser.id),
-          eq(trips.idempotencyKey, data.idempotencyKey),
-        ))
+        .where(and(eq(trips.userId, currentUser.id), eq(trips.idempotencyKey, data.idempotencyKey)))
         .limit(1);
       if (existing) {
         return c.json({ ok: true, data: { trip: existing } }, 200);
@@ -54,15 +51,18 @@ tripsRouter.post(
           eq(trips.userId, currentUser.id),
           lt(trips.startedAt, new Date(data.endedAt)),
           gt(trips.endedAt, new Date(data.startedAt)),
-        )
+        ),
       )
       .limit(1);
 
     if (overlap) {
-      return c.json({
-        ok: false,
-        error: { code: "VALIDATION_ERROR", message: "Ce trajet chevauche un trajet existant." }
-      }, 409);
+      return c.json(
+        {
+          ok: false,
+          error: { code: "VALIDATION_ERROR", message: "Ce trajet chevauche un trajet existant." },
+        },
+        409,
+      );
     }
 
     // Get user's vehicle profile for savings calculation
@@ -82,7 +82,13 @@ tripsRouter.post(
       fuelPriceEur = fuelPriceData.priceEur;
     } catch {
       // On any failure, use hardcoded fallback so trip creation is never blocked
-      const FALLBACK: Record<string, number> = { sp95: 1.75, sp98: 1.85, diesel: 1.65, e85: 0.85, gpl: 0.95 };
+      const FALLBACK: Record<string, number> = {
+        sp95: 1.75,
+        sp98: 1.85,
+        diesel: 1.65,
+        e85: 0.85,
+        gpl: 0.95,
+      };
       fuelPriceEur = FALLBACK[fuelType] ?? 1.75;
     }
 
@@ -92,19 +98,22 @@ tripsRouter.post(
       fuelPriceEur,
     });
 
-    const [trip] = await db.insert(trips).values({
-      userId: currentUser.id,
-      distanceKm: data.distanceKm,
-      durationSec: data.durationSec,
-      co2SavedKg: savings.co2SavedKg,
-      moneySavedEur: savings.moneySavedEur,
-      fuelSavedL: savings.fuelSavedL,
-      fuelPriceEur,
-      startedAt: new Date(data.startedAt),
-      endedAt: new Date(data.endedAt),
-      gpsPoints: data.gpsPoints ?? null,
-      idempotencyKey: data.idempotencyKey ?? null,
-    }).returning();
+    const [trip] = await db
+      .insert(trips)
+      .values({
+        userId: currentUser.id,
+        distanceKm: data.distanceKm,
+        durationSec: data.durationSec,
+        co2SavedKg: savings.co2SavedKg,
+        moneySavedEur: savings.moneySavedEur,
+        fuelSavedL: savings.fuelSavedL,
+        fuelPriceEur,
+        startedAt: new Date(data.startedAt),
+        endedAt: new Date(data.endedAt),
+        gpsPoints: data.gpsPoints ?? null,
+        idempotencyKey: data.idempotencyKey ?? null,
+      })
+      .returning();
 
     // Evaluate badge thresholds and unlock any newly earned achievements
     const newBadges = await evaluateAndUnlockBadges(currentUser.id);
@@ -126,76 +135,60 @@ tripsRouter.post(
 );
 
 // GET /api/trips — Paginated list (own trips)
-tripsRouter.get(
-  "/",
-  zValidator("query", tripsListQuery, validationHook),
-  async (c) => {
-    const { page, limit, from, to } = c.req.valid("query");
-    const currentUser = c.get("user");
-    const { offset } = paginationToOffset(page, limit);
+tripsRouter.get("/", zValidator("query", tripsListQuery, validationHook), async (c) => {
+  const { page, limit, from, to } = c.req.valid("query");
+  const currentUser = c.get("user");
+  const { offset } = paginationToOffset(page, limit);
 
-    const conditions = [eq(trips.userId, currentUser.id)];
-    if (from) conditions.push(gte(trips.startedAt, new Date(from)));
-    if (to) conditions.push(lte(trips.startedAt, new Date(to)));
+  const conditions = [eq(trips.userId, currentUser.id)];
+  if (from) conditions.push(gte(trips.startedAt, new Date(from)));
+  if (to) conditions.push(lte(trips.startedAt, new Date(to)));
 
-    const where = and(...conditions);
+  const where = and(...conditions);
 
-    const [data, [countResult]] = await Promise.all([
-      db.select().from(trips)
-        .where(where)
-        .orderBy(desc(trips.startedAt))
-        .limit(limit)
-        .offset(offset),
-      db.select({ count: count() }).from(trips).where(where),
-    ]);
+  const [data, [countResult]] = await Promise.all([
+    db.select().from(trips).where(where).orderBy(desc(trips.startedAt)).limit(limit).offset(offset),
+    db.select({ count: count() }).from(trips).where(where),
+  ]);
 
-    const total = countResult?.count ?? 0;
+  const total = countResult?.count ?? 0;
 
-    return c.json({
-      ok: true,
-      data: { trips: data },
-      pagination: buildPagination(page, limit, total),
-    });
-  },
-);
+  return c.json({
+    ok: true,
+    data: { trips: data },
+    pagination: buildPagination(page, limit, total),
+  });
+});
 
 // GET /api/trips/:id — Single trip
-tripsRouter.get(
-  "/:id",
-  zValidator("param", uuidParam, validationHook),
-  async (c) => {
-    const { id } = c.req.valid("param");
-    const currentUser = c.get("user");
+tripsRouter.get("/:id", zValidator("param", uuidParam, validationHook), async (c) => {
+  const { id } = c.req.valid("param");
+  const currentUser = c.get("user");
 
-    const [trip] = await db.select().from(trips).where(eq(trips.id, id));
+  const [trip] = await db.select().from(trips).where(eq(trips.id, id));
 
-    if (!trip) throw notFound(`Trip ${id} not found`);
-    if (trip.userId !== currentUser.id) throw forbidden();
+  if (!trip) throw notFound(`Trip ${id} not found`);
+  if (trip.userId !== currentUser.id) throw forbidden();
 
-    return c.json({ ok: true, data: { trip } });
-  },
-);
+  return c.json({ ok: true, data: { trip } });
+});
 
 // DELETE /api/trips/:id — Delete trip
-tripsRouter.delete(
-  "/:id",
-  zValidator("param", uuidParam, validationHook),
-  async (c) => {
-    const { id } = c.req.valid("param");
-    const currentUser = c.get("user");
+tripsRouter.delete("/:id", zValidator("param", uuidParam, validationHook), async (c) => {
+  const { id } = c.req.valid("param");
+  const currentUser = c.get("user");
 
-    const [trip] = await db.select().from(trips).where(eq(trips.id, id));
+  const [trip] = await db.select().from(trips).where(eq(trips.id, id));
 
-    if (!trip) throw notFound(`Trip ${id} not found`);
-    if (trip.userId !== currentUser.id) throw forbidden();
+  if (!trip) throw notFound(`Trip ${id} not found`);
+  if (trip.userId !== currentUser.id) throw forbidden();
 
-    await db.delete(trips).where(eq(trips.id, id));
+  await db.delete(trips).where(eq(trips.id, id));
 
-    // Re-evaluate badges — revoke any that are no longer earned
-    const revokedBadges = await reevaluateBadges(currentUser.id);
+  // Re-evaluate badges — revoke any that are no longer earned
+  const revokedBadges = await reevaluateBadges(currentUser.id);
 
-    return c.json({ ok: true, data: { revokedBadges } });
-  },
-);
+  return c.json({ ok: true, data: { revokedBadges } });
+});
 
 export { tripsRouter };

--- a/server/src/routes/users.routes.ts
+++ b/server/src/routes/users.routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { eq, sum, count, sql } from "drizzle-orm";
+import { eq, sum, count } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { trips, achievements } from "../db/schema";
@@ -42,38 +42,31 @@ usersRouter.get("/profile", async (c) => {
 });
 
 // PATCH /api/user/profile — Update vehicle/preferences
-usersRouter.patch(
-  "/profile",
-  zValidator("json", updateUserSchema, validationHook),
-  async (c) => {
-    const data = c.req.valid("json");
-    const currentUser = c.get("user");
+usersRouter.patch("/profile", zValidator("json", updateUserSchema, validationHook), async (c) => {
+  const data = c.req.valid("json");
+  const currentUser = c.get("user");
 
-    if (Object.keys(data).length === 0) {
-      return c.json({ ok: true, data: { user: currentUser } });
-    }
+  if (Object.keys(data).length === 0) {
+    return c.json({ ok: true, data: { user: currentUser } });
+  }
 
-    const [updated] = await db
-      .update(user)
-      .set({
-        ...data,
-        updatedAt: new Date(),
-      })
-      .where(eq(user.id, currentUser.id))
-      .returning();
+  const [updated] = await db
+    .update(user)
+    .set({
+      ...data,
+      updatedAt: new Date(),
+    })
+    .where(eq(user.id, currentUser.id))
+    .returning();
 
-    return c.json({ ok: true, data: { user: updated } });
-  },
-);
+  return c.json({ ok: true, data: { user: updated } });
+});
 
 // GET /api/user/export — GDPR data export
 usersRouter.get("/export", async (c) => {
   const currentUser = c.get("user");
 
-  const userTrips = await db
-    .select()
-    .from(trips)
-    .where(eq(trips.userId, currentUser.id));
+  const userTrips = await db.select().from(trips).where(eq(trips.userId, currentUser.id));
 
   const userAchievements = await db
     .select()

--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -6,16 +6,18 @@ const gpsPointSchema = z.object({
   ts: z.number(),
 });
 
-export const createTripSchema = z.object({
-  distanceKm: z.number().positive().max(500),
-  durationSec: z.number().int().min(1).max(86400),
-  startedAt: z.string().datetime(),
-  endedAt: z.string().datetime(),
-  gpsPoints: z.array(gpsPointSchema).max(10000).nullable().optional(),
-  idempotencyKey: z.string().uuid().optional(),
-}).refine(
-  (data) => new Date(data.startedAt) < new Date(data.endedAt),
-  { message: "startedAt must be before endedAt", path: ["startedAt"] }
-);
+export const createTripSchema = z
+  .object({
+    distanceKm: z.number().positive().max(500),
+    durationSec: z.number().int().min(1).max(86400),
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime(),
+    gpsPoints: z.array(gpsPointSchema).max(10000).nullable().optional(),
+    idempotencyKey: z.string().uuid().optional(),
+  })
+  .refine((data) => new Date(data.startedAt) < new Date(data.endedAt), {
+    message: "startedAt must be before endedAt",
+    path: ["startedAt"],
+  });
 
 export type CreateTripInput = z.infer<typeof createTripSchema>;

--- a/server/src/validators/users.ts
+++ b/server/src/validators/users.ts
@@ -8,7 +8,10 @@ export const updateUserSchema = z.object({
   mileage: z.number().int().nonnegative().optional(),
   leaderboardOptOut: z.boolean().optional(),
   reminderEnabled: z.boolean().optional(),
-  reminderTime: z.string().regex(/^\d{2}:\d{2}$/, "Must be HH:MM format").optional(),
+  reminderTime: z
+    .string()
+    .regex(/^\d{2}:\d{2}$/, "Must be HH:MM format")
+    .optional(),
   reminderDays: z.array(z.enum(WEEK_DAYS as unknown as [string, ...string[]])).optional(),
 });
 

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -4,36 +4,36 @@ import type { User, Trip, Achievement, GpsPoint, FuelType, WeekDay } from "./typ
 
 export const API_ROUTES = {
   // Auth (Better Auth handles these)
-  AUTH_GOOGLE:       { method: "GET",    path: "/api/auth/sign-in/social" },
-  AUTH_SESSION:      { method: "GET",    path: "/api/auth/get-session" },
-  AUTH_SIGN_OUT:     { method: "POST",   path: "/api/auth/sign-out" },
+  AUTH_GOOGLE: { method: "GET", path: "/api/auth/sign-in/social" },
+  AUTH_SESSION: { method: "GET", path: "/api/auth/get-session" },
+  AUTH_SIGN_OUT: { method: "POST", path: "/api/auth/sign-out" },
 
   // Trips
-  TRIPS_LIST:        { method: "GET",    path: "/api/trips" },
-  TRIPS_CREATE:      { method: "POST",   path: "/api/trips" },
-  TRIPS_GET:         { method: "GET",    path: "/api/trips/:id" },
-  TRIPS_DELETE:      { method: "DELETE", path: "/api/trips/:id" },
+  TRIPS_LIST: { method: "GET", path: "/api/trips" },
+  TRIPS_CREATE: { method: "POST", path: "/api/trips" },
+  TRIPS_GET: { method: "GET", path: "/api/trips/:id" },
+  TRIPS_DELETE: { method: "DELETE", path: "/api/trips/:id" },
 
   // Stats
-  STATS_SUMMARY:     { method: "GET",    path: "/api/stats/summary" },
-  STATS_LEADERBOARD: { method: "GET",    path: "/api/stats/leaderboard" },
+  STATS_SUMMARY: { method: "GET", path: "/api/stats/summary" },
+  STATS_LEADERBOARD: { method: "GET", path: "/api/stats/leaderboard" },
 
   // User profile
-  USER_PROFILE:      { method: "GET",    path: "/api/user/profile" },
-  USER_UPDATE:       { method: "PATCH",  path: "/api/user/profile" },
+  USER_PROFILE: { method: "GET", path: "/api/user/profile" },
+  USER_UPDATE: { method: "PATCH", path: "/api/user/profile" },
 
   // Achievements
-  ACHIEVEMENTS_LIST: { method: "GET",    path: "/api/achievements" },
+  ACHIEVEMENTS_LIST: { method: "GET", path: "/api/achievements" },
 
   // Push subscriptions
-  PUSH_SUBSCRIBE:    { method: "POST",   path: "/api/push/subscribe" },
-  PUSH_UNSUBSCRIBE:  { method: "DELETE", path: "/api/push/subscribe" },
+  PUSH_SUBSCRIBE: { method: "POST", path: "/api/push/subscribe" },
+  PUSH_UNSUBSCRIBE: { method: "DELETE", path: "/api/push/subscribe" },
 
   // Fuel prices
-  FUEL_PRICE:        { method: "GET",    path: "/api/fuel-price" },
+  FUEL_PRICE: { method: "GET", path: "/api/fuel-price" },
 
   // Health
-  HEALTH:            { method: "GET",    path: "/api/health" },
+  HEALTH: { method: "GET", path: "/api/health" },
 } as const;
 
 // ---- Request payloads ----
@@ -41,8 +41,8 @@ export const API_ROUTES = {
 export interface CreateTripRequest {
   distanceKm: number;
   durationSec: number;
-  startedAt: string;  // ISO 8601
-  endedAt: string;    // ISO 8601
+  startedAt: string; // ISO 8601
+  endedAt: string; // ISO 8601
   gpsPoints?: GpsPoint[] | null;
   idempotencyKey?: string;
 }
@@ -54,7 +54,7 @@ export interface UpdateUserRequest {
   mileage?: number;
   leaderboardOptOut?: boolean;
   reminderEnabled?: boolean;
-  reminderTime?: string;  // HH:MM
+  reminderTime?: string; // HH:MM
   reminderDays?: WeekDay[];
 }
 
@@ -139,4 +139,4 @@ export const ERROR_CODES = {
   INTERNAL_ERROR: "INTERNAL_ERROR",
 } as const;
 
-export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -57,7 +57,15 @@ export type WeekDay = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 
 export const FUEL_TYPES: readonly FuelType[] = ["sp95", "sp98", "diesel", "e85", "gpl"] as const;
 
-export const WEEK_DAYS: readonly WeekDay[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+export const WEEK_DAYS: readonly WeekDay[] = [
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+  "sun",
+] as const;
 
 // CO2 emission factor: kg CO2 per liter of fuel (ADEME)
 export const CO2_KG_PER_LITER = 2.31;
@@ -65,18 +73,18 @@ export const CO2_KG_PER_LITER = 2.31;
 // ---- Badge definitions (static, not in DB) ----
 
 export const BADGES = {
-  first_trip:  { id: "first_trip",  label: "Premier trajet",       icon: "🚴" },
-  trips_10:    { id: "trips_10",    label: "10 trajets",           icon: "🔟" },
-  trips_50:    { id: "trips_50",    label: "50 trajets",           icon: "🏅" },
-  trips_100:   { id: "trips_100",   label: "100 trajets",          icon: "💯" },
-  km_100:      { id: "km_100",      label: "100 km",               icon: "🛤️" },
-  km_500:      { id: "km_500",      label: "500 km",               icon: "🗺️" },
-  km_1000:     { id: "km_1000",     label: "1 000 km",             icon: "🌍" },
-  co2_10kg:    { id: "co2_10kg",    label: "10 kg CO₂ économisés", icon: "🌱" },
-  co2_100kg:   { id: "co2_100kg",   label: "100 kg CO₂ économisés", icon: "🌳" },
-  co2_1t:      { id: "co2_1t",      label: "1 tonne CO₂ économisée", icon: "🌲" },
-  streak_7:    { id: "streak_7",    label: "7 jours de streak",    icon: "🔥" },
-  streak_30:   { id: "streak_30",   label: "30 jours de streak",   icon: "⚡" },
+  first_trip: { id: "first_trip", label: "Premier trajet", icon: "🚴" },
+  trips_10: { id: "trips_10", label: "10 trajets", icon: "🔟" },
+  trips_50: { id: "trips_50", label: "50 trajets", icon: "🏅" },
+  trips_100: { id: "trips_100", label: "100 trajets", icon: "💯" },
+  km_100: { id: "km_100", label: "100 km", icon: "🛤️" },
+  km_500: { id: "km_500", label: "500 km", icon: "🗺️" },
+  km_1000: { id: "km_1000", label: "1 000 km", icon: "🌍" },
+  co2_10kg: { id: "co2_10kg", label: "10 kg CO₂ économisés", icon: "🌱" },
+  co2_100kg: { id: "co2_100kg", label: "100 kg CO₂ économisés", icon: "🌳" },
+  co2_1t: { id: "co2_1t", label: "1 tonne CO₂ économisée", icon: "🌲" },
+  streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥" },
+  streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡" },
 } as const;
 
 export type BadgeId = keyof typeof BADGES;
@@ -85,7 +93,7 @@ export type BadgeId = keyof typeof BADGES;
 
 export const IMPACT_REFERENCES = [
   { label: "arbre planté (absorption annuelle)", co2Kg: 21 },
-  { label: "trajet Paris–Lyon en voiture",       co2Kg: 45 },
-  { label: "plein d'essence (50L SP95)",         co2Kg: 115 },
-  { label: "vol Paris–New York (aller)",         co2Kg: 400 },
+  { label: "trajet Paris–Lyon en voiture", co2Kg: 45 },
+  { label: "plein d'essence (50L SP95)", co2Kg: 115 },
+  { label: "vol Paris–New York (aller)", co2Kg: 400 },
 ] as const;


### PR DESCRIPTION
## Summary
- **ESLint 10** with flat config: TypeScript support via `typescript-eslint`, React hooks rules for `client/`, relaxed rules for server and test files
- **Prettier** with consistent formatting across the monorepo (double quotes, semicolons, trailing commas, 100 char width)
- **Husky + lint-staged** pre-commit hook: auto-fixes lint + formatting on staged `.ts/.tsx` files
- **CI job** added: `Lint & Format` runs `bun run lint` and `bun run format:check` on every PR
- All existing files auto-formatted; unused imports removed; new React 19 strict rules downgraded to warnings

## Configuration
- `eslint.config.js` — flat config with per-directory overrides (server, client, tests, config files)
- `.prettierrc` + `.prettierignore` — formatting rules
- `.husky/pre-commit` — runs `bunx lint-staged`
- `lint-staged` config in root `package.json`

## Scripts added
- `bun run lint` / `bun run lint:fix`
- `bun run format` / `bun run format:check`

## Test plan
- [x] `bun run lint` passes (0 errors, 15 warnings — all intentionally warn-level)
- [x] `bun run format:check` passes
- [x] `bun run typecheck` passes
- [x] Pre-commit hook tested via the commit itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)