### PR TITLE
fix: stop button position and map visibility during active tracking

### DIFF
--- a/client/e2e/tracking-layout.spec.ts
+++ b/client/e2e/tracking-layout.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test("#82 regression: stop button anchored at bottom and map visible during tracking", async ({
+  page,
+  context,
+}) => {
+  // Grant geolocation and fake position
+  await context.grantPermissions(["geolocation"]);
+  await context.setGeolocation({ latitude: 48.8566, longitude: 2.3522 });
+
+  // Stub API
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  // Start tracking
+  const startBtn = page.getByText("Démarrer");
+  await expect(startBtn).toBeVisible();
+  await startBtn.click();
+
+  // Wait for tracking UI
+  const stopBtn = page.getByText("Terminer");
+  await expect(stopBtn).toBeVisible({ timeout: 5000 });
+
+  // REGRESSION: Map must be visible during tracking
+  const mapContainer = page.locator(".leaflet-container");
+  await expect(mapContainer).toBeVisible({ timeout: 3000 });
+  const mapBox = await mapContainer.boundingBox();
+  expect(mapBox).not.toBeNull();
+  expect(mapBox!.height).toBeGreaterThan(50);
+
+  // REGRESSION: Stop button must be near the bottom of the viewport
+  const stopBtnBox = await stopBtn.boundingBox();
+  expect(stopBtnBox).not.toBeNull();
+  const viewport = page.viewportSize()!;
+  // Button bottom edge should be in the lower 40% of the viewport
+  const buttonBottom = stopBtnBox!.y + stopBtnBox!.height;
+  expect(buttonBottom).toBeGreaterThan(viewport.height * 0.6);
+
+  // REGRESSION: Stop button must be below the map (not overlapping)
+  expect(stopBtnBox!.y).toBeGreaterThanOrEqual(mapBox!.y + mapBox!.height - 1);
+
+  // ErrorBoundary should not appear
+  const errorBoundary = page.getByText("Une erreur est survenue");
+  await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
+});

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -171,7 +171,9 @@ export function TripPage() {
   };
 
   return (
-    <div className="relative flex h-full flex-col">
+    <div
+      className={`relative flex flex-col ${uiState === "tracking" ? "h-[calc(100dvh_-_6rem)]" : "h-full"}`}
+    >
       {/* Header with persistent GPS indicator */}
       <header
         role="banner"
@@ -299,7 +301,7 @@ export function TripPage() {
           </div>
 
           {/* Mini map */}
-          <div className="relative flex-1" style={{ minHeight: "150px" }}>
+          <div className="relative min-h-0 flex-1" data-testid="tracking-map">
             <MapContainer
               center={currentPos as LatLngExpression}
               zoom={15}


### PR DESCRIPTION
Closes #82

## Summary
- **Map invisible during tracking**: PullToRefresh's wrapper div broke the `h-full` height chain, leaving `flex-1` on the map with no space to expand. Fixed by using viewport-based height (`100dvh - 6rem`) during tracking, making the layout independent of the parent chain.
- **Stop button mid-screen**: With the flex column now properly constrained, `flex-1` on the map pushes the stop button to the bottom naturally.
- **Regression test**: Verifies map visibility, map height > 50px, stop button in lower 40% of viewport, and no button/map overlap.

## Changes
- `client/src/pages/TripPage.tsx` — 2 lines changed (container height + map flex classes)
- `client/e2e/tracking-layout.spec.ts` — new regression test

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] New regression test `tracking-layout.spec.ts` passes
- [x] All 16 Playwright e2e tests pass
- [ ] Manual test on mobile: start tracking → map visible, stop button at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)