### PR TITLE
fix: leaderboard category filters occupy full width

### DIFF
--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -107,8 +107,8 @@ export function LeaderboardPage() {
           </div>
 
           {/* Category switcher — icons only, label below */}
-          <div className="mt-3 flex flex-col items-start gap-2">
-            <div className="flex gap-2" data-testid="category-switcher">
+          <div className="mt-3 flex flex-col gap-2">
+            <div className="flex w-full gap-2" data-testid="category-switcher">
               {categoryOptions.map((opt) => {
                 const Icon = opt.icon;
                 return (


### PR DESCRIPTION
Closes #108

Regression from #107: `items-start` on the wrapper div prevented the icon buttons from stretching to full width. Removed `items-start`, added `w-full` to the button row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)