### PR TITLE
fix: leaderboard category filters overflow on mobile

### DIFF
--- a/client/e2e/leaderboard-period.spec.ts
+++ b/client/e2e/leaderboard-period.spec.ts
@@ -105,14 +105,15 @@ test.describe("Leaderboard period filter", () => {
     const errorBoundary = page.getByText("Une erreur est survenue");
     await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
 
-    // Category switcher should be visible with all 4 buttons
+    // Category switcher should be visible with all 5 icon buttons
     const catSwitcher = page.getByTestId("category-switcher");
     await expect(catSwitcher).toBeVisible();
 
-    await expect(catSwitcher.getByText("CO₂")).toBeVisible();
-    await expect(catSwitcher.getByText("Série")).toBeVisible();
-    await expect(catSwitcher.getByText("Trajets")).toBeVisible();
-    await expect(catSwitcher.getByText("Vitesse")).toBeVisible();
+    await expect(catSwitcher.getByLabel("CO₂")).toBeVisible();
+    await expect(catSwitcher.getByLabel("Série")).toBeVisible();
+    await expect(catSwitcher.getByLabel("Trajets")).toBeVisible();
+    await expect(catSwitcher.getByLabel("Vitesse")).toBeVisible();
+    await expect(catSwitcher.getByLabel("€")).toBeVisible();
   });
 
   test("clicking a category button updates active state", async ({ page }) => {
@@ -122,11 +123,11 @@ test.describe("Leaderboard period filter", () => {
     await expect(catSwitcher).toBeVisible();
 
     // "CO₂" should be active by default
-    const co2Btn = catSwitcher.getByText("CO₂");
+    const co2Btn = catSwitcher.getByLabel("CO₂");
     await expect(co2Btn).toHaveClass(/bg-primary/);
 
     // Click "Série" and verify it becomes active
-    const serieBtn = catSwitcher.getByText("Série");
+    const serieBtn = catSwitcher.getByLabel("Série");
     await serieBtn.click();
     await expect(serieBtn).toHaveClass(/bg-primary/);
 

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -95,7 +95,7 @@ export function LeaderboardPage() {
               <button
                 key={opt.value}
                 onClick={() => setPeriod(opt.value)}
-                className={`rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                className={`flex-1 rounded-lg px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
                   opt.value === period
                     ? "bg-primary/20 text-primary-light"
                     : "bg-surface-high text-text-muted"
@@ -106,25 +106,30 @@ export function LeaderboardPage() {
             ))}
           </div>
 
-          {/* Category switcher */}
-          <div className="mt-3 flex gap-2" data-testid="category-switcher">
-            {categoryOptions.map((opt) => {
-              const Icon = opt.icon;
-              return (
-                <button
-                  key={opt.value}
-                  onClick={() => setCategory(opt.value)}
-                  className={`flex items-center gap-1.5 rounded-lg px-3 py-2 text-[11px] font-bold uppercase tracking-wider transition-colors ${
-                    opt.value === category
-                      ? "bg-primary/20 text-primary-light"
-                      : "bg-surface-high text-text-muted"
-                  }`}
-                >
-                  <Icon size={14} />
-                  {opt.label}
-                </button>
-              );
-            })}
+          {/* Category switcher — icons only, label below */}
+          <div className="mt-3 flex flex-col items-start gap-2">
+            <div className="flex gap-2" data-testid="category-switcher">
+              {categoryOptions.map((opt) => {
+                const Icon = opt.icon;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => setCategory(opt.value)}
+                    className={`flex h-10 flex-1 items-center justify-center rounded-lg transition-colors ${
+                      opt.value === category
+                        ? "bg-primary/20 text-primary-light"
+                        : "bg-surface-high text-text-muted"
+                    }`}
+                    aria-label={opt.label}
+                  >
+                    <Icon size={18} />
+                  </button>
+                );
+              })}
+            </div>
+            <span className="text-xs font-bold uppercase tracking-wider text-primary-light">
+              {categoryOptions.find((o) => o.value === category)?.label}
+            </span>
           </div>
         </section>
 


### PR DESCRIPTION
Closes #104

## Summary
- Category buttons now show **icons only** with the selected label below
- Both filter rows (period + category) use `flex-1` to fill the full width evenly
- No more overflow on narrow mobile screens

## Test plan
- [x] All 19 Playwright e2e tests pass (leaderboard tests updated for icon-only buttons)
- [ ] Manual: leaderboard filters don't overflow on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)