### PR TITLE
feat: add comprehensive server-side unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: cd client && bunx vitest run
+      - run: cd server && bunx vitest run
 
   smoke:
     name: Smoke test (Playwright)

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
-    "typecheck": "bunx tsc --noEmit"
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bunx vitest run"
   },
   "dependencies": {
     "hono": "^4.7.0",

--- a/server/src/lib/__tests__/badges.test.ts
+++ b/server/src/lib/__tests__/badges.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock db to prevent real Postgres connection on module load
+vi.mock("../../db", () => ({ db: {} }));
+vi.mock("../../db/schema", () => ({ trips: {}, achievements: {} }));
+vi.mock("../streaks", () => ({ computeStreak: vi.fn() }));
+
+import { BADGE_THRESHOLDS, type UserStats } from "../badges";
+
+function makeStats(overrides: Partial<UserStats> = {}): UserStats {
+  return {
+    totalDistanceKm: 0,
+    totalCo2SavedKg: 0,
+    tripCount: 0,
+    currentStreak: 0,
+    ...overrides,
+  };
+}
+
+describe("BADGE_THRESHOLDS", () => {
+  describe("first_trip", () => {
+    it("unlocks when tripCount >= 1", () => {
+      expect(BADGE_THRESHOLDS.first_trip(makeStats({ tripCount: 1 }))).toBe(true);
+    });
+
+    it("does not unlock when tripCount = 0", () => {
+      expect(BADGE_THRESHOLDS.first_trip(makeStats({ tripCount: 0 }))).toBe(false);
+    });
+  });
+
+  describe("trips_10", () => {
+    it("unlocks at exactly 10 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_10(makeStats({ tripCount: 10 }))).toBe(true);
+    });
+
+    it("does not unlock at 9 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_10(makeStats({ tripCount: 9 }))).toBe(false);
+    });
+  });
+
+  describe("trips_50", () => {
+    it("unlocks at exactly 50 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_50(makeStats({ tripCount: 50 }))).toBe(true);
+    });
+
+    it("does not unlock at 49 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_50(makeStats({ tripCount: 49 }))).toBe(false);
+    });
+  });
+
+  describe("trips_100", () => {
+    it("unlocks at exactly 100 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_100(makeStats({ tripCount: 100 }))).toBe(true);
+    });
+
+    it("does not unlock at 99 trips", () => {
+      expect(BADGE_THRESHOLDS.trips_100(makeStats({ tripCount: 99 }))).toBe(false);
+    });
+  });
+
+  describe("km_100", () => {
+    it("unlocks at exactly 100 km", () => {
+      expect(BADGE_THRESHOLDS.km_100(makeStats({ totalDistanceKm: 100 }))).toBe(true);
+    });
+
+    it("does not unlock at 99.9 km", () => {
+      expect(BADGE_THRESHOLDS.km_100(makeStats({ totalDistanceKm: 99.9 }))).toBe(false);
+    });
+
+    it("unlocks above threshold", () => {
+      expect(BADGE_THRESHOLDS.km_100(makeStats({ totalDistanceKm: 200 }))).toBe(true);
+    });
+  });
+
+  describe("km_500", () => {
+    it("unlocks at exactly 500 km", () => {
+      expect(BADGE_THRESHOLDS.km_500(makeStats({ totalDistanceKm: 500 }))).toBe(true);
+    });
+
+    it("does not unlock at 499 km", () => {
+      expect(BADGE_THRESHOLDS.km_500(makeStats({ totalDistanceKm: 499 }))).toBe(false);
+    });
+  });
+
+  describe("km_1000", () => {
+    it("unlocks at exactly 1000 km", () => {
+      expect(BADGE_THRESHOLDS.km_1000(makeStats({ totalDistanceKm: 1000 }))).toBe(true);
+    });
+
+    it("does not unlock at 999 km", () => {
+      expect(BADGE_THRESHOLDS.km_1000(makeStats({ totalDistanceKm: 999 }))).toBe(false);
+    });
+  });
+
+  describe("co2_10kg", () => {
+    it("unlocks at exactly 10 kg CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_10kg(makeStats({ totalCo2SavedKg: 10 }))).toBe(true);
+    });
+
+    it("does not unlock at 9.99 kg CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_10kg(makeStats({ totalCo2SavedKg: 9.99 }))).toBe(false);
+    });
+  });
+
+  describe("co2_100kg", () => {
+    it("unlocks at exactly 100 kg CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_100kg(makeStats({ totalCo2SavedKg: 100 }))).toBe(true);
+    });
+
+    it("does not unlock at 99 kg CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_100kg(makeStats({ totalCo2SavedKg: 99 }))).toBe(false);
+    });
+  });
+
+  describe("co2_1t", () => {
+    it("unlocks at exactly 1000 kg (1 tonne) CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_1t(makeStats({ totalCo2SavedKg: 1000 }))).toBe(true);
+    });
+
+    it("does not unlock at 999 kg CO2", () => {
+      expect(BADGE_THRESHOLDS.co2_1t(makeStats({ totalCo2SavedKg: 999 }))).toBe(false);
+    });
+  });
+
+  describe("streak_7", () => {
+    it("unlocks at exactly 7-day streak", () => {
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 7 }))).toBe(true);
+    });
+
+    it("does not unlock at 6-day streak", () => {
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 6 }))).toBe(false);
+    });
+
+    it("unlocks above threshold", () => {
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 14 }))).toBe(true);
+    });
+  });
+
+  describe("streak_30", () => {
+    it("unlocks at exactly 30-day streak", () => {
+      expect(BADGE_THRESHOLDS.streak_30(makeStats({ currentStreak: 30 }))).toBe(true);
+    });
+
+    it("does not unlock at 29-day streak", () => {
+      expect(BADGE_THRESHOLDS.streak_30(makeStats({ currentStreak: 29 }))).toBe(false);
+    });
+  });
+
+  describe("independence from other stats", () => {
+    it("km badge ignores trip count and streak", () => {
+      const stats = makeStats({
+        totalDistanceKm: 100,
+        tripCount: 0,
+        currentStreak: 0,
+      });
+      expect(BADGE_THRESHOLDS.km_100(stats)).toBe(true);
+      expect(BADGE_THRESHOLDS.first_trip(stats)).toBe(false);
+    });
+
+    it("streak badge ignores distance and co2", () => {
+      const stats = makeStats({
+        currentStreak: 7,
+        totalDistanceKm: 0,
+        totalCo2SavedKg: 0,
+      });
+      expect(BADGE_THRESHOLDS.streak_7(stats)).toBe(true);
+      expect(BADGE_THRESHOLDS.km_100(stats)).toBe(false);
+    });
+  });
+});

--- a/server/src/lib/__tests__/calculations.test.ts
+++ b/server/src/lib/__tests__/calculations.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { calculateSavings } from "../calculations";
+
+describe("calculateSavings", () => {
+  it("calculates normal case (10km, 7L/100km, 1.85 EUR/L)", () => {
+    const result = calculateSavings({
+      distanceKm: 10,
+      consumptionL100: 7,
+      fuelPriceEur: 1.85,
+    });
+    // fuelSaved = 10 * 7 / 100 = 0.7 L
+    expect(result.fuelSavedL).toBe(0.7);
+    // co2 = 0.7 * 2.31 = 1.617
+    expect(result.co2SavedKg).toBe(1.617);
+    // money = 0.7 * 1.85 = 1.295 -> rounded to 1.30
+    expect(result.moneySavedEur).toBe(1.3);
+  });
+
+  it("returns zeros for zero distance", () => {
+    const result = calculateSavings({
+      distanceKm: 0,
+      consumptionL100: 7,
+      fuelPriceEur: 1.85,
+    });
+    expect(result.fuelSavedL).toBe(0);
+    expect(result.co2SavedKg).toBe(0);
+    expect(result.moneySavedEur).toBe(0);
+  });
+
+  it("handles high consumption (15L/100km)", () => {
+    const result = calculateSavings({
+      distanceKm: 50,
+      consumptionL100: 15,
+      fuelPriceEur: 1.85,
+    });
+    // fuelSaved = 50 * 15 / 100 = 7.5 L
+    expect(result.fuelSavedL).toBe(7.5);
+    // co2 = 7.5 * 2.31 = 17.325
+    expect(result.co2SavedKg).toBe(17.325);
+    // money = 7.5 * 1.85 = 13.875 -> 13.88
+    expect(result.moneySavedEur).toBe(13.88);
+  });
+
+  it("handles low fuel price (E85 at 0.85 EUR/L)", () => {
+    const result = calculateSavings({
+      distanceKm: 20,
+      consumptionL100: 10,
+      fuelPriceEur: 0.85,
+    });
+    // fuelSaved = 20 * 10 / 100 = 2 L
+    expect(result.fuelSavedL).toBe(2);
+    // co2 = 2 * 2.31 = 4.62
+    expect(result.co2SavedKg).toBe(4.62);
+    // money = 2 * 0.85 = 1.70
+    expect(result.moneySavedEur).toBe(1.7);
+  });
+
+  it("rounds CO2 to 3 decimal places", () => {
+    // Choose values that produce many decimals
+    // distanceKm=1, consumption=3, price=1 => fuel=0.03
+    // co2 = 0.03 * 2.31 = 0.0693 -> rounded to 0.069
+    const result = calculateSavings({
+      distanceKm: 1,
+      consumptionL100: 3,
+      fuelPriceEur: 1,
+    });
+    expect(result.co2SavedKg).toBe(0.069);
+  });
+
+  it("rounds money to 2 decimal places", () => {
+    // fuel = 10 * 6 / 100 = 0.6
+    // money = 0.6 * 1.333 = 0.7998 -> rounded to 0.80
+    const result = calculateSavings({
+      distanceKm: 10,
+      consumptionL100: 6,
+      fuelPriceEur: 1.333,
+    });
+    expect(result.moneySavedEur).toBe(0.8);
+  });
+
+  it("rounds fuelSavedL to 3 decimal places", () => {
+    // fuel = 7 * 3 / 100 = 0.21
+    const result = calculateSavings({
+      distanceKm: 7,
+      consumptionL100: 3,
+      fuelPriceEur: 1,
+    });
+    expect(result.fuelSavedL).toBe(0.21);
+  });
+
+  it("handles very small distance", () => {
+    const result = calculateSavings({
+      distanceKm: 0.1,
+      consumptionL100: 7,
+      fuelPriceEur: 1.85,
+    });
+    // fuelSaved = 0.1 * 7 / 100 = 0.007
+    expect(result.fuelSavedL).toBe(0.007);
+    // co2 = 0.007 * 2.31 = 0.01617 -> 0.016
+    expect(result.co2SavedKg).toBe(0.016);
+    // money = 0.007 * 1.85 = 0.01295 -> 0.01
+    expect(result.moneySavedEur).toBe(0.01);
+  });
+});

--- a/server/src/lib/__tests__/streaks.test.ts
+++ b/server/src/lib/__tests__/streaks.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+
+// Mock db and schema to prevent real Postgres connection on module load
+vi.mock("../../db", () => ({ db: {} }));
+vi.mock("../../db/schema", () => ({ trips: {} }));
+vi.mock("../../db/schema/auth", () => ({ user: {} }));
+vi.mock("../../lib/validation", () => ({ validationHook: vi.fn() }));
+
+import { computeStreakFromDates, computeAvgSpeedKmh } from "../../routes/leaderboard.routes";
+
+/**
+ * Helper: format a Date as YYYY-MM-DD (UTC) — matches the server's dateToDay().
+ */
+function dateToDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Build an array of consecutive YYYY-MM-DD strings ending on `endDate`,
+ * going back `count` days.
+ */
+function consecutiveDays(count: number, endDate: Date): string[] {
+  const dates: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setUTCDate(d.getUTCDate() - i);
+    dates.push(dateToDay(d));
+  }
+  return dates;
+}
+
+describe("computeStreakFromDates", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(computeStreakFromDates([])).toBe(0);
+  });
+
+  it("returns 1 for single day that is today", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    expect(computeStreakFromDates(["2025-06-15"])).toBe(1);
+  });
+
+  it("returns 1 for single day that is yesterday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    expect(computeStreakFromDates(["2025-06-14"])).toBe(1);
+  });
+
+  it("returns 0 for a date more than 1 day in the past", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    expect(computeStreakFromDates(["2025-06-13"])).toBe(0);
+  });
+
+  it("counts consecutive days correctly", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    const dates = consecutiveDays(5, new Date("2025-06-15T00:00:00Z"));
+    // 2025-06-11, 2025-06-12, 2025-06-13, 2025-06-14, 2025-06-15
+    expect(computeStreakFromDates(dates)).toBe(5);
+  });
+
+  it("breaks streak on a gap", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    const dates = [
+      "2025-06-10", // gap on June 11
+      "2025-06-12",
+      "2025-06-13",
+      "2025-06-14",
+      "2025-06-15",
+    ];
+    expect(computeStreakFromDates(dates)).toBe(4);
+  });
+
+  it("deduplicates dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    const dates = [
+      "2025-06-14",
+      "2025-06-14", // duplicate
+      "2025-06-15",
+      "2025-06-15", // duplicate
+    ];
+    expect(computeStreakFromDates(dates)).toBe(2);
+  });
+
+  it("handles unsorted input", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    const dates = ["2025-06-15", "2025-06-13", "2025-06-14"];
+    expect(computeStreakFromDates(dates)).toBe(3);
+  });
+
+  it("returns 0 when all dates are old", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+
+    const dates = ["2025-01-01", "2025-01-02", "2025-01-03"];
+    expect(computeStreakFromDates(dates)).toBe(0);
+  });
+});
+
+describe("computeAvgSpeedKmh", () => {
+  it("returns 0 for zero duration", () => {
+    expect(computeAvgSpeedKmh(10, 0)).toBe(0);
+  });
+
+  it("returns 0 for negative duration", () => {
+    expect(computeAvgSpeedKmh(10, -1)).toBe(0);
+  });
+
+  it("calculates correct average speed", () => {
+    // 10 km in 1800 sec (30 min) = 20 km/h
+    expect(computeAvgSpeedKmh(10, 1800)).toBe(20);
+  });
+
+  it("rounds to 1 decimal place", () => {
+    // 10 km in 2700 sec (45 min) = 13.333... km/h -> 13.3
+    expect(computeAvgSpeedKmh(10, 2700)).toBe(13.3);
+  });
+});

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -8,26 +8,26 @@ import type { BadgeId } from "@ecoride/shared/types";
  * Badge threshold definitions.
  * Each entry maps a BadgeId to a predicate over the user's aggregate stats.
  */
-interface UserStats {
+export interface UserStats {
   totalDistanceKm: number;
   totalCo2SavedKg: number;
   tripCount: number;
   currentStreak: number;
 }
 
-const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
-  first_trip: (s) => s.tripCount >= 1,
-  trips_10: (s) => s.tripCount >= 10,
-  trips_50: (s) => s.tripCount >= 50,
-  trips_100: (s) => s.tripCount >= 100,
-  km_100: (s) => s.totalDistanceKm >= 100,
-  km_500: (s) => s.totalDistanceKm >= 500,
-  km_1000: (s) => s.totalDistanceKm >= 1000,
-  co2_10kg: (s) => s.totalCo2SavedKg >= 10,
-  co2_100kg: (s) => s.totalCo2SavedKg >= 100,
-  co2_1t: (s) => s.totalCo2SavedKg >= 1000,
-  streak_7: (s) => s.currentStreak >= 7,
-  streak_30: (s) => s.currentStreak >= 30,
+export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
+  first_trip:  (s) => s.tripCount >= 1,
+  trips_10:    (s) => s.tripCount >= 10,
+  trips_50:    (s) => s.tripCount >= 50,
+  trips_100:   (s) => s.tripCount >= 100,
+  km_100:      (s) => s.totalDistanceKm >= 100,
+  km_500:      (s) => s.totalDistanceKm >= 500,
+  km_1000:     (s) => s.totalDistanceKm >= 1000,
+  co2_10kg:    (s) => s.totalCo2SavedKg >= 10,
+  co2_100kg:   (s) => s.totalCo2SavedKg >= 100,
+  co2_1t:      (s) => s.totalCo2SavedKg >= 1000,
+  streak_7:    (s) => s.currentStreak >= 7,
+  streak_30:   (s) => s.currentStreak >= 30,
 };
 
 /**
@@ -67,10 +67,7 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
   // 3. Determine which badges are newly earned
   const newlyUnlocked: BadgeId[] = [];
 
-  for (const [badgeId, check] of Object.entries(BADGE_THRESHOLDS) as [
-    BadgeId,
-    (s: UserStats) => boolean,
-  ][]) {
+  for (const [badgeId, check] of Object.entries(BADGE_THRESHOLDS) as [BadgeId, (s: UserStats) => boolean][]) {
     if (!unlockedSet.has(badgeId) && check(userStats)) {
       newlyUnlocked.push(badgeId);
     }
@@ -134,7 +131,12 @@ export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
   if (revoked.length > 0) {
     await db
       .delete(achievements)
-      .where(and(eq(achievements.userId, userId), inArray(achievements.badgeId, revoked)));
+      .where(
+        and(
+          eq(achievements.userId, userId),
+          inArray(achievements.badgeId, revoked),
+        ),
+      );
   }
 
   return revoked;

--- a/server/src/routes/__tests__/leaderboard.test.ts
+++ b/server/src/routes/__tests__/leaderboard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock db and schema to prevent real Postgres connection on module load
+vi.mock("../../db", () => ({ db: {} }));
+vi.mock("../../db/schema", () => ({ trips: {} }));
+vi.mock("../../db/schema/auth", () => ({ user: {} }));
+vi.mock("../../lib/validation", () => ({ validationHook: vi.fn() }));
+
+import { denseRank } from "../leaderboard.routes";
+
+describe("denseRank", () => {
+  it("assigns rank 1 to all tied entries", () => {
+    const entries = [
+      { name: "Alice", score: 100 },
+      { name: "Bob", score: 100 },
+      { name: "Charlie", score: 100 },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked.map((e) => e.rank)).toEqual([1, 1, 1]);
+  });
+
+  it("assigns correct ranks with no ties", () => {
+    const entries = [
+      { name: "Alice", score: 100 },
+      { name: "Bob", score: 80 },
+      { name: "Charlie", score: 60 },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked.map((e) => e.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("uses position-based ranking after ties (standard competition ranking)", () => {
+    // The implementation uses idx+1 after a value change,
+    // producing standard competition ranking (1, 1, 3) not dense (1, 1, 2)
+    const entries = [
+      { name: "Alice", score: 100 },
+      { name: "Bob", score: 100 },
+      { name: "Charlie", score: 80 },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked.map((e) => e.rank)).toEqual([1, 1, 3]);
+  });
+
+  it("handles single entry", () => {
+    const entries = [{ name: "Alice", score: 50 }];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked).toEqual([{ name: "Alice", score: 50, rank: 1 }]);
+  });
+
+  it("handles empty array", () => {
+    const ranked = denseRank([], () => 0);
+    expect(ranked).toEqual([]);
+  });
+
+  it("preserves original entry properties", () => {
+    const entries = [
+      { id: "1", name: "Alice", score: 100, extra: "data" },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked[0]).toEqual({
+      id: "1",
+      name: "Alice",
+      score: 100,
+      extra: "data",
+      rank: 1,
+    });
+  });
+
+  it("handles multiple tie groups", () => {
+    const entries = [
+      { name: "A", score: 100 },
+      { name: "B", score: 100 },
+      { name: "C", score: 80 },
+      { name: "D", score: 80 },
+      { name: "E", score: 60 },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    // A=1, B=1, C=3, D=3, E=5
+    expect(ranked.map((e) => e.rank)).toEqual([1, 1, 3, 3, 5]);
+  });
+
+  it("handles zero values", () => {
+    const entries = [
+      { name: "A", score: 0 },
+      { name: "B", score: 0 },
+    ];
+    const ranked = denseRank(entries, (e) => e.score);
+    expect(ranked.map((e) => e.rank)).toEqual([1, 1]);
+  });
+});

--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -283,7 +283,7 @@ leaderboardRouter.get("/", zValidator("query", leaderboardQuery, validationHook)
  * Assign dense ranks based on a value extractor.
  * Entries with the same value get the same rank.
  */
-function denseRank<T>(entries: T[], getValue: (entry: T) => number): (T & { rank: number })[] {
+export function denseRank<T>(entries: T[], getValue: (entry: T) => number): (T & { rank: number })[] {
   let currentRank = 1;
   return entries.map((entry, idx) => {
     const val = getValue(entry);

--- a/server/src/validators/__tests__/trips.test.ts
+++ b/server/src/validators/__tests__/trips.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import { createTripSchema } from "../trips";
+
+function validTrip(overrides: Record<string, unknown> = {}) {
+  return {
+    distanceKm: 10,
+    durationSec: 1800,
+    startedAt: "2025-06-15T08:00:00Z",
+    endedAt: "2025-06-15T08:30:00Z",
+    ...overrides,
+  };
+}
+
+describe("createTripSchema", () => {
+  describe("valid inputs", () => {
+    it("accepts a minimal valid trip", () => {
+      const result = createTripSchema.safeParse(validTrip());
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts trip with gpsPoints", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          gpsPoints: [
+            { lat: 48.8566, lng: 2.3522, ts: 1718438400000 },
+            { lat: 48.857, lng: 2.353, ts: 1718438410000 },
+          ],
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts trip with null gpsPoints", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ gpsPoints: null }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts trip with idempotencyKey", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ idempotencyKey: "550e8400-e29b-41d4-a716-446655440000" }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts trip with no idempotencyKey", () => {
+      const result = createTripSchema.safeParse(validTrip());
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts distanceKm exactly 500 (max boundary)", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ distanceKm: 500 }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts durationSec exactly 1 (min boundary)", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: 1 }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts durationSec exactly 86400 (max boundary)", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: 86400 }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("distanceKm validation", () => {
+    it("rejects distanceKm > 500", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ distanceKm: 501 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects distanceKm = 0", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ distanceKm: 0 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects negative distanceKm", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ distanceKm: -1 }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("durationSec validation", () => {
+    it("rejects durationSec < 1", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: 0 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects negative durationSec", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: -5 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects durationSec > 86400", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: 86401 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-integer durationSec", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ durationSec: 1800.5 }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("startedAt / endedAt validation", () => {
+    it("rejects when startedAt >= endedAt", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          startedAt: "2025-06-15T09:00:00Z",
+          endedAt: "2025-06-15T08:00:00Z",
+        }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.map((i) => i.path.join("."));
+        expect(paths).toContain("startedAt");
+      }
+    });
+
+    it("rejects when startedAt equals endedAt", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          startedAt: "2025-06-15T08:00:00Z",
+          endedAt: "2025-06-15T08:00:00Z",
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid datetime strings", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ startedAt: "not-a-date" }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("gpsPoints validation", () => {
+    it("rejects gpsPoints array with > 10000 items", () => {
+      const points = Array.from({ length: 10001 }, (_, i) => ({
+        lat: 48.8566,
+        lng: 2.3522,
+        ts: 1718438400000 + i,
+      }));
+      const result = createTripSchema.safeParse(
+        validTrip({ gpsPoints: points }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts gpsPoints array with exactly 10000 items", () => {
+      const points = Array.from({ length: 10000 }, (_, i) => ({
+        lat: 48.8566,
+        lng: 2.3522,
+        ts: 1718438400000 + i,
+      }));
+      const result = createTripSchema.safeParse(
+        validTrip({ gpsPoints: points }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects gpsPoint with lat out of range", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          gpsPoints: [{ lat: 91, lng: 2.3522, ts: 1718438400000 }],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects gpsPoint with lat below -90", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          gpsPoints: [{ lat: -91, lng: 2.3522, ts: 1718438400000 }],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects gpsPoint with lng out of range", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          gpsPoints: [{ lat: 48.8566, lng: 181, ts: 1718438400000 }],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects gpsPoint with lng below -180", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({
+          gpsPoints: [{ lat: 48.8566, lng: -181, ts: 1718438400000 }],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("idempotencyKey validation", () => {
+    it("rejects non-UUID idempotencyKey", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ idempotencyKey: "not-a-uuid" }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid UUID v4", () => {
+      const result = createTripSchema.safeParse(
+        validTrip({ idempotencyKey: "f47ac10b-58cc-4372-a567-0e02b2c3d479" }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@ecoride/shared": path.resolve(__dirname, "../shared"),
+    },
+  },
+  test: {
+    globals: true,
+    exclude: ["node_modules/**"],
+  },
+});


### PR DESCRIPTION
## Summary
- **Set up vitest for server** — `server/vitest.config.ts` + `"test"` script in `server/package.json`
- **83 unit tests** covering all pure logic functions with zero DB/HTTP dependencies:
  - `calculateSavings()` — normal, zero-distance, high-consumption, low-price, rounding edge cases
  - `computeStreakFromDates()` — consecutive days, gaps, dedup, unsorted input, stale dates
  - `computeAvgSpeedKmh()` — zero/negative duration, rounding
  - `BADGE_THRESHOLDS` — all 12 badge predicates at exact boundary and just below
  - `createTripSchema` (Zod) — valid inputs, distanceKm/durationSec limits, startedAt > endedAt, GPS point bounds, idempotencyKey UUID format
  - `denseRank()` — ties, no ties, gaps after ties, single/empty, property preservation
- **CI updated** to run `cd server && bunx vitest run` in the test job
- Minor exports added (`BADGE_THRESHOLDS`, `UserStats`, `denseRank`) to make pure functions testable

## Test plan
- [x] `bunx vitest run` in `server/` passes (83/83)
- [x] `bunx vitest run` in `client/` still passes (74/74)
- [x] `bun run typecheck` passes across all workspaces
- [ ] CI pipeline runs both client and server tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)