### PR TITLE
feat: in-app bug report and feature request form

### DIFF
--- a/client/e2e/feedback.spec.ts
+++ b/client/e2e/feedback.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("In-app feedback form (#84)", () => {
+  test("feedback form submits bug report via POST /api/feedback", async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+    });
+
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    let feedbackPayload: unknown = null;
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session: {
+              id: "s",
+              userId: "u",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "u",
+              name: "Test",
+              email: "t@t.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        });
+      }
+
+      // Capture feedback POST
+      if (url.includes("/feedback") && route.request().method() === "POST") {
+        feedbackPayload = route.request().postDataJSON();
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { issueNumber: 42, issueUrl: "https://github.com/test/42" },
+          }),
+        });
+      }
+
+      // Profile data
+      if (url.includes("/user/profile")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              user: {
+                id: "u",
+                name: "Test",
+                email: "t@t.com",
+                createdAt: new Date().toISOString(),
+                vehicleModel: null,
+                fuelType: "sp95",
+                consumptionL100: 7,
+                isAdmin: false,
+              },
+              stats: {
+                totalDistanceKm: 50,
+                totalCo2SavedKg: 8,
+                totalMoneySavedEur: 12,
+                totalFuelSavedL: 5,
+                tripCount: 3,
+              },
+            },
+          }),
+        });
+      }
+
+      // Fuel price
+      if (url.includes("/fuel-price")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { priceEur: 1.75, fuelType: "sp95", updatedAt: new Date().toISOString() },
+          }),
+        });
+      }
+
+      // Achievements
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { achievements: [] } }),
+      });
+    });
+
+    await page.goto("/profile", { waitUntil: "networkidle" });
+
+    // Open the feedback section (scroll down to find it)
+    const feedbackBtn = page.getByText("Signaler un problème");
+    await feedbackBtn.scrollIntoViewIfNeeded();
+    await expect(feedbackBtn).toBeVisible({ timeout: 5000 });
+    await feedbackBtn.click();
+
+    // Fill the form
+    await page.getByPlaceholder("Titre").fill("La carte ne charge pas");
+    await page
+      .getByPlaceholder("Décrivez le problème ou votre idée...")
+      .fill("La carte reste vide quand je démarre un trajet sur iOS Safari.");
+
+    // Submit
+    await page.getByText("Envoyer").click();
+
+    // Should show success message
+    await expect(page.getByText("Merci pour votre retour")).toBeVisible({ timeout: 5000 });
+
+    // Verify the payload sent to the API
+    expect(feedbackPayload).toEqual({
+      type: "bug",
+      title: "La carte ne charge pas",
+      description: "La carte reste vide quand je démarre un trajet sur iOS Safari.",
+    });
+  });
+});

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -269,3 +269,16 @@ export function useExportData() {
     },
   });
 }
+
+export function useSubmitFeedback() {
+  return useMutation({
+    mutationFn: (data: { type: "bug" | "feature"; title: string; description: string }) =>
+      apiFetch<{
+        ok: boolean;
+        data: { issueNumber: number | null; issueUrl: string | null };
+      }>("/feedback", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }).then((r) => r.data),
+  });
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -14,6 +14,7 @@ import {
   Download,
   Trash2,
   Shield,
+  MessageSquarePlus,
 } from "lucide-react";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
@@ -24,6 +25,7 @@ import {
   useFuelPrice,
   useDeleteAccount,
   useExportData,
+  useSubmitFeedback,
 } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { signOut } from "@/lib/auth";
@@ -39,6 +41,7 @@ export function ProfilePage() {
   const push = usePushNotifications();
   const deleteAccount = useDeleteAccount();
   const exportData = useExportData();
+  const submitFeedback = useSubmitFeedback();
 
   const userFuelType = profileData?.user?.fuelType ?? "sp95";
   const { data: fuelPrice, isPending: fuelPriceLoading } = useFuelPrice(userFuelType);
@@ -49,6 +52,11 @@ export function ProfilePage() {
   const [fuelType, setFuelType] = useState<FuelType>("sp95");
   const [consumption, setConsumption] = useState("");
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [feedbackType, setFeedbackType] = useState<"bug" | "feature">("bug");
+  const [feedbackTitle, setFeedbackTitle] = useState("");
+  const [feedbackDesc, setFeedbackDesc] = useState("");
+  const [feedbackSent, setFeedbackSent] = useState(false);
 
   const user = profileData?.user;
   const stats = profileData?.stats;
@@ -436,6 +444,109 @@ export function ProfilePage() {
                 </button>
               )}
             </div>
+          </div>
+
+          {/* Feedback form */}
+          <div className="overflow-hidden rounded-lg bg-surface-low">
+            <button
+              onClick={() => {
+                setShowFeedback(!showFeedback);
+                setFeedbackSent(false);
+              }}
+              className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
+            >
+              <div className="flex items-center gap-4">
+                <MessageSquarePlus size={20} className="text-text-muted" />
+                <span className="text-sm font-medium">Signaler un problème</span>
+              </div>
+              {showFeedback ? (
+                <ChevronDown size={18} className="text-text-dim" />
+              ) : (
+                <ChevronRight size={18} className="text-text-dim" />
+              )}
+            </button>
+            {showFeedback && (
+              <div className="space-y-3 px-4 pb-4">
+                {feedbackSent ? (
+                  <div className="flex items-center gap-3 rounded-lg bg-primary/10 p-4">
+                    <Check size={18} className="text-primary-light" />
+                    <span className="text-sm font-medium text-primary-light">
+                      Merci pour votre retour !
+                    </span>
+                  </div>
+                ) : (
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      submitFeedback.mutate(
+                        {
+                          type: feedbackType,
+                          title: feedbackTitle,
+                          description: feedbackDesc,
+                        },
+                        {
+                          onSuccess: () => {
+                            setFeedbackSent(true);
+                            setFeedbackTitle("");
+                            setFeedbackDesc("");
+                          },
+                        },
+                      );
+                    }}
+                    className="space-y-3"
+                  >
+                    <div className="flex gap-2">
+                      {(["bug", "feature"] as const).map((t) => (
+                        <button
+                          key={t}
+                          type="button"
+                          onClick={() => setFeedbackType(t)}
+                          className={`flex-1 rounded-lg py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
+                            feedbackType === t
+                              ? "bg-primary/20 text-primary-light"
+                              : "bg-surface-high text-text-muted"
+                          }`}
+                        >
+                          {t === "bug" ? "Bug" : "Idée"}
+                        </button>
+                      ))}
+                    </div>
+                    <input
+                      type="text"
+                      value={feedbackTitle}
+                      onChange={(e) => setFeedbackTitle(e.target.value)}
+                      placeholder="Titre"
+                      required
+                      minLength={3}
+                      maxLength={200}
+                      className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                    <textarea
+                      value={feedbackDesc}
+                      onChange={(e) => setFeedbackDesc(e.target.value)}
+                      placeholder="Décrivez le problème ou votre idée..."
+                      required
+                      minLength={10}
+                      maxLength={2000}
+                      rows={4}
+                      className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                    <button
+                      type="submit"
+                      disabled={submitFeedback.isPending}
+                      className="w-full rounded-lg bg-primary py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
+                    >
+                      {submitFeedback.isPending ? "Envoi..." : "Envoyer"}
+                    </button>
+                    {submitFeedback.isError && (
+                      <p className="text-center text-xs text-danger">
+                        Erreur lors de l&apos;envoi. Réessayez.
+                      </p>
+                    )}
+                  </form>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Admin link (only visible for admins) */}

--- a/server/src/routes/feedback.routes.ts
+++ b/server/src/routes/feedback.routes.ts
@@ -1,0 +1,90 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { validationHook } from "../lib/validation";
+import { rateLimit } from "../lib/rate-limit";
+import { logAudit } from "../lib/audit";
+import { logger } from "../lib/logger";
+import type { AuthEnv } from "../types/context";
+
+const feedbackSchema = z.object({
+  type: z.enum(["bug", "feature"]),
+  title: z.string().min(3).max(200),
+  description: z.string().min(10).max(2000),
+});
+
+const feedbackRouter = new Hono<AuthEnv>();
+
+// POST /api/feedback — Create a GitHub issue from user feedback (3 req/hour)
+feedbackRouter.post(
+  "/",
+  rateLimit({ maxRequests: 3, windowMs: 60 * 60 * 1000, prefix: "feedback" }),
+  zValidator("json", feedbackSchema, validationHook),
+  async (c) => {
+    const data = c.req.valid("json");
+    const currentUser = c.get("user");
+
+    const label = data.type === "bug" ? "bug" : "enhancement";
+    const prefix = data.type === "bug" ? "Bug report" : "Feature request";
+    const title = `[In-app] ${prefix}: ${data.title}`;
+    const body = `${data.description}\n\n---\n*Submitted by ${currentUser.name ?? currentUser.email} via ecoRide app*`;
+
+    const githubToken = process.env.GITHUB_TOKEN;
+
+    if (githubToken) {
+      try {
+        const res = await fetch("https://api.github.com/repos/vlebourl/ecoride/issues", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${githubToken}`,
+            Accept: "application/vnd.github+json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ title, body, labels: [label] }),
+        });
+
+        if (!res.ok) {
+          const errBody = await res.text();
+          logger.error("github_issue_creation_failed", {
+            status: res.status,
+            body: errBody,
+          });
+          return c.json({ ok: false, error: "Failed to create issue" }, 502);
+        }
+
+        const issue = (await res.json()) as { number: number; html_url: string };
+        logAudit(currentUser.id, "feedback_submitted", data.title, {
+          type: data.type,
+          title: data.title,
+          githubIssue: issue.number,
+        });
+
+        return c.json({
+          ok: true,
+          data: { issueNumber: issue.number, issueUrl: issue.html_url },
+        });
+      } catch (err) {
+        logger.error("github_issue_creation_error", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return c.json({ ok: false, error: "Failed to create issue" }, 502);
+      }
+    }
+
+    // No GitHub token — just log it
+    logAudit(currentUser.id, "feedback_submitted", data.title, {
+      type: data.type,
+      title: data.title,
+      description: data.description,
+    });
+    logger.info("feedback_received_no_github", {
+      userId: currentUser.id,
+      type: data.type,
+      title: data.title,
+    });
+
+    return c.json({ ok: true, data: { issueNumber: null, issueUrl: null } });
+  },
+);
+
+export { feedbackRouter };

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7,6 +7,7 @@ import { achievementsRouter } from "./achievements.routes";
 import { fuelPriceRouter } from "./fuel-price.routes";
 import { pushRouter } from "./push.routes";
 import { adminRouter } from "./admin.routes";
+import { feedbackRouter } from "./feedback.routes";
 import type { AuthEnv } from "../types/context";
 
 const apiRouter = new Hono<AuthEnv>();
@@ -19,5 +20,6 @@ apiRouter.route("/achievements", achievementsRouter);
 apiRouter.route("/fuel-price", fuelPriceRouter);
 apiRouter.route("/push", pushRouter);
 apiRouter.route("/admin", adminRouter);
+apiRouter.route("/feedback", feedbackRouter);
 
 export { apiRouter };


### PR DESCRIPTION
Closes #84

## Summary
- New "Signaler un problème" collapsible section in the Profile page
- Form with Bug/Feature toggle, title, and description
- `POST /api/feedback` backend endpoint (rate limited: 3/hour)
- Creates a GitHub issue if `GITHUB_TOKEN` is configured in Coolify env
- Falls back to audit log if no token
- Success confirmation after submission

## Changes
- `server/src/routes/feedback.routes.ts` — new route
- `server/src/routes/index.ts` — mount feedback route
- `client/src/hooks/queries.ts` — `useSubmitFeedback` mutation
- `client/src/pages/ProfilePage.tsx` — feedback form UI
- `client/e2e/feedback.spec.ts` — regression test

## Test plan
- [x] TypeScript checks pass (client + server)
- [x] All 18 Playwright e2e tests pass
- [x] Regression test verifies form submit and API payload
- [ ] Manual: Profile → Signaler un problème → fill + submit
- [ ] Set GITHUB_TOKEN in Coolify env to enable GitHub issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)