### PR TITLE
feat: progressive milestones for €, km and CO2 on home screen

### DIFF
--- a/client/e2e/milestones.spec.ts
+++ b/client/e2e/milestones.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Progressive milestones (#85)", () => {
+  test("dashboard shows 3 milestone progress bars", async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+    });
+
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session: {
+              id: "s",
+              userId: "u",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "u",
+              name: "Test",
+              email: "t@t.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/stats/summary")) {
+        const isAllTime = url.includes("period=all");
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              totalDistanceKm: isAllTime ? 75 : 5,
+              totalCo2SavedKg: isAllTime ? 8 : 0.8,
+              totalMoneySavedEur: isAllTime ? 15 : 1.2,
+              totalFuelSavedL: isAllTime ? 6 : 0.5,
+              tripCount: isAllTime ? 10 : 1,
+              currentStreak: 3,
+              longestStreak: 5,
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/user/profile")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              user: {
+                id: "u",
+                name: "Test",
+                email: "t@t.com",
+                createdAt: new Date().toISOString(),
+                vehicleModel: "Test Car",
+                fuelType: "sp95",
+                consumptionL100: 7,
+                isAdmin: false,
+              },
+              stats: {
+                totalDistanceKm: 75,
+                totalCo2SavedKg: 8,
+                totalMoneySavedEur: 15,
+                totalFuelSavedL: 6,
+                tripCount: 10,
+              },
+            },
+          }),
+        });
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: {} }),
+      });
+    });
+
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    // Scroll to milestones section
+    const section = page.getByTestId("milestones");
+    await section.scrollIntoViewIfNeeded();
+    await expect(section).toBeVisible({ timeout: 5000 });
+
+    // Should show "Prochains objectifs" heading
+    await expect(page.getByText("Prochains objectifs")).toBeVisible();
+
+    // Should have 3 milestone cards
+    const cards = section.locator(":scope > div");
+    await expect(cards).toHaveCount(3);
+
+    // Verify milestone labels for the stubbed values:
+    // €15 → next is €20 "Un resto"
+    await expect(section.getByText("Un resto")).toBeVisible();
+    // 75km → next is 100 "Paris → Chartres" (→ is \u2192)
+    await expect(section.getByText(/Paris.*Chartres/)).toBeVisible();
+    // 8kg CO2 → next is 10 "1h d'avion évitée" (d' uses \u2019)
+    await expect(section.getByText(/avion.*vit/)).toBeVisible();
+
+    // Verify progress values are shown
+    await expect(section.getByText(/15.*20.*€/)).toBeVisible();
+    await expect(section.getByText(/75.*100.*km/)).toBeVisible();
+    await expect(section.getByText(/8.*10.*kg/)).toBeVisible();
+  });
+});

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,10 +1,57 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Link } from "react-router";
-import { Bike, Leaf, MapPin, ChevronRight, Car, X, CloudOff } from "lucide-react";
+import { Bike, Leaf, MapPin, ChevronRight, Car, X, CloudOff, Euro, Route } from "lucide-react";
 import { ImpactMeter } from "@/components/ui/ImpactMeter";
 import { useDashboardSummary, useProfile } from "@/hooks/queries";
 import { getPendingTrips } from "@/lib/offline-queue";
 import appLogo from "/pwa-192x192.png?url";
+
+interface Milestone {
+  value: number;
+  label: string;
+}
+
+const MONEY_MILESTONES: Milestone[] = [
+  { value: 5, label: "Un café offert" },
+  { value: 10, label: "Une place de ciné" },
+  { value: 20, label: "Un resto" },
+  { value: 50, label: "Un plein gratuit" },
+  { value: 100, label: "Un weekend" },
+  { value: 200, label: "Un vélo neuf" },
+  { value: 500, label: "Des vacances" },
+  { value: 1000, label: "Millionnaire vert" },
+];
+
+const KM_MILESTONES: Milestone[] = [
+  { value: 10, label: "Première vraie balade" },
+  { value: 50, label: "Paris \u2192 Versailles" },
+  { value: 100, label: "Paris \u2192 Chartres" },
+  { value: 500, label: "Paris \u2192 Lyon" },
+  { value: 1000, label: "Paris \u2192 Barcelone" },
+  { value: 5000, label: "Paris \u2192 Moscou" },
+  { value: 10000, label: "Tour de France" },
+];
+
+const CO2_MILESTONES: Milestone[] = [
+  { value: 1, label: "Un aller-retour CDG" },
+  { value: 10, label: "1h d\u2019avion \u00e9vit\u00e9e" },
+  { value: 50, label: "Paris \u2192 Bordeaux" },
+  { value: 100, label: "Paris \u2192 Marseille" },
+  { value: 500, label: "Un vol transatlantique" },
+  { value: 1000, label: "1 tonne de CO\u2082 !" },
+];
+
+function getNextMilestone(current: number, milestones: Milestone[]) {
+  const next = milestones.find((m) => m.value > current);
+  if (!next) {
+    const last = milestones[milestones.length - 1]!;
+    return { target: last.value, label: last.label, progress: 1 };
+  }
+  const prev = milestones.filter((m) => m.value <= current).pop();
+  const base = prev?.value ?? 0;
+  const progress = (current - base) / (next.value - base);
+  return { target: next.value, label: next.label, progress: Math.min(progress, 1) };
+}
 
 export function DashboardPage() {
   const { data: today, isPending: todayPending } = useDashboardSummary("day");
@@ -14,6 +61,37 @@ export function DashboardPage() {
   const pendingTrips = getPendingTrips();
 
   const isPending = todayPending || allTimePending;
+
+  // MUST be before any early return to respect Rules of Hooks
+  const milestones = useMemo(
+    () =>
+      allTime
+        ? [
+            {
+              key: "eur",
+              icon: <Euro size={16} className="text-primary-light" />,
+              current: allTime.totalMoneySavedEur,
+              unit: "€",
+              ...getNextMilestone(allTime.totalMoneySavedEur, MONEY_MILESTONES),
+            },
+            {
+              key: "km",
+              icon: <Route size={16} className="text-primary-light" />,
+              current: allTime.totalDistanceKm,
+              unit: "km",
+              ...getNextMilestone(allTime.totalDistanceKm, KM_MILESTONES),
+            },
+            {
+              key: "co2",
+              icon: <Leaf size={16} className="text-primary-light" />,
+              current: allTime.totalCo2SavedKg,
+              unit: "kg",
+              ...getNextMilestone(allTime.totalCo2SavedKg, CO2_MILESTONES),
+            },
+          ]
+        : [],
+    [allTime],
+  );
 
   if (isPending || !today || !allTime) {
     return (
@@ -169,6 +247,34 @@ export function DashboardPage() {
                 : "Commencez votre série !"}
             </span>
           </div>
+
+          {/* Progressive Milestones */}
+          <section className="space-y-3" data-testid="milestones">
+            <h3 className="text-xs font-bold uppercase tracking-widest text-text-muted">
+              Prochains objectifs
+            </h3>
+            {milestones.map((m) => (
+              <div key={m.key} className="rounded-xl bg-surface-container p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {m.icon}
+                    <span className="text-xs font-bold text-text-muted">{m.label}</span>
+                  </div>
+                  <span className="text-xs font-bold text-primary-light">
+                    {m.current < m.target
+                      ? `${Math.round(m.current)} / ${m.target} ${m.unit}`
+                      : `${m.target} ${m.unit}`}
+                  </span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-surface-high">
+                  <div
+                    className="h-full rounded-full bg-primary transition-all duration-500"
+                    style={{ width: `${Math.max(m.progress * 100, 2)}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </section>
 
           {/* Impact Meter (all-time) */}
           <ImpactMeter co2TotalKg={allTime.totalCo2SavedKg} />


### PR DESCRIPTION
Closes #85

## Summary
- 3 progress bars on the dashboard: money saved (€), kilometers, CO2
- Each shows current value, next milestone target, and a motivating label
- Milestones escalate: €5 "Un café" → €1000 "Millionnaire vert", 10km "Première balade" → 10000km "Tour de France", etc.
- Progress calculated relative to the previous milestone (not from 0)
- `useMemo` placed before early return to respect Rules of Hooks

## Changes
- `client/src/pages/DashboardPage.tsx` — milestone constants, helper function, UI section
- `client/e2e/milestones.spec.ts` — regression test

## Test plan
- [x] TypeScript passes
- [x] All 20 Playwright e2e tests pass
- [ ] Manual: dashboard shows 3 progress bars with correct milestones

🤖 Generated with [Claude Code](https://claude.com/claude-code)