### PR TITLE
fix: use 100dvh and safe-area insets to prevent page overflow

### DIFF
--- a/client/e2e/safe-area.spec.ts
+++ b/client/e2e/safe-area.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for #131 — pages were incorrectly scrollable because
+ * the root element used `100vh` / `100%` (which ignores the phone status
+ * bar and gesture bar on iOS/Android), and the AppShell had no
+ * safe-area-inset-top padding.
+ *
+ * The fix:
+ * 1. Use `100dvh` on #root so dynamic viewport height is respected.
+ * 2. Add `pt-[env(safe-area-inset-top)]` to AppShell.
+ * 3. Ensure `viewport-fit=cover` is set (required for env() insets).
+ * 4. Remove `min-h-screen` (100vh) from body.
+ */
+
+test.describe("safe area insets (#131)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: {} }),
+      }),
+    );
+  });
+
+  test("viewport meta includes viewport-fit=cover", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const content = await page.getAttribute('meta[name="viewport"]', "content");
+    expect(content).toContain("viewport-fit=cover");
+  });
+
+  test("#root uses 100dvh height (not 100vh or 100%)", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const rootHeightRule = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (
+              rule instanceof CSSStyleRule &&
+              rule.selectorText === "#root" &&
+              rule.style.height
+            ) {
+              return rule.style.height;
+            }
+          }
+        } catch {
+          /* cross-origin sheets */
+        }
+      }
+      return null;
+    });
+
+    expect(rootHeightRule).toBe("100dvh");
+  });
+
+  test("body does not use min-h-screen (100vh)", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const bodyClasses = await page.getAttribute("body", "class");
+    expect(bodyClasses).not.toContain("min-h-screen");
+  });
+
+  test("AppShell pages do not overflow viewport at mobile size", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/trip", { waitUntil: "networkidle" });
+
+    const overflow = await page.evaluate(() => ({
+      scrollHeight: document.documentElement.scrollHeight,
+      clientHeight: document.documentElement.clientHeight,
+    }));
+
+    expect(overflow.scrollHeight).toBeLessThanOrEqual(overflow.clientHeight);
+  });
+});

--- a/client/index.html
+++ b/client/index.html
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>ecoRide</title>
   </head>
-  <body class="bg-bg text-text min-h-screen">
+  <body class="bg-bg text-text">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -37,10 +37,13 @@
 }
 
 html,
-body,
-#root {
+body {
   height: 100%;
   margin: 0;
+}
+
+#root {
+  height: 100dvh;
 }
 
 body {

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -15,7 +15,7 @@ export function AppShell() {
   }, [queryClient]);
 
   return (
-    <div className="flex h-full flex-col bg-bg">
+    <div className="flex h-full flex-col bg-bg pt-[env(safe-area-inset-top)]">
       <main className="flex-1 overflow-hidden pb-24">
         <PullToRefresh onRefresh={handleRefresh} scrollKey={location.pathname}>
           <Outlet />


### PR DESCRIPTION
## Summary

Fixes #131 — Pages were incorrectly scrollable on mobile due to missing safe area insets (status bar + gesture bar).

- **`#root` uses `100dvh`** instead of `100%` to respect dynamic viewport height on mobile browsers
- **AppShell adds `pt-[env(safe-area-inset-top)]`** to push content below the status bar when `viewport-fit=cover` is active
- **Removed `min-h-screen` (100vh)** from body in `index.html` — it conflicted with the dvh-based sizing
- BottomNav already handles `safe-area-inset-bottom` via its existing `pb-[calc(0.5rem+env(safe-area-inset-bottom,0.5rem))]`

## Test plan

- [x] Playwright regression test (`e2e/safe-area.spec.ts`) verifying:
  - `viewport-fit=cover` is set in viewport meta
  - `#root` CSS uses `100dvh` (not `100vh` or `100%`)
  - Body does not have `min-h-screen` class
  - AppShell pages don't overflow viewport at mobile size (390x844)
- [ ] Manual test on iOS Safari / Android Chrome to confirm no scroll overflow
- [x] All 9 smoke tests pass
- [x] Typecheck passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)