### PR TITLE
fix: chart trips query exceeds server limit (400 Bad Request)

### DIFF
--- a/client/e2e/stats-period.spec.ts
+++ b/client/e2e/stats-period.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from "@playwright/test";
  * the selected period. After the fix, useChartTrips(period) fetches the
  * correct date range and the chart data is re-aggregated accordingly.
  *
- * Strategy: intercept /api/trips chart calls (limit=500) and verify that
+ * Strategy: intercept /api/trips chart calls (limit=100) and verify that
  * switching period triggers new requests with progressively earlier `from` dates.
  */
 test.describe("Stats evolution period filter (#86)", () => {
@@ -29,8 +29,8 @@ test.describe("Stats evolution period filter (#86)", () => {
     await page.route("**/api/**", (route) => {
       const url = route.request().url();
 
-      // Track chart requests (limit=500 distinguishes them from list requests)
-      if (url.includes("/trips") && url.includes("limit=500")) {
+      // Track chart requests (limit=100 distinguishes them from list requests)
+      if (url.includes("/trips") && url.includes("limit=100")) {
         const fromMatch = url.match(/from=([^&]+)/);
         if (fromMatch) chartFromDates.push(decodeURIComponent(fromMatch[1]));
       }

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -73,7 +73,7 @@ export function useChartTrips(period: "week" | "month" | "year") {
         data: { trips: Trip[] };
         pagination: { page: number; limit: number; total: number; totalPages: number };
       }>(
-        `/trips?from=${encodeURIComponent(fromStr)}&to=${encodeURIComponent(toStr)}&limit=500`,
+        `/trips?from=${encodeURIComponent(fromStr)}&to=${encodeURIComponent(toStr)}&limit=100`,
       ).then((r) => r.data.trips),
   });
 }


### PR DESCRIPTION
## Summary
- Hotfix for the stats chart regression introduced in #97
- `useChartTrips` used `limit=500` but the server validator caps at `max(100)` → **400 Bad Request** → chart shows no data
- Changed to `limit=100` to match server constraint

## Test plan
- [x] Stats period regression test updated and passes
- [x] All e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)