### PR TITLE
fix: stats evolution charts respect the period filter

### DIFF
--- a/client/e2e/stats-period.spec.ts
+++ b/client/e2e/stats-period.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for #86: stats evolution charts must respect the period filter.
+ *
+ * Before the fix, useWeeklyTrips() was hardcoded to Mon→Sun regardless of
+ * the selected period. After the fix, useChartTrips(period) fetches the
+ * correct date range and the chart data is re-aggregated accordingly.
+ *
+ * Strategy: intercept /api/trips chart calls (limit=500) and verify that
+ * switching period triggers new requests with progressively earlier `from` dates.
+ */
+test.describe("Stats evolution period filter (#86)", () => {
+  test("switching period changes the trips date range query", async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+    });
+
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    const chartFromDates: string[] = [];
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      // Track chart requests (limit=500 distinguishes them from list requests)
+      if (url.includes("/trips") && url.includes("limit=500")) {
+        const fromMatch = url.match(/from=([^&]+)/);
+        if (fromMatch) chartFromDates.push(decodeURIComponent(fromMatch[1]));
+      }
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session: {
+              id: "s",
+              userId: "u",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "u",
+              name: "Test",
+              email: "t@t.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/stats/summary")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              totalDistanceKm: 120,
+              totalCo2SavedKg: 18,
+              totalMoneySavedEur: 25,
+              totalFuelSavedL: 10,
+              tripCount: 5,
+              currentStreak: 2,
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/trips")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              trips: [
+                {
+                  id: "t1",
+                  userId: "u",
+                  distanceKm: 10,
+                  durationSec: 1800,
+                  co2SavedKg: 1.5,
+                  moneySavedEur: 2.1,
+                  fuelSavedL: 0.7,
+                  startedAt: new Date().toISOString(),
+                  endedAt: new Date().toISOString(),
+                  gpsPoints: null,
+                },
+              ],
+            },
+            pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+          }),
+        });
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { achievements: [] } }),
+      });
+    });
+
+    // Load stats page — default period is "week"
+    await page.goto("/stats", { waitUntil: "networkidle" });
+
+    // Should have made a chart request for this week
+    expect(chartFromDates.length).toBeGreaterThanOrEqual(1);
+    const weekFrom = new Date(chartFromDates[chartFromDates.length - 1]);
+
+    // Click "Mois" — should fetch from 1st of current month (earlier than Monday)
+    chartFromDates.length = 0;
+    await page.getByText("Mois", { exact: true }).click();
+    await page.waitForTimeout(1000);
+    expect(chartFromDates.length).toBeGreaterThanOrEqual(1);
+    const monthFrom = new Date(chartFromDates[chartFromDates.length - 1]);
+    expect(monthFrom.getTime()).toBeLessThanOrEqual(weekFrom.getTime());
+
+    // Click "Année" — should fetch from Jan 1st (earlier than 1st of month)
+    chartFromDates.length = 0;
+    await page.getByText("Année", { exact: true }).click();
+    await page.waitForTimeout(1000);
+    expect(chartFromDates.length).toBeGreaterThanOrEqual(1);
+    const yearFrom = new Date(chartFromDates[chartFromDates.length - 1]);
+    expect(yearFrom.getTime()).toBeLessThanOrEqual(monthFrom.getTime());
+
+    // Year start should be in January of the current year
+    expect(yearFrom.getFullYear()).toBe(new Date().getFullYear());
+    expect(yearFrom.getMonth()).toBeLessThanOrEqual(0); // January = 0
+  });
+});

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -48,24 +48,33 @@ export function useTrips(page = 1, limit = 50) {
   });
 }
 
-export function useWeeklyTrips() {
+export function useChartTrips(period: "week" | "month" | "year") {
   const now = new Date();
-  const monday = new Date(now);
-  monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
-  monday.setHours(0, 0, 0, 0);
-  const from = monday.toISOString();
-  const to = now.toISOString();
+  let from: Date;
+
+  if (period === "week") {
+    from = new Date(now);
+    from.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+    from.setHours(0, 0, 0, 0);
+  } else if (period === "month") {
+    from = new Date(now.getFullYear(), now.getMonth(), 1);
+  } else {
+    from = new Date(now.getFullYear(), 0, 1);
+  }
+
+  const fromStr = from.toISOString();
+  const toStr = now.toISOString();
 
   return useQuery({
-    queryKey: ["trips", "weekly", from],
+    queryKey: ["trips", "chart", period, fromStr],
     queryFn: () =>
       apiFetch<{
         ok: boolean;
         data: { trips: Trip[] };
         pagination: { page: number; limit: number; total: number; totalPages: number };
-      }>(`/trips?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&limit=100`).then(
-        (r) => r.data.trips,
-      ),
+      }>(
+        `/trips?from=${encodeURIComponent(fromStr)}&to=${encodeURIComponent(toStr)}&limit=500`,
+      ).then((r) => r.data.trips),
   });
 }
 

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -11,7 +11,7 @@ import {
   useDashboardSummary,
   useTrips,
   useTrip,
-  useWeeklyTrips,
+  useChartTrips,
   useAchievements,
   useDeleteTrip,
 } from "@/hooks/queries";
@@ -33,6 +33,20 @@ const metricLabels: Record<Metric, string> = {
 };
 
 const DAY_LABELS = ["L", "M", "M", "J", "V", "S", "D"];
+const MONTH_LABELS = [
+  "Jan",
+  "Fév",
+  "Mar",
+  "Avr",
+  "Mai",
+  "Juin",
+  "Juil",
+  "Août",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Déc",
+];
 
 const allBadgeIds = Object.keys(BADGES) as BadgeId[];
 
@@ -80,7 +94,7 @@ export function StatsPage() {
   const [selectedTrip, setSelectedTrip] = useState<Trip | null>(null);
   const { data: s, isPending: summaryLoading } = useDashboardSummary("month");
   const { data: tripsData, isPending: tripsLoading } = useTrips(1, 10);
-  const { data: weeklyTrips, isPending: weeklyLoading } = useWeeklyTrips();
+  const { data: chartTripsData, isPending: chartLoading } = useChartTrips(period);
   const { data: achievements, isPending: achievementsLoading } = useAchievements();
   const { data: tripDetail } = useTrip(selectedTrip?.id ?? null);
   const deleteTrip = useDeleteTrip();
@@ -100,27 +114,55 @@ export function StatsPage() {
   const gpsPoints = displayTrip?.gpsPoints;
   const hasGpsTrack = Array.isArray(gpsPoints) && gpsPoints.length > 1;
 
-  const isPending = summaryLoading || tripsLoading || weeklyLoading || achievementsLoading;
+  const isPending = summaryLoading || tripsLoading || chartLoading || achievementsLoading;
 
   const trips = tripsData?.trips ?? [];
-  const chartTrips = weeklyTrips ?? [];
+  const chartTrips = chartTripsData ?? [];
 
-  // Build weekly chart data from all trips this week (memoized)
+  // Build chart data from trips for the selected period (memoized)
   // MUST be before any early return to respect Rules of Hooks
-  const weeklyData = useMemo(() => {
-    const data = DAY_LABELS.map((day) => ({ day, km: 0, co2: 0, eur: 0 }));
+  const chartData = useMemo(() => {
+    let data: { label: string; km: number; co2: number; eur: number }[];
 
-    for (const trip of chartTrips) {
-      const tripDate = new Date(trip.startedAt);
-      const dayIdx = (tripDate.getDay() + 6) % 7; // Mon=0, Sun=6
-      if (data[dayIdx]) {
-        data[dayIdx].km += trip.distanceKm;
-        data[dayIdx].co2 += trip.co2SavedKg;
-        data[dayIdx].eur += trip.moneySavedEur;
+    if (period === "week") {
+      data = DAY_LABELS.map((label) => ({ label, km: 0, co2: 0, eur: 0 }));
+      for (const trip of chartTrips) {
+        const dayIdx = (new Date(trip.startedAt).getDay() + 6) % 7;
+        if (data[dayIdx]) {
+          data[dayIdx].km += trip.distanceKm;
+          data[dayIdx].co2 += trip.co2SavedKg;
+          data[dayIdx].eur += trip.moneySavedEur;
+        }
+      }
+    } else if (period === "month") {
+      const now = new Date();
+      const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+      data = Array.from({ length: daysInMonth }, (_, i) => ({
+        label: String(i + 1),
+        km: 0,
+        co2: 0,
+        eur: 0,
+      }));
+      for (const trip of chartTrips) {
+        const dayOfMonth = new Date(trip.startedAt).getDate() - 1;
+        if (data[dayOfMonth]) {
+          data[dayOfMonth].km += trip.distanceKm;
+          data[dayOfMonth].co2 += trip.co2SavedKg;
+          data[dayOfMonth].eur += trip.moneySavedEur;
+        }
+      }
+    } else {
+      data = MONTH_LABELS.map((label) => ({ label, km: 0, co2: 0, eur: 0 }));
+      for (const trip of chartTrips) {
+        const monthIdx = new Date(trip.startedAt).getMonth();
+        if (data[monthIdx]) {
+          data[monthIdx].km += trip.distanceKm;
+          data[monthIdx].co2 += trip.co2SavedKg;
+          data[monthIdx].eur += trip.moneySavedEur;
+        }
       }
     }
 
-    // Round values for display
     for (const d of data) {
       d.km = Math.round(d.km * 10) / 10;
       d.co2 = Math.round(d.co2 * 10) / 10;
@@ -128,7 +170,7 @@ export function StatsPage() {
     }
 
     return data;
-  }, [chartTrips]);
+  }, [chartTrips, period]);
 
   if (isPending || !s) {
     return (
@@ -274,13 +316,14 @@ export function StatsPage() {
               {/* Line Chart */}
               <div className="rounded-xl border border-outline-variant/10 bg-surface-low p-4">
                 <ResponsiveContainer width="100%" height={200}>
-                  <LineChart data={weeklyData}>
+                  <LineChart data={chartData}>
                     <CartesianGrid stroke="#2e3842" strokeDasharray="3 3" vertical={false} />
                     <XAxis
-                      dataKey="day"
+                      dataKey="label"
                       tick={{ fill: "#8a9ba8", fontSize: 11, fontWeight: 600 }}
                       axisLine={false}
                       tickLine={false}
+                      interval={period === "month" ? 4 : 0}
                     />
                     <Tooltip
                       contentStyle={{


### PR DESCRIPTION
Closes #86

## Summary
- **Root cause**: `useWeeklyTrips()` was hardcoded to fetch Mon→Sun, and chart data was always aggregated into 7 day-of-week buckets — the `period` state was never used.
- **Fix**: Replace with `useChartTrips(period)` that calculates the correct `from`/`to` date range, and rebuild chart data aggregation per period:
  - **Semaine**: 7 bars (L, M, M, J, V, S, D) — by day-of-week
  - **Mois**: 28-31 bars (1, 2, ... 31) — by day-of-month
  - **Année**: 12 bars (Jan, Fév, ... Déc) — by month
- **Regression test**: Verifies that switching period triggers API requests with progressively earlier date ranges

## Changes
- `client/src/hooks/queries.ts` — replace `useWeeklyTrips()` with `useChartTrips(period)`
- `client/src/pages/StatsPage.tsx` — period-aware aggregation + month labels
- `client/e2e/stats-period.spec.ts` — new regression test

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 17 Playwright e2e tests pass (including new regression test)
- [ ] Manual: Stats → click Semaine/Mois/Année → chart updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)