### PR TITLE
fix: consistent number precision across all pages (#113)

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -277,7 +277,7 @@ export function DashboardPage() {
                   </div>
                   <span className="text-xs font-bold text-primary-light">
                     {m.current < m.target
-                      ? `${Math.round(m.current)} / ${m.target} ${m.unit}`
+                      ? `${m.unit === "€" ? m.current.toFixed(2) : m.unit === "km" || m.unit === "kg" ? m.current.toFixed(1) : Math.round(m.current)} / ${m.target} ${m.unit}`
                       : `${m.target} ${m.unit}`}
                   </span>
                 </div>

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -50,6 +50,19 @@ export function LeaderboardPage() {
 
   const unit = categoryUnits[category];
 
+  const formatValue = (v: number) => {
+    switch (category) {
+      case "co2":
+        return Number(v).toFixed(1);
+      case "money":
+        return Number(v).toFixed(2);
+      case "speed":
+        return Math.round(v);
+      default:
+        return v;
+    }
+  };
+
   if (isPending || !data) {
     return (
       <div
@@ -166,7 +179,7 @@ export function LeaderboardPage() {
                     {top3[1].name}
                   </span>
                   <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                    {top3[1].value} {unit}
+                    {formatValue(top3[1].value)} {unit}
                   </span>
                 </div>
               )}
@@ -186,7 +199,7 @@ export function LeaderboardPage() {
                   </div>
                   <span className="mt-4 text-sm font-bold text-text">{top3[0].name}</span>
                   <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                    {top3[0].value} {unit}
+                    {formatValue(top3[0].value)} {unit}
                   </span>
                 </div>
               )}
@@ -208,7 +221,7 @@ export function LeaderboardPage() {
                     {top3[2].name}
                   </span>
                   <span className="mt-1 text-xs font-black uppercase tracking-widest text-primary-light">
-                    {top3[2].value} {unit}
+                    {formatValue(top3[2].value)} {unit}
                   </span>
                 </div>
               )}
@@ -251,7 +264,7 @@ export function LeaderboardPage() {
                     </div>
                     <div className="text-right">
                       <span className="block text-sm font-black text-text">
-                        {entry.value} {unit.toLowerCase()}
+                        {formatValue(entry.value)} {unit.toLowerCase()}
                       </span>
                     </div>
                   </div>

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -198,7 +198,7 @@ export function ProfilePage() {
             <p className="text-xs font-bold uppercase tracking-widest text-text-dim">Economisé</p>
             <div className="mt-1 flex items-baseline gap-1">
               <span className="text-3xl font-bold text-text">
-                {stats.totalMoneySavedEur.toFixed(0)}
+                {stats.totalMoneySavedEur.toFixed(2)}
               </span>
               <span className="text-xs font-bold uppercase tracking-widest text-text-dim">EUR</span>
             </div>

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -382,7 +382,9 @@ export function StatsPage() {
                       </div>
                     </div>
                     <div className="text-right">
-                      <p className="text-sm font-bold text-primary-light">+{trip.distanceKm} KM</p>
+                      <p className="text-sm font-bold text-primary-light">
+                        +{Number(trip.distanceKm).toFixed(1)} KM
+                      </p>
                       <p className="text-xs font-bold uppercase tracking-tighter text-on-surface-variant">
                         {trip.co2SavedKg.toFixed(1)} KG CO₂
                       </p>


### PR DESCRIPTION
## Summary
- **StatsPage**: Trip list distance now shows 1 decimal (`12.3 KM` instead of raw DB value)
- **ProfilePage**: Money saved shows 2 decimals (`45.50 EUR` instead of `45 EUR`)
- **LeaderboardPage**: All values formatted per category (CO2: 1 decimal, money: 2 decimals, speed: rounded, trips/streak: integer)
- **DashboardPage**: Milestone progress formatted per unit type (€ → 2 decimals, km/kg → 1 decimal)

## Precision rules
| Metric | Decimals | Example |
|--------|----------|---------|
| Distance | 1 | 12.3 km |
| CO₂ | 1 | 1.5 kg |
| Money | 2 | 3.50 € |
| Speed | 0 | 25 km/h |

Closes #113

## Test plan
- [x] TypeScript typecheck passes
- [x] Vite build succeeds
- [x] All existing Playwright smoke tests pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)