### PR TITLE
fix: trip detail panel anchors to viewport bottom (#130)

### DIFF
--- a/client/e2e/trip-detail-panel.spec.ts
+++ b/client/e2e/trip-detail-panel.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for #130: Trip detail slide-up panel must be anchored to the
+ * viewport bottom (position: fixed), not the page content bottom.
+ *
+ * Before the fix, the bottom sheet was rendered inside the PullToRefresh
+ * container which applies CSS `transform` on its children. This created a new
+ * containing block, causing `position: fixed` to behave like `position: absolute`
+ * relative to the PullToRefresh wrapper instead of the viewport.
+ *
+ * After the fix, the bottom sheet is rendered via createPortal to document.body,
+ * escaping the PullToRefresh transform context.
+ */
+test.describe("Trip detail panel viewport anchoring (#130)", () => {
+  test.use({ serviceWorkers: "block" });
+
+  test("bottom sheet is anchored to viewport bottom, not page bottom", async ({ page }) => {
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    const trip = {
+      id: "trip-1",
+      userId: "u",
+      distanceKm: 5.2,
+      durationSec: 1200,
+      co2SavedKg: 1.8,
+      moneySavedEur: 1.5,
+      fuelSavedL: 0.6,
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      gpsPoints: [],
+    };
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session: {
+              id: "s",
+              userId: "u",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "u",
+              name: "Test",
+              email: "t@t.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/stats/summary")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: {
+              totalDistanceKm: 120,
+              totalCo2SavedKg: 18,
+              totalMoneySavedEur: 25,
+              totalFuelSavedL: 10,
+              tripCount: 5,
+              currentStreak: 2,
+            },
+          }),
+        });
+      }
+
+      if (url.match(/\/trips\/trip-1$/)) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: trip }),
+        });
+      }
+
+      if (url.includes("/trips")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { trips: [trip] },
+            pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+          }),
+        });
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { achievements: [] } }),
+      });
+    });
+
+    await page.goto("/stats", { waitUntil: "networkidle" });
+
+    // Click the trip to open the bottom sheet
+    await page.getByText("+5.2 KM").click();
+
+    // Wait for the bottom sheet dialog
+    const sheet = page.getByRole("dialog", { name: "Détail du trajet" });
+    await expect(sheet).toBeVisible({ timeout: 3000 });
+
+    // The dialog must have position: fixed (not absolute/relative/static)
+    const position = await sheet.evaluate((el) => getComputedStyle(el).position);
+    expect(position).toBe("fixed");
+
+    // The dialog must be a direct child of document.body (rendered via portal),
+    // NOT inside the PullToRefresh container which applies transform and breaks fixed positioning
+    const parentTagName = await sheet.evaluate((el) => el.parentElement?.tagName);
+    expect(parentTagName).toBe("BODY");
+  });
+});

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Bike, BarChart3, Trash2, X } from "lucide-react";
 import type { Trip } from "@ecoride/shared/types";
 import { LineChart, Line, XAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
@@ -438,93 +439,95 @@ export function StatsPage() {
         </section>
       </div>
 
-      {/* Bottom sheet — trip detail / delete */}
-      {selectedTrip && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="Détail du trajet"
-          className="fixed inset-0 z-[60] flex items-end justify-center"
-          onClick={() => setSelectedTrip(null)}
-        >
-          {/* Backdrop */}
-          <div className="absolute inset-0 bg-black/50" />
-
-          {/* Sheet */}
+      {/* Bottom sheet — trip detail / delete (portal to escape PullToRefresh transform) */}
+      {selectedTrip &&
+        createPortal(
           <div
-            className="relative w-full max-w-lg overflow-y-auto max-h-[85vh] rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
-            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Détail du trajet"
+            className="fixed inset-0 z-[60] flex items-end justify-center"
+            onClick={() => setSelectedTrip(null)}
           >
-            {/* Handle */}
-            <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-surface-highest" />
+            {/* Backdrop */}
+            <div className="absolute inset-0 bg-black/50" />
 
-            {/* Header */}
-            <div className="mb-6 flex items-start justify-between">
-              <div>
-                <h3 className="text-lg font-bold">{tripLabel(selectedTrip.startedAt)}</h3>
-                <p className="text-sm text-text-muted">
-                  {new Date(selectedTrip.startedAt).toLocaleDateString("fr-FR", {
-                    weekday: "long",
-                    day: "numeric",
-                    month: "long",
-                  })}
-                </p>
+            {/* Sheet */}
+            <div
+              className="relative w-full max-w-lg overflow-y-auto max-h-[85vh] rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Handle */}
+              <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-surface-highest" />
+
+              {/* Header */}
+              <div className="mb-6 flex items-start justify-between">
+                <div>
+                  <h3 className="text-lg font-bold">{tripLabel(selectedTrip.startedAt)}</h3>
+                  <p className="text-sm text-text-muted">
+                    {new Date(selectedTrip.startedAt).toLocaleDateString("fr-FR", {
+                      weekday: "long",
+                      day: "numeric",
+                      month: "long",
+                    })}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setSelectedTrip(null)}
+                  aria-label="Fermer"
+                  className="rounded-lg p-2 text-text-muted active:bg-surface-high"
+                >
+                  <X size={20} />
+                </button>
               </div>
+
+              {/* GPS Track Map */}
+              {hasGpsTrack && <TripMiniMap gpsPoints={gpsPoints} />}
+
+              {/* Manual entry label */}
+              {!hasGpsTrack && (
+                <p className="mb-4 text-center text-xs text-text-dim">Saisie manuelle</p>
+              )}
+
+              {/* Stats */}
+              <div className="mb-6 grid grid-cols-3 gap-4 text-center">
+                <div>
+                  <p className="text-xl font-bold text-primary-light">
+                    {Number(selectedTrip.distanceKm).toFixed(1)}
+                  </p>
+                  <p className="text-xs font-bold uppercase text-text-muted">km</p>
+                </div>
+                <div>
+                  <p className="text-xl font-bold text-primary-light">
+                    {selectedTrip.co2SavedKg.toFixed(1)}
+                  </p>
+                  <p className="text-xs font-bold uppercase text-text-muted">kg CO₂</p>
+                </div>
+                <div>
+                  <p className="text-xl font-bold text-primary-light">
+                    {selectedTrip.moneySavedEur.toFixed(2)}
+                  </p>
+                  <p className="text-xs font-bold uppercase text-text-muted">€</p>
+                </div>
+              </div>
+
+              {/* Delete button */}
               <button
-                onClick={() => setSelectedTrip(null)}
-                aria-label="Fermer"
-                className="rounded-lg p-2 text-text-muted active:bg-surface-high"
+                onClick={() => {
+                  deleteTrip.mutate(selectedTrip.id, {
+                    onSuccess: () => setSelectedTrip(null),
+                  });
+                }}
+                disabled={deleteTrip.isPending}
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-danger/10 py-3 text-sm font-bold text-danger active:scale-95 disabled:opacity-50"
               >
-                <X size={20} />
+                <Trash2 size={16} />
+                {deleteTrip.isPending ? "Suppression..." : "Supprimer ce trajet"}
               </button>
             </div>
-
-            {/* GPS Track Map */}
-            {hasGpsTrack && <TripMiniMap gpsPoints={gpsPoints} />}
-
-            {/* Manual entry label */}
-            {!hasGpsTrack && (
-              <p className="mb-4 text-center text-xs text-text-dim">Saisie manuelle</p>
-            )}
-
-            {/* Stats */}
-            <div className="mb-6 grid grid-cols-3 gap-4 text-center">
-              <div>
-                <p className="text-xl font-bold text-primary-light">
-                  {Number(selectedTrip.distanceKm).toFixed(1)}
-                </p>
-                <p className="text-xs font-bold uppercase text-text-muted">km</p>
-              </div>
-              <div>
-                <p className="text-xl font-bold text-primary-light">
-                  {selectedTrip.co2SavedKg.toFixed(1)}
-                </p>
-                <p className="text-xs font-bold uppercase text-text-muted">kg CO₂</p>
-              </div>
-              <div>
-                <p className="text-xl font-bold text-primary-light">
-                  {selectedTrip.moneySavedEur.toFixed(2)}
-                </p>
-                <p className="text-xs font-bold uppercase text-text-muted">€</p>
-              </div>
-            </div>
-
-            {/* Delete button */}
-            <button
-              onClick={() => {
-                deleteTrip.mutate(selectedTrip.id, {
-                  onSuccess: () => setSelectedTrip(null),
-                });
-              }}
-              disabled={deleteTrip.isPending}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-danger/10 py-3 text-sm font-bold text-danger active:scale-95 disabled:opacity-50"
-            >
-              <Trash2 size={16} />
-              {deleteTrip.isPending ? "Suppression..." : "Supprimer ce trajet"}
-            </button>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- **Root cause**: The trip detail bottom sheet was rendered inside the `PullToRefresh` container, which applies CSS `transform: translateY(...)` on its children wrapper. This creates a new containing block per CSS spec, causing `position: fixed` to behave like `position: absolute` relative to the PullToRefresh wrapper instead of the viewport.
- **Fix**: Wrap the bottom sheet in `createPortal(…, document.body)` so it renders directly on `<body>`, escaping the PullToRefresh transform context.
- **Regression test**: New Playwright e2e test verifies the dialog has `position: fixed` computed style and is a direct child of `document.body`.

Closes #130

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] All 27 Playwright tests pass (including new regression test)
- [ ] Manual: open Stats page, tap a trip → bottom sheet slides up from screen bottom, not page bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)