### PR TITLE
fix: add vertical scroll to stats recent activities (#129)

### DIFF
--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -366,7 +366,7 @@ export function StatsPage() {
               <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
                 Activité récente
               </h3>
-              <div className="space-y-3">
+              <div className="max-h-80 space-y-3 overflow-y-auto">
                 {trips.length === 0 && (
                   <p className="text-center text-sm text-text-muted">Aucun trajet enregistré</p>
                 )}


### PR DESCRIPTION
## Summary
- Adds `max-h-80 overflow-y-auto` to the "Activité récente" trip list container in StatsPage
- The list now scrolls when there are more than ~3-4 items instead of expanding the page indefinitely

Closes #129

## Test plan
- [x] Typecheck passes
- [x] Client build passes
- [x] All 22 Playwright e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)