### PR TITLE
feat: admin dashboard with health, stats, trips

### DIFF
--- a/client/e2e/smoke.spec.ts
+++ b/client/e2e/smoke.spec.ts
@@ -18,6 +18,7 @@ const PAGES = [
   { path: "/stats", name: "Stats" },
   { path: "/leaderboard", name: "Leaderboard" },
   { path: "/profile", name: "Profile" },
+  { path: "/admin", name: "Admin" },
   { path: "/privacy", name: "Privacy" },
   { path: "/nonexistent", name: "404" },
 ];
@@ -44,3 +45,120 @@ for (const { path, name } of PAGES) {
     await expect(body).not.toBeEmpty();
   });
 }
+
+test.describe("admin dashboard", () => {
+  // Block service workers so route stubs can intercept fetch requests
+  test.use({ serviceWorkers: "block" });
+
+  test("Admin (/admin) renders dashboard when user is admin", async ({ page }) => {
+    const adminUser = {
+      id: "admin-1",
+      name: "Admin",
+      email: "admin@test.com",
+      isAdmin: true,
+      image: null,
+      vehicleModel: null,
+      fuelType: null,
+      consumptionL100: null,
+      mileage: null,
+      leaderboardOptOut: false,
+      reminderEnabled: false,
+      reminderTime: null,
+      reminderDays: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      emailVerified: true,
+    };
+
+    // Single route handler that dispatches based on URL
+    await page.route(/\/api\//, (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            user: adminUser,
+            session: {
+              id: "session-1",
+              token: "test-token",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/api/user/profile")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              user: adminUser,
+              stats: {
+                totalDistanceKm: 0,
+                totalCo2SavedKg: 0,
+                totalMoneySavedEur: 0,
+                totalFuelSavedL: 0,
+                tripCount: 0,
+              },
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/api/admin/health")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              version: "1.0.0",
+              uptime: 3600,
+              userCount: 5,
+              tripCount: 42,
+              tripsToday: 3,
+              tripsThisWeek: 12,
+              dbConnected: true,
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/api/admin/stats")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              users: [],
+              recentTrips: [],
+              dailyTripCounts: [],
+            },
+          }),
+        });
+      }
+
+      // Default stub for any other API calls
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: {} }),
+      });
+    });
+
+    await page.goto("/admin", { waitUntil: "networkidle" });
+
+    // Should not crash
+    const errorBoundary = page.getByText("Une erreur est survenue");
+    await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
+
+    // Should show admin header text
+    const adminHeader = page.getByText("Admin");
+    await expect(adminHeader).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ const LeaderboardPage = lazy(() =>
 const ProfilePage = lazy(() =>
   import("@/pages/ProfilePage").then((m) => ({ default: m.ProfilePage })),
 );
+const AdminPage = lazy(() => import("@/pages/AdminPage").then((m) => ({ default: m.AdminPage })));
 const NotFoundPage = lazy(() =>
   import("@/pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })),
 );
@@ -43,6 +44,7 @@ export function App() {
             <Route path="stats" element={<StatsPage />} />
             <Route path="leaderboard" element={<LeaderboardPage />} />
             <Route path="profile" element={<ProfilePage />} />
+            <Route path="admin" element={<AdminPage />} />
           </Route>
         </Route>
         <Route path="*" element={<NotFoundPage />} />

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -128,6 +128,61 @@ export function useFuelPrice(fuelType: string) {
   });
 }
 
+// ---- Admin queries ----
+
+export interface AdminHealthData {
+  version: string;
+  uptime: number;
+  userCount: number;
+  tripCount: number;
+  tripsToday: number;
+  tripsThisWeek: number;
+  dbConnected: boolean;
+}
+
+export interface AdminStatsUser {
+  id: string;
+  name: string;
+  email: string;
+  tripCount: number;
+  totalCo2: number;
+  createdAt: string;
+  isAdmin: boolean;
+}
+
+export interface AdminStatsTrip {
+  id: string;
+  userId: string;
+  userName: string;
+  distanceKm: number;
+  durationSec: number;
+  co2SavedKg: number;
+  startedAt: string;
+}
+
+export interface AdminStatsData {
+  users: AdminStatsUser[];
+  recentTrips: AdminStatsTrip[];
+  dailyTripCounts: { date: string; count: number }[];
+}
+
+export function useAdminHealth() {
+  return useQuery({
+    queryKey: ["admin", "health"],
+    queryFn: () =>
+      apiFetch<{ ok: boolean; data: AdminHealthData }>("/admin/health").then((r) => r.data),
+    refetchInterval: 30_000, // refresh every 30s
+  });
+}
+
+export function useAdminStats() {
+  return useQuery({
+    queryKey: ["admin", "stats"],
+    queryFn: () =>
+      apiFetch<{ ok: boolean; data: AdminStatsData }>("/admin/stats").then((r) => r.data),
+  });
+}
+
 // ---- Mutations ----
 
 export function useCreateTrip() {

--- a/client/src/lib/mock-data.ts
+++ b/client/src/lib/mock-data.ts
@@ -14,6 +14,7 @@ export const mockUser: User = {
   reminderEnabled: true,
   reminderTime: "08:00",
   reminderDays: ["mon", "tue", "wed", "thu", "fri"],
+  isAdmin: false,
   createdAt: "2026-01-15T10:00:00Z",
 };
 

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,0 +1,327 @@
+import { useEffect } from "react";
+import { useNavigate, Link } from "react-router";
+import {
+  Shield,
+  Users,
+  MapPin,
+  Calendar,
+  CalendarDays,
+  Database,
+  Clock,
+  ArrowLeft,
+  Bike,
+} from "lucide-react";
+import { useAdminHealth, useAdminStats, useProfile } from "@/hooks/queries";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}j ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatDuration(sec: number): string {
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  if (h > 0) return `${h}h${m.toString().padStart(2, "0")}`;
+  return `${m}min`;
+}
+
+export function AdminPage() {
+  const navigate = useNavigate();
+  const { data: profileData, isPending: profilePending } = useProfile();
+  const { data: health, isPending: healthPending } = useAdminHealth();
+  const { data: stats, isPending: statsPending } = useAdminStats();
+
+  const isAdmin = profileData?.user?.isAdmin === true;
+
+  // Redirect non-admin users
+  useEffect(() => {
+    if (!profilePending && profileData?.user && !profileData.user.isAdmin) {
+      navigate("/", { replace: true });
+    }
+  }, [profilePending, profileData, navigate]);
+
+  if (profilePending) {
+    return (
+      <div
+        className="flex flex-1 items-center justify-center"
+        role="status"
+        aria-label="Chargement"
+      >
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  const chartData = stats?.dailyTripCounts.map((d) => ({
+    date: new Date(d.date + "T00:00:00").toLocaleDateString("fr-FR", {
+      weekday: "short",
+      day: "numeric",
+    }),
+    count: d.count,
+  }));
+
+  return (
+    <>
+      {/* Header */}
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center gap-3 bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
+        <Link to="/" className="rounded-lg p-1 text-text-muted hover:text-text" aria-label="Retour">
+          <ArrowLeft size={20} />
+        </Link>
+        <div className="flex items-center gap-2">
+          <Shield size={20} className="text-primary-light" />
+          <span className="text-xl font-bold tracking-tighter">
+            <span className="text-text">Admin</span>
+            <span className="text-text-dim"> — </span>
+            <span className="text-text">eco</span>
+            <span className="text-primary-light">Ride</span>
+          </span>
+        </div>
+      </header>
+
+      <div className="space-y-6 px-6 pb-6">
+        {/* System Info Card */}
+        <section className="rounded-xl bg-surface-low p-5">
+          <h2 className="mb-3 text-xs font-bold uppercase tracking-widest text-text-muted">
+            Systeme
+          </h2>
+          {healthPending ? (
+            <div className="flex justify-center py-4">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            </div>
+          ) : health ? (
+            <div className="grid grid-cols-3 gap-4">
+              <div className="flex flex-col items-center gap-1">
+                <span className="text-xs font-bold uppercase text-text-dim">Version</span>
+                <span className="text-sm font-bold text-text">{health.version}</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Clock size={14} className="text-text-dim" />
+                <span className="text-xs font-bold uppercase text-text-dim">Uptime</span>
+                <span className="text-sm font-bold text-text">{formatUptime(health.uptime)}</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Database size={14} className="text-text-dim" />
+                <span className="text-xs font-bold uppercase text-text-dim">DB</span>
+                <span
+                  className={`text-sm font-bold ${health.dbConnected ? "text-primary-light" : "text-danger"}`}
+                >
+                  {health.dbConnected ? "OK" : "DOWN"}
+                </span>
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        {/* Stats Cards Row */}
+        <section className="grid grid-cols-2 gap-4">
+          <StatCard
+            icon={<Users size={18} className="text-primary-light" />}
+            label="Utilisateurs"
+            value={health?.userCount}
+            loading={healthPending}
+          />
+          <StatCard
+            icon={<MapPin size={18} className="text-primary-light" />}
+            label="Trajets total"
+            value={health?.tripCount}
+            loading={healthPending}
+          />
+          <StatCard
+            icon={<Calendar size={18} className="text-primary-light" />}
+            label="Aujourd'hui"
+            value={health?.tripsToday}
+            loading={healthPending}
+          />
+          <StatCard
+            icon={<CalendarDays size={18} className="text-primary-light" />}
+            label="Cette semaine"
+            value={health?.tripsThisWeek}
+            loading={healthPending}
+          />
+        </section>
+
+        {/* Chart: trips per day (last 7 days) */}
+        <section className="rounded-xl bg-surface-low p-5">
+          <h2 className="mb-4 text-xs font-bold uppercase tracking-widest text-text-muted">
+            Trajets — 7 derniers jours
+          </h2>
+          {statsPending ? (
+            <div className="flex justify-center py-8">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            </div>
+          ) : chartData && chartData.length > 0 ? (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 11 }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  allowDecimals={false}
+                  tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 11 }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={30}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "#2d3436",
+                    border: "1px solid rgba(255,255,255,0.1)",
+                    borderRadius: "8px",
+                    color: "#dfe6e9",
+                    fontSize: "12px",
+                  }}
+                  labelStyle={{ color: "#dfe6e9" }}
+                />
+                <Bar dataKey="count" fill="#2ecc71" radius={[4, 4, 0, 0]} name="Trajets" />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <p className="py-4 text-center text-sm text-text-muted">Aucune donnee</p>
+          )}
+        </section>
+
+        {/* Users Table */}
+        <section className="rounded-xl bg-surface-low p-5">
+          <h2 className="mb-4 text-xs font-bold uppercase tracking-widest text-text-muted">
+            Utilisateurs
+          </h2>
+          {statsPending ? (
+            <div className="flex justify-center py-4">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            </div>
+          ) : stats?.users && stats.users.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-white/5 text-xs font-bold uppercase tracking-widest text-text-dim">
+                    <th className="pb-3 pr-4">Nom</th>
+                    <th className="pb-3 pr-4">Email</th>
+                    <th className="pb-3 pr-4 text-right">Trajets</th>
+                    <th className="pb-3 pr-4 text-right">CO2 (kg)</th>
+                    <th className="pb-3 text-right">Inscrit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {stats.users.map((u) => (
+                    <tr key={u.id} className="border-b border-white/5 last:border-0">
+                      <td className="py-3 pr-4 font-medium text-text">
+                        {u.name}
+                        {u.isAdmin && (
+                          <span className="ml-2 inline-flex items-center rounded bg-primary/20 px-1.5 py-0.5 text-xs font-bold text-primary-light">
+                            admin
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-3 pr-4 text-text-muted">{u.email}</td>
+                      <td className="py-3 pr-4 text-right text-text">{u.tripCount}</td>
+                      <td className="py-3 pr-4 text-right text-text">
+                        {typeof u.totalCo2 === "number" ? u.totalCo2.toFixed(1) : "0.0"}
+                      </td>
+                      <td className="py-3 text-right text-text-muted">{formatDate(u.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="py-4 text-center text-sm text-text-muted">Aucun utilisateur</p>
+          )}
+        </section>
+
+        {/* Recent Trips */}
+        <section className="rounded-xl bg-surface-low p-5">
+          <h2 className="mb-4 text-xs font-bold uppercase tracking-widest text-text-muted">
+            Derniers trajets
+          </h2>
+          {statsPending ? (
+            <div className="flex justify-center py-4">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            </div>
+          ) : stats?.recentTrips && stats.recentTrips.length > 0 ? (
+            <div className="space-y-3">
+              {stats.recentTrips.map((trip) => (
+                <div
+                  key={trip.id}
+                  className="flex items-center gap-3 rounded-lg bg-surface-high p-3"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+                    <Bike size={18} className="text-primary-light" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <span className="truncate text-sm font-bold text-text">{trip.userName}</span>
+                      <span className="shrink-0 text-xs text-text-dim">
+                        {trip.distanceKm.toFixed(1)} km
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-text-muted">
+                      <span>{formatDate(trip.startedAt)}</span>
+                      <span>-</span>
+                      <span>{formatDuration(trip.durationSec)}</span>
+                      <span>-</span>
+                      <span>{trip.co2SavedKg.toFixed(1)} kg CO2</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="py-4 text-center text-sm text-text-muted">Aucun trajet</p>
+          )}
+        </section>
+      </div>
+    </>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  loading,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number | undefined;
+  loading: boolean;
+}) {
+  return (
+    <div className="rounded-xl bg-surface-low p-5">
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="text-xs font-bold uppercase tracking-widest text-text-dim">{label}</span>
+      </div>
+      <div className="mt-2">
+        {loading ? (
+          <div className="h-8 w-16 animate-pulse rounded bg-surface-high" />
+        ) : (
+          <span className="text-3xl font-bold text-text">{value ?? 0}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, Link } from "react-router";
 import {
   User as UserIcon,
   Bike,
@@ -13,6 +13,7 @@ import {
   Droplets,
   Download,
   Trash2,
+  Shield,
 } from "lucide-react";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
@@ -436,6 +437,20 @@ export function ProfilePage() {
               )}
             </div>
           </div>
+
+          {/* Admin link (only visible for admins) */}
+          {user.isAdmin && (
+            <Link
+              to="/admin"
+              className="mt-4 flex w-full items-center justify-between rounded-lg bg-surface-high p-4 transition-colors hover:bg-surface-low"
+            >
+              <div className="flex items-center gap-4">
+                <Shield size={20} className="text-primary-light" />
+                <span className="text-sm font-medium">Administration</span>
+              </div>
+              <ChevronRight size={18} className="text-text-dim" />
+            </Link>
+          )}
 
           <button
             onClick={handleLogout}

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -50,6 +50,7 @@ export const auth = betterAuth({
       reminderEnabled: { type: "boolean", required: false, defaultValue: false },
       reminderTime: { type: "string", required: false },
       reminderDays: { type: "string[]", required: false },
+      isAdmin: { type: "boolean", required: false, defaultValue: false },
     },
   },
 });

--- a/server/src/auth/admin.ts
+++ b/server/src/auth/admin.ts
@@ -1,0 +1,16 @@
+import { createMiddleware } from "hono/factory";
+import { forbidden } from "../lib/errors";
+import type { AuthEnv } from "../types/context";
+
+/**
+ * Admin middleware — must be used AFTER authMiddleware.
+ * Checks that the authenticated user has isAdmin === true.
+ * Returns 403 Forbidden otherwise.
+ */
+export const adminMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
+  const user = c.get("user");
+  if (!user || user.isAdmin !== true) {
+    throw forbidden("Admin access required");
+  }
+  await next();
+});

--- a/server/src/db/schema/auth.ts
+++ b/server/src/db/schema/auth.ts
@@ -21,6 +21,7 @@ export const user = pgTable("user", {
   reminderEnabled: boolean("reminder_enabled").notNull().default(false),
   reminderTime: text("reminder_time"), // HH:MM
   reminderDays: text("reminder_days").array(), // ["mon","tue",...]
+  isAdmin: boolean("is_admin").notNull().default(false),
 });
 
 // Better Auth session table

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -1,0 +1,158 @@
+import { Hono } from "hono";
+import { eq, count, gte, sum, sql, desc } from "drizzle-orm";
+import { db } from "../db";
+import { user, trips } from "../db/schema";
+import { adminMiddleware } from "../auth/admin";
+import type { AuthEnv } from "../types/context";
+
+const appVersion = (() => {
+  try {
+    return require("../../package.json").version;
+  } catch {
+    return "unknown";
+  }
+})();
+
+const adminRouter = new Hono<AuthEnv>();
+
+// All admin routes require admin privileges
+adminRouter.use("*", adminMiddleware);
+
+// GET /api/admin/health — Enhanced health check (admin-only)
+adminRouter.get("/health", async (c) => {
+  // User count
+  const [userCountResult] = await db.select({ value: count() }).from(user);
+  const userCount = userCountResult?.value ?? 0;
+
+  // Trip count
+  const [tripCountResult] = await db.select({ value: count() }).from(trips);
+  const tripCount = tripCountResult?.value ?? 0;
+
+  // Trips today
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+  const [tripsTodayResult] = await db
+    .select({ value: count() })
+    .from(trips)
+    .where(gte(trips.startedAt, todayMidnight));
+  const tripsToday = tripsTodayResult?.value ?? 0;
+
+  // Trips this week (Monday 00:00)
+  const weekStart = new Date();
+  weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+  weekStart.setHours(0, 0, 0, 0);
+  const [tripsWeekResult] = await db
+    .select({ value: count() })
+    .from(trips)
+    .where(gte(trips.startedAt, weekStart));
+  const tripsThisWeek = tripsWeekResult?.value ?? 0;
+
+  // DB connectivity check
+  let dbConnected = false;
+  try {
+    await db.execute(sql`SELECT 1`);
+    dbConnected = true;
+  } catch {
+    // dbConnected stays false
+  }
+
+  return c.json({
+    ok: true,
+    data: {
+      version: appVersion,
+      uptime: process.uptime(),
+      userCount,
+      tripCount,
+      tripsToday,
+      tripsThisWeek,
+      dbConnected,
+    },
+  });
+});
+
+// GET /api/admin/stats — Detailed admin stats
+adminRouter.get("/stats", async (c) => {
+  // Users with trip count and total CO2
+  const users = await db
+    .select({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      createdAt: user.createdAt,
+      isAdmin: user.isAdmin,
+      tripCount: count(trips.id),
+      totalCo2: sum(trips.co2SavedKg).mapWith(Number),
+    })
+    .from(user)
+    .leftJoin(trips, eq(user.id, trips.userId))
+    .groupBy(user.id, user.name, user.email, user.createdAt, user.isAdmin)
+    .orderBy(desc(user.createdAt));
+
+  // Recent 20 trips with user name
+  const recentTrips = await db
+    .select({
+      id: trips.id,
+      userId: trips.userId,
+      userName: user.name,
+      distanceKm: trips.distanceKm,
+      durationSec: trips.durationSec,
+      co2SavedKg: trips.co2SavedKg,
+      startedAt: trips.startedAt,
+    })
+    .from(trips)
+    .innerJoin(user, eq(trips.userId, user.id))
+    .orderBy(desc(trips.startedAt))
+    .limit(20);
+
+  // Daily trip counts for last 7 days
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 6);
+  sevenDaysAgo.setHours(0, 0, 0, 0);
+
+  const dailyTrips = await db
+    .select({
+      date: sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`.as("date"),
+      count: count(),
+    })
+    .from(trips)
+    .where(gte(trips.startedAt, sevenDaysAgo))
+    .groupBy(sql`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`)
+    .orderBy(sql`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`);
+
+  // Fill in missing days with count 0
+  const dailyTripCounts: { date: string; count: number }[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(sevenDaysAgo);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toISOString().split("T")[0]!;
+    const found = dailyTrips.find((r) => String(r.date) === dateStr);
+    dailyTripCounts.push({ date: dateStr, count: found ? found.count : 0 });
+  }
+
+  return c.json({
+    ok: true,
+    data: {
+      users: users.map((u) => ({
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        tripCount: u.tripCount,
+        totalCo2: u.totalCo2 ?? 0,
+        createdAt: u.createdAt.toISOString(),
+        isAdmin: u.isAdmin,
+      })),
+      recentTrips: recentTrips.map((t) => ({
+        id: t.id,
+        userId: t.userId,
+        userName: t.userName,
+        distanceKm: t.distanceKm,
+        durationSec: t.durationSec,
+        co2SavedKg: t.co2SavedKg,
+        startedAt: t.startedAt.toISOString(),
+      })),
+      dailyTripCounts,
+    },
+  });
+});
+
+export { adminRouter };

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6,6 +6,7 @@ import { statsRouter } from "./stats.routes";
 import { achievementsRouter } from "./achievements.routes";
 import { fuelPriceRouter } from "./fuel-price.routes";
 import { pushRouter } from "./push.routes";
+import { adminRouter } from "./admin.routes";
 import type { AuthEnv } from "../types/context";
 
 const apiRouter = new Hono<AuthEnv>();
@@ -17,5 +18,6 @@ apiRouter.route("/stats", statsRouter);
 apiRouter.route("/achievements", achievementsRouter);
 apiRouter.route("/fuel-price", fuelPriceRouter);
 apiRouter.route("/push", pushRouter);
+apiRouter.route("/admin", adminRouter);
 
 export { apiRouter };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -13,6 +13,7 @@ export interface User {
   reminderEnabled: boolean;
   reminderTime: string | null;
   reminderDays: WeekDay[] | null;
+  isAdmin: boolean;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Add `isAdmin` boolean flag to user table (DB schema + Better Auth config)
- Create admin middleware that checks `isAdmin === true`, returns 403 otherwise
- Add `GET /api/admin/health` endpoint: version, uptime, user/trip counts, DB connectivity
- Add `GET /api/admin/stats` endpoint: users with trip counts + CO2, last 20 trips, daily trip chart (7 days)
- Create `AdminPage` component: system info card, stats cards row, bar chart (recharts), users table, recent trips list — charcoal theme matching the rest of the app
- Add `/admin` route (lazy-loaded, inside ProtectedRoute, with client-side isAdmin guard)
- Add `useAdminHealth()` and `useAdminStats()` query hooks
- Show "Administration" link in ProfilePage settings section (only when `user.isAdmin`)
- Add Playwright smoke test for `/admin` page (service workers blocked, admin API stubs)

## Test plan
- [x] `bun run typecheck` passes (server + client)
- [x] Playwright smoke tests pass (9/9 including new admin test)
- [ ] Manually verify admin page loads with admin user
- [ ] Verify non-admin users are redirected from /admin
- [ ] Verify /api/admin/* endpoints return 403 for non-admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)