### PR TITLE
fix: allow relative paths in admin announcement and notification URLs

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -372,7 +372,7 @@ function AnnouncementSection() {
           className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
         />
         <input
-          type="url"
+          type="text"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           placeholder="Lien (optionnel, ex: /profile)"
@@ -491,7 +491,7 @@ function NotificationSection({ users }: { users?: { id: string; name: string; em
           className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
         />
         <input
-          type="url"
+          type="text"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           placeholder="Lien notification (optionnel)"

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -165,7 +165,7 @@ adminRouter.get("/stats", async (c) => {
 const sendNotificationSchema = z.object({
   title: z.string().min(1).max(100),
   body: z.string().min(1).max(500),
-  url: z.string().url().optional(),
+  url: z.string().min(1).optional(),
   userIds: z.array(z.string().min(1)).optional(),
 });
 
@@ -248,7 +248,7 @@ adminRouter.get("/notifications", async (c) => {
 const createAnnouncementSchema = z.object({
   title: z.string().min(1).max(100),
   body: z.string().min(1).max(500),
-  url: z.string().url().optional(),
+  url: z.string().min(1).optional(),
 });
 
 // POST /api/admin/announcements — Create announcement


### PR DESCRIPTION
## Summary
Admin forms rejected `/profile` as a URL because `type="url"` and `z.string().url()` require absolute URLs. Changed to accept both absolute URLs and relative paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)