### PR TITLE
fix: idle map fills available space instead of fixed 50vh (#122)

### DIFF
--- a/client/e2e/idle-map-height.spec.ts
+++ b/client/e2e/idle-map-height.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test("#122 regression: idle map fills available space with no gap below buttons", async ({
+  page,
+  context,
+}) => {
+  // Grant geolocation and fake position
+  await context.grantPermissions(["geolocation"]);
+  await context.setGeolocation({ latitude: 48.8566, longitude: 2.3522 });
+
+  // Stub API
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  // Wait for idle UI (start button visible)
+  const startBtn = page.getByText("Démarrer");
+  await expect(startBtn).toBeVisible({ timeout: 5000 });
+
+  // Map must be visible
+  const mapContainer = page.locator(".leaflet-container");
+  await expect(mapContainer).toBeVisible({ timeout: 3000 });
+  const mapBox = await mapContainer.boundingBox();
+  expect(mapBox).not.toBeNull();
+
+  // REGRESSION: Map should be significantly taller than a small fixed height.
+  // With flex-1 it fills available space; the old 50vh was about 422px on 844px viewport.
+  // Now it should be taller since it expands to fill space between header and buttons.
+  const viewport = page.viewportSize()!;
+  expect(mapBox!.height).toBeGreaterThan(viewport.height * 0.5);
+
+  // REGRESSION: The gap between the map bottom and buttons top should be minimal
+  // (just CSS padding/margin, not a large blank area)
+  const buttonsContainer = startBtn.locator("..");
+  const buttonsBox = await buttonsContainer.boundingBox();
+  expect(buttonsBox).not.toBeNull();
+
+  const mapBottom = mapBox!.y + mapBox!.height;
+  const gapBetweenMapAndButtons = buttonsBox!.y - mapBottom;
+  // With the old 50vh, there was a large gap (100px+). With flex-1, it should be small.
+  expect(gapBetweenMapAndButtons).toBeLessThan(30);
+
+  // ErrorBoundary should not appear
+  const errorBoundary = page.getByText("Une erreur est survenue");
+  await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
+});

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -171,9 +171,7 @@ export function TripPage() {
   };
 
   return (
-    <div
-      className={`relative flex flex-col ${uiState === "tracking" ? "h-[calc(100dvh_-_6rem)]" : "h-full"}`}
-    >
+    <div className="relative flex h-[calc(100dvh_-_6rem)] flex-col">
       {/* Header with persistent GPS indicator */}
       <header
         role="banner"
@@ -338,7 +336,7 @@ export function TripPage() {
 
       {/* === IDLE / STOPPED / MANUAL: full map === */}
       {uiState !== "tracking" && (
-        <div className="relative" style={{ height: "50vh", minHeight: "250px" }}>
+        <div className="relative min-h-0 flex-1">
           <MapContainer
             center={currentPos as LatLngExpression}
             zoom={15}


### PR DESCRIPTION
## Summary
- The map on the Trip tab in idle state used a fixed `50vh` height, leaving a large blank gap below the action buttons
- Changed the idle map container from `style={{ height: "50vh" }}` to `flex-1 min-h-0` so it fills all available space between header and buttons
- Unified the root container height to `calc(100dvh - 6rem)` for both idle and tracking states (needed because PullToRefresh breaks `h-full` propagation)

## Test plan
- [x] Playwright regression test (`idle-map-height.spec.ts`) verifies:
  - Map height > 50% of viewport (was only ~50vh before, now fills remaining space)
  - Gap between map and buttons < 30px (was 100px+ before)
- [x] Existing `tracking-layout.spec.ts` still passes (tracking mode unaffected)
- [x] All 9 smoke tests pass
- [x] Typecheck passes
- [x] Build succeeds

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)