### PR TITLE
feat: admin announcements with swipable in-app banner

### DIFF
--- a/client/e2e/admin-notifications.spec.ts
+++ b/client/e2e/admin-notifications.spec.ts
@@ -93,6 +93,15 @@ test.describe("Admin push notifications (#92)", () => {
         });
       }
 
+      // Announcements
+      if (url.includes("/admin/announcements")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: { announcements: [] } }),
+        });
+      }
+
       // POST notification — capture and return success
       if (url.includes("/admin/notifications") && route.request().method() === "POST") {
         return route.fulfill({
@@ -147,9 +156,11 @@ test.describe("Admin push notifications (#92)", () => {
     await bellSection.scrollIntoViewIfNeeded();
     await expect(bellSection).toBeVisible({ timeout: 5000 });
 
-    // Fill compose form
-    await page.getByPlaceholder("Titre").fill("Nouvelle feature !");
-    await page.getByPlaceholder("Message...").fill("Les milestones sont disponibles.");
+    // Fill notification compose form
+    await page.getByPlaceholder("Titre de la notification").fill("Nouvelle feature !");
+    await page
+      .getByPlaceholder("Contenu de la notification...")
+      .fill("Les milestones sont disponibles.");
 
     // Submit
     await page.getByText("Envoyer").click();

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -232,6 +232,65 @@ export function useSendAdminNotification() {
   });
 }
 
+// ---- Announcements ----
+
+export interface Announcement {
+  id: string;
+  title: string;
+  body: string;
+  url: string | null;
+  active: boolean;
+  createdAt: string;
+}
+
+export function useActiveAnnouncement() {
+  return useQuery({
+    queryKey: ["announcement", "active"],
+    queryFn: () =>
+      apiFetch<{ ok: boolean; data: { announcement: Announcement | null } }>(
+        "/announcements/active",
+      ).then((r) => r.data.announcement),
+    staleTime: 60_000,
+  });
+}
+
+export function useAdminAnnouncements() {
+  return useQuery({
+    queryKey: ["admin", "announcements"],
+    queryFn: () =>
+      apiFetch<{ ok: boolean; data: { announcements: Announcement[] } }>(
+        "/admin/announcements",
+      ).then((r) => r.data.announcements),
+  });
+}
+
+export function useCreateAnnouncement() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { title: string; body: string; url?: string }) =>
+      apiFetch<{ ok: boolean; data: { announcement: Announcement } }>("/admin/announcements", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }).then((r) => r.data.announcement),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "announcements"] });
+      qc.invalidateQueries({ queryKey: ["announcement", "active"] });
+    },
+  });
+}
+
+export function useDeleteAnnouncement() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<{ ok: boolean }>(`/admin/announcements/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "announcements"] });
+      qc.invalidateQueries({ queryKey: ["announcement", "active"] });
+    },
+  });
+}
+
 // ---- Mutations ----
 
 export function useCreateTrip() {

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -13,11 +13,16 @@ import {
   Send,
   Bell,
   Check,
+  Megaphone,
+  Trash2,
 } from "lucide-react";
 import {
   useAdminHealth,
   useAdminStats,
   useAdminNotifications,
+  useAdminAnnouncements,
+  useCreateAnnouncement,
+  useDeleteAnnouncement,
   useSendAdminNotification,
   useProfile,
 } from "@/hooks/queries";
@@ -302,10 +307,126 @@ export function AdminPage() {
             <p className="py-4 text-center text-sm text-text-muted">Aucun trajet</p>
           )}
         </section>
+        {/* Announcements */}
+        <AnnouncementSection />
+
         {/* Push Notifications */}
         <NotificationSection users={stats?.users} />
       </div>
     </>
+  );
+}
+
+function AnnouncementSection() {
+  const { data: list, isPending } = useAdminAnnouncements();
+  const createAnn = useCreateAnnouncement();
+  const deleteAnn = useDeleteAnnouncement();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [url, setUrl] = useState("");
+  const [created, setCreated] = useState(false);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Megaphone size={18} className="text-primary-light" />
+        <h3 className="text-sm font-bold uppercase tracking-widest text-text-dim">
+          Annonces in-app
+        </h3>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          createAnn.mutate(
+            { title, body, url: url || undefined },
+            {
+              onSuccess: () => {
+                setCreated(true);
+                setTitle("");
+                setBody("");
+                setUrl("");
+                setTimeout(() => setCreated(false), 3000);
+              },
+            },
+          );
+        }}
+        className="space-y-3 rounded-xl bg-surface-low p-5"
+      >
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Titre de l'annonce"
+          required
+          maxLength={100}
+          className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Message..."
+          required
+          maxLength={500}
+          rows={2}
+          className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Lien (optionnel, ex: /profile)"
+          className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+        <button
+          type="submit"
+          disabled={createAnn.isPending}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
+        >
+          {created ? (
+            <>
+              <Check size={16} />
+              {"Publiée !"}
+            </>
+          ) : (
+            <>
+              <Megaphone size={16} />
+              {"Publier l'annonce"}
+            </>
+          )}
+        </button>
+      </form>
+
+      {!isPending && list && list.length > 0 && (
+        <div className="max-h-60 space-y-2 overflow-auto">
+          {list.map((a) => (
+            <div
+              key={a.id}
+              className="flex items-center justify-between rounded-lg bg-surface-low p-3"
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-bold text-text">{a.title}</p>
+                  {a.active && (
+                    <span className="rounded bg-primary/20 px-1.5 py-0.5 text-[10px] font-bold text-primary-light">
+                      ACTIVE
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-text-muted">{a.body}</p>
+              </div>
+              <button
+                onClick={() => deleteAnn.mutate(a.id)}
+                disabled={deleteAnn.isPending}
+                className="shrink-0 rounded p-2 text-text-dim hover:text-danger"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -355,7 +476,7 @@ function NotificationSection({ users }: { users?: { id: string; name: string; em
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="Titre"
+          placeholder="Titre de la notification"
           required
           maxLength={100}
           className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
@@ -363,7 +484,7 @@ function NotificationSection({ users }: { users?: { id: string; name: string; em
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
-          placeholder="Message..."
+          placeholder="Contenu de la notification..."
           required
           maxLength={500}
           rows={3}
@@ -373,7 +494,7 @@ function NotificationSection({ users }: { users?: { id: string; name: string; em
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          placeholder="Lien (optionnel)"
+          placeholder="Lien notification (optionnel)"
           className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
         />
 

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useCallback } from "react";
 import { Link } from "react-router";
 import {
   Bike,
   Leaf,
   MapPin,
+  Megaphone,
   ChevronRight,
   Car,
   X,
@@ -12,7 +13,7 @@ import {
   Route,
   Bell,
 } from "lucide-react";
-import { useDashboardSummary, useProfile } from "@/hooks/queries";
+import { useDashboardSummary, useProfile, useActiveAnnouncement } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { getPendingTrips } from "@/lib/offline-queue";
 import appLogo from "/pwa-192x192.png?url";
@@ -89,6 +90,24 @@ export function DashboardPage() {
     () => localStorage.getItem("ecoride:notification-prompt-dismissed") === "true",
   );
   const push = usePushNotifications();
+  const { data: announcement } = useActiveAnnouncement();
+  const [annDismissed, setAnnDismissed] = useState(
+    () => !!localStorage.getItem("ecoride:ann-dismissed"),
+  );
+  const annSwipeRef = useRef<{ startX: number; currentX: number }>({ startX: 0, currentX: 0 });
+  const annRef = useRef<HTMLDivElement>(null);
+
+  const dismissAnn = useCallback(() => {
+    if (announcement) {
+      localStorage.setItem("ecoride:ann-dismissed", announcement.id);
+      setAnnDismissed(true);
+    }
+  }, [announcement]);
+
+  // Reset dismiss when announcement changes
+  const dismissedId = localStorage.getItem("ecoride:ann-dismissed");
+  const showAnn = announcement && !annDismissed && dismissedId !== announcement.id;
+
   const pendingTrips = getPendingTrips();
 
   const isPending = todayPending || allTimePending;
@@ -150,6 +169,59 @@ export function DashboardPage() {
           <span className="text-primary-light">Ride</span>
         </span>
       </header>
+
+      {/* Admin announcement banner (swipable) */}
+      {showAnn && (
+        <div
+          ref={annRef}
+          data-testid="announcement-banner"
+          className="mx-6 rounded-xl border border-primary/20 bg-primary/10 px-4 py-3 transition-all"
+          onTouchStart={(e) => {
+            annSwipeRef.current.startX = e.touches[0]!.clientX;
+            annSwipeRef.current.currentX = e.touches[0]!.clientX;
+          }}
+          onTouchMove={(e) => {
+            annSwipeRef.current.currentX = e.touches[0]!.clientX;
+            const dx = annSwipeRef.current.currentX - annSwipeRef.current.startX;
+            if (annRef.current) {
+              annRef.current.style.transform = `translateX(${dx}px)`;
+              annRef.current.style.opacity = String(1 - Math.abs(dx) / 200);
+            }
+          }}
+          onTouchEnd={() => {
+            const dx = annSwipeRef.current.currentX - annSwipeRef.current.startX;
+            if (Math.abs(dx) > 100) {
+              dismissAnn();
+            } else if (annRef.current) {
+              annRef.current.style.transform = "";
+              annRef.current.style.opacity = "";
+            }
+          }}
+        >
+          <div className="flex items-start gap-3">
+            <Megaphone size={18} className="mt-0.5 shrink-0 text-primary-light" />
+            <div className="flex-1">
+              <p className="text-sm font-bold text-text">{announcement.title}</p>
+              <p className="text-xs text-text-muted">{announcement.body}</p>
+            </div>
+            <button
+              onClick={dismissAnn}
+              aria-label="Fermer l'annonce"
+              className="shrink-0 rounded p-1 text-text-muted hover:text-text"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          {announcement.url && (
+            <Link
+              to={announcement.url}
+              className="mt-2 inline-block text-xs font-bold text-primary-light underline"
+            >
+              En savoir plus
+            </Link>
+          )}
+        </div>
+      )}
 
       {/* Offline pending trips banner */}
       {pendingTrips.length > 0 && (

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -4,3 +4,4 @@ export { achievements } from "./schema/achievements";
 export { pushSubscriptions } from "./schema/push-subscriptions";
 export { auditLogs } from "./schema/audit-log";
 export { notificationLogs } from "./schema/notification-logs";
+export { announcements } from "./schema/announcements";

--- a/server/src/db/schema/announcements.ts
+++ b/server/src/db/schema/announcements.ts
@@ -1,0 +1,14 @@
+import { pgTable, text, timestamp, uuid, boolean } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const announcements = pgTable("announcements", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  adminId: text("admin_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  body: text("body").notNull(),
+  url: text("url"),
+  active: boolean("active").notNull().default(true),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -3,7 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { eq, count, gte, sum, sql, desc } from "drizzle-orm";
 import { db } from "../db";
-import { user, trips, notificationLogs } from "../db/schema";
+import { user, trips, notificationLogs, announcements } from "../db/schema";
 import { adminMiddleware } from "../auth/admin";
 import { validationHook } from "../lib/validation";
 import { rateLimit } from "../lib/rate-limit";
@@ -241,6 +241,67 @@ adminRouter.get("/notifications", async (c) => {
       })),
     },
   });
+});
+
+// --- Announcements ---
+
+const createAnnouncementSchema = z.object({
+  title: z.string().min(1).max(100),
+  body: z.string().min(1).max(500),
+  url: z.string().url().optional(),
+});
+
+// POST /api/admin/announcements — Create announcement
+adminRouter.post(
+  "/announcements",
+  zValidator("json", createAnnouncementSchema, validationHook),
+  async (c) => {
+    const data = c.req.valid("json");
+    const currentUser = c.get("user");
+
+    // Deactivate all previous announcements
+    await db.update(announcements).set({ active: false });
+
+    const [ann] = await db
+      .insert(announcements)
+      .values({
+        adminId: currentUser.id,
+        title: data.title,
+        body: data.body,
+        url: data.url ?? null,
+      })
+      .returning();
+
+    logAudit(currentUser.id, "announcement_created", data.title);
+
+    return c.json(
+      { ok: true, data: { announcement: { ...ann, createdAt: ann!.createdAt.toISOString() } } },
+      201,
+    );
+  },
+);
+
+// GET /api/admin/announcements — List all announcements
+adminRouter.get("/announcements", async (c) => {
+  const list = await db
+    .select()
+    .from(announcements)
+    .orderBy(desc(announcements.createdAt))
+    .limit(20);
+
+  return c.json({
+    ok: true,
+    data: {
+      announcements: list.map((a) => ({ ...a, createdAt: a.createdAt.toISOString() })),
+    },
+  });
+});
+
+// DELETE /api/admin/announcements/:id — Delete announcement
+adminRouter.delete("/announcements/:id", async (c) => {
+  const id = c.req.param("id");
+  await db.delete(announcements).where(eq(announcements.id, id));
+  return c.json({ ok: true });
 });
 
 export { adminRouter };

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -8,9 +8,28 @@ import { fuelPriceRouter } from "./fuel-price.routes";
 import { pushRouter } from "./push.routes";
 import { adminRouter } from "./admin.routes";
 import { feedbackRouter } from "./feedback.routes";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { announcements } from "../db/schema";
 import type { AuthEnv } from "../types/context";
 
 const apiRouter = new Hono<AuthEnv>();
+
+// Public: get the current active announcement (no auth required)
+apiRouter.get("/announcements/active", async (c) => {
+  const [active] = await db
+    .select()
+    .from(announcements)
+    .where(eq(announcements.active, true))
+    .limit(1);
+
+  return c.json({
+    ok: true,
+    data: {
+      announcement: active ? { ...active, createdAt: active.createdAt.toISOString() } : null,
+    },
+  });
+});
 
 apiRouter.route("/trips", tripsRouter);
 apiRouter.route("/user", usersRouter);


### PR DESCRIPTION
## Summary
New announcement system: admins create banners from the admin panel, users see them as swipable cards on the dashboard.

### How it works
1. Admin creates an announcement (title + body + optional link)
2. Previous active announcement is auto-deactivated
3. All users see the banner on next app load
4. Users dismiss by swiping left/right or tapping X
5. Dismiss persisted in localStorage (per announcement ID)

### Backend
- `announcements` table + CRUD endpoints
- `GET /api/announcements/active` — public endpoint for the dashboard

### Frontend
- Admin: compose form + announcement list with active badge + delete
- Dashboard: swipable banner with opacity/transform animation

## Test plan
- [x] All 22 Playwright tests pass
- [ ] Manual: create announcement in admin → banner appears on dashboard
- [ ] After deploy: run `bunx drizzle-kit push` for the new table

🤖 Generated with [Claude Code](https://claude.com/claude-code)