### PR TITLE
fix: auto-resync push subscription on every app load

### DIFF
--- a/client/src/hooks/usePushNotifications.ts
+++ b/client/src/hooks/usePushNotifications.ts
@@ -3,7 +3,7 @@ import {
   isPushSupported,
   subscribeToPush,
   unsubscribeFromPush,
-  getCurrentPushSubscription,
+  syncPushSubscription,
 } from "@/lib/push";
 import { useUpdateProfile } from "./queries";
 
@@ -19,8 +19,10 @@ export function usePushNotifications() {
   const [busy, setBusy] = useState(false);
   const updateProfile = useUpdateProfile();
 
-  // Check initial state
+  // Check initial state and silently re-sync subscription with server
   useEffect(() => {
+    let ignore = false;
+
     if (!isPushSupported()) {
       setStatus("unsupported");
       return;
@@ -31,9 +33,15 @@ export function usePushNotifications() {
       return;
     }
 
-    getCurrentPushSubscription().then((sub) => {
-      setStatus(sub ? "subscribed" : "unsubscribed");
+    // If permission is granted, sync subscription with server (handles
+    // stale FCM endpoints after SW updates). If not granted, just check state.
+    syncPushSubscription().then((sub) => {
+      if (!ignore) setStatus(sub ? "subscribed" : "unsubscribed");
     });
+
+    return () => {
+      ignore = true;
+    };
   }, []);
 
   const toggle = useCallback(async () => {

--- a/client/src/lib/push.ts
+++ b/client/src/lib/push.ts
@@ -96,9 +96,51 @@ export async function unsubscribeFromPush(): Promise<void> {
 export async function getCurrentPushSubscription(): Promise<PushSubscription | null> {
   if (!isPushSupported()) return null;
   try {
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (!registration) return null;
     return await registration.pushManager.getSubscription();
   } catch {
+    return null;
+  }
+}
+
+/**
+ * Silently re-sync the current browser push subscription with the server.
+ * Called on every app load when permission is "granted" to ensure the server
+ * always has the latest FCM endpoint (which changes after SW updates).
+ * If no browser subscription exists but permission is granted, re-subscribes.
+ */
+export async function syncPushSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported() || Notification.permission !== "granted") return null;
+
+  try {
+    let subscription = await getCurrentPushSubscription();
+
+    if (!subscription) {
+      // Permission granted but no subscription — re-subscribe silently
+      const registration = await navigator.serviceWorker.ready;
+      const vapidPublicKey = await getVapidPublicKey();
+      if (!vapidPublicKey || vapidPublicKey.length < 20) return null;
+
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer,
+      });
+    }
+
+    // Send current subscription to server (upserts — updates endpoint if changed)
+    const keys = subscription.toJSON().keys!;
+    await apiFetch("/push/subscribe", {
+      method: "POST",
+      body: JSON.stringify({
+        endpoint: subscription.endpoint,
+        keys: { p256dh: keys.p256dh, auth: keys.auth },
+      }),
+    });
+
+    return subscription;
+  } catch (err) {
+    console.warn("[push] sync failed:", err);
     return null;
   }
 }

--- a/server/src/routes/push.routes.ts
+++ b/server/src/routes/push.routes.ts
@@ -45,6 +45,9 @@ pushRouter.post(
       return c.json({ ok: true, data: { subscriptionId: existing.id } });
     }
 
+    // New endpoint — remove stale subscriptions for this user (old SW endpoints)
+    await db.delete(pushSubscriptions).where(eq(pushSubscriptions.userId, currentUser.id));
+
     const [sub] = await db
       .insert(pushSubscriptions)
       .values({


### PR DESCRIPTION
Closes #112
Closes #111

## Root cause
After a service worker update (every deploy), the FCM push endpoint changes. The server still had the old endpoint → 410 Gone → notifications silently fail.

## Fix
- **Client**: `syncPushSubscription()` runs on every app load when `Notification.permission === "granted"`. Re-sends the current browser subscription to the server, or re-subscribes silently if the SW lost the subscription.
- **Server**: When a new endpoint is registered, deletes old stale subscriptions for that user (prevents dead endpoint accumulation).
- **Hook**: Uses `getRegistration()` instead of `.ready` (avoids hanging when SW is inactive).

Transparent for the user — no re-toggle needed after deploys.

## Test plan
- [x] TypeScript passes (client + server)
- [x] All 21 Playwright tests pass
- [ ] Manual: enable notifications → deploy new version → notifications still arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)