### PR TITLE
feat: swipe navigation between pages

### DIFF
--- a/client/e2e/swipe-navigation.spec.ts
+++ b/client/e2e/swipe-navigation.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("swipe navigation between pages", () => {
+  test.use({ serviceWorkers: "block", hasTouch: true });
+
+  const fakeUser = {
+    id: "u1",
+    name: "Test",
+    email: "t@t.com",
+    isAdmin: false,
+    image: null,
+    vehicleModel: null,
+    fuelType: null,
+    consumptionL100: null,
+    mileage: null,
+    leaderboardOptOut: false,
+    reminderEnabled: false,
+    reminderTime: null,
+    reminderDays: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    emailVerified: true,
+  };
+
+  const emptyStats = {
+    totalDistanceKm: 0,
+    totalCo2SavedKg: 0,
+    totalMoneySavedEur: 0,
+    totalFuelSavedL: 0,
+    tripCount: 0,
+    currentStreakDays: 0,
+    longestStreakDays: 0,
+    avgSpeedKmh: 0,
+    maxSpeedKmh: 0,
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await page.route(/\/api\//, (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            user: fakeUser,
+            session: {
+              id: "s1",
+              token: "tok",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+          }),
+        });
+      }
+
+      if (url.includes("/api/stats/summary")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: emptyStats }),
+        });
+      }
+
+      if (url.includes("/api/user/profile")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: { user: fakeUser, stats: emptyStats } }),
+        });
+      }
+
+      if (url.includes("/api/announcements")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: [] }),
+        });
+      }
+
+      if (url.includes("/api/trips")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: [] }),
+        });
+      }
+
+      if (url.includes("/api/stats")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: [] }),
+        });
+      }
+
+      if (url.includes("/api/leaderboard")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, data: [] }),
+        });
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: {} }),
+      });
+    });
+  });
+
+  async function swipe(
+    page: import("@playwright/test").Page,
+    startX: number,
+    endX: number,
+    y: number,
+  ) {
+    const client = await page.context().newCDPSession(page);
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: startX, y }],
+    });
+    const midX = (startX + endX) / 2;
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x: midX, y }],
+    });
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x: endX, y }],
+    });
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  }
+
+  test("swipe left on home navigates to trip page", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+    await expect(page.locator("nav[aria-label='Navigation principale']")).toBeVisible({
+      timeout: 5000,
+    });
+    await swipe(page, 300, 80, 400);
+    await expect(page).toHaveURL(/\/trip/, { timeout: 3000 });
+  });
+
+  test("swipe right on stats page navigates to trip page", async ({ page }) => {
+    await page.goto("/stats", { waitUntil: "networkidle" });
+    await expect(page.locator("nav[aria-label='Navigation principale']")).toBeVisible({
+      timeout: 5000,
+    });
+    await swipe(page, 80, 300, 400);
+    await expect(page).toHaveURL(/\/trip/, { timeout: 3000 });
+  });
+
+  test("swipe right on home does not navigate (already first tab)", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+    await expect(page.locator("nav[aria-label='Navigation principale']")).toBeVisible({
+      timeout: 5000,
+    });
+    await swipe(page, 80, 300, 400);
+    await page.waitForTimeout(500);
+    expect(page.url()).toMatch(/\/$/);
+  });
+});

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -4,18 +4,25 @@ import { useQueryClient } from "@tanstack/react-query";
 import { BottomNav } from "./BottomNav";
 import { PullToRefresh } from "@/components/ui/PullToRefresh";
 import { useOfflineSync } from "@/hooks/useOfflineSync";
+import { useSwipeNavigation } from "@/hooks/useSwipeNavigation";
 
 export function AppShell() {
   const queryClient = useQueryClient();
   const location = useLocation();
   useOfflineSync();
+  const swipe = useSwipeNavigation();
 
   const handleRefresh = useCallback(async () => {
     await queryClient.invalidateQueries();
   }, [queryClient]);
 
   return (
-    <div className="flex h-full flex-col bg-bg pt-[env(safe-area-inset-top)]">
+    <div
+      className="flex h-full flex-col bg-bg pt-[env(safe-area-inset-top)]"
+      onTouchStart={swipe.onTouchStart}
+      onTouchMove={swipe.onTouchMove}
+      onTouchEnd={swipe.onTouchEnd}
+    >
       <main className="flex-1 overflow-hidden pb-24">
         <PullToRefresh onRefresh={handleRefresh} scrollKey={location.pathname}>
           <Outlet />

--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -1,13 +1,16 @@
 import { NavLink } from "react-router";
 import { LayoutDashboard, Bike, BarChart3, Trophy, User } from "lucide-react";
+import { NAV_ROUTES } from "@/lib/navTabs";
 
-const tabs = [
-  { to: "/", icon: LayoutDashboard, label: "Accueil" },
-  { to: "/trip", icon: Bike, label: "Trajet" },
-  { to: "/stats", icon: BarChart3, label: "Stats" },
-  { to: "/leaderboard", icon: Trophy, label: "Classement" },
-  { to: "/profile", icon: User, label: "Profil" },
-] as const;
+const icons = {
+  "/": { icon: LayoutDashboard, label: "Accueil" },
+  "/trip": { icon: Bike, label: "Trajet" },
+  "/stats": { icon: BarChart3, label: "Stats" },
+  "/leaderboard": { icon: Trophy, label: "Classement" },
+  "/profile": { icon: User, label: "Profil" },
+} as const;
+
+const tabs = NAV_ROUTES.map((to) => ({ to, ...icons[to] }));
 
 export function BottomNav() {
   return (

--- a/client/src/hooks/useSwipeNavigation.ts
+++ b/client/src/hooks/useSwipeNavigation.ts
@@ -1,0 +1,57 @@
+import { useCallback, useRef } from "react";
+import { useLocation, useNavigate } from "react-router";
+import { NAV_ROUTES } from "@/lib/navTabs";
+
+/** Minimum horizontal distance (px) to trigger navigation. */
+const SWIPE_THRESHOLD = 60;
+/** Tan of max angle from horizontal — if dy/dx > this, it's a vertical gesture. */
+const ANGLE_LIMIT = 0.6;
+/** Elements that should not trigger swipe (CSS selectors). */
+const IGNORE_SELECTORS = ".leaflet-container, input, textarea, [data-no-swipe]";
+
+export function useSwipeNavigation() {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const locked = useRef<"horizontal" | "vertical" | null>(null);
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.closest(IGNORE_SELECTORS)) return;
+    startX.current = e.touches[0]!.clientX;
+    startY.current = e.touches[0]!.clientY;
+    locked.current = null;
+  }, []);
+
+  const onTouchMove = useCallback((e: React.TouchEvent) => {
+    if (locked.current === "vertical") return;
+    const dx = e.touches[0]!.clientX - startX.current;
+    const dy = e.touches[0]!.clientY - startY.current;
+
+    // Lock direction on first significant movement
+    if (locked.current === null && (Math.abs(dx) > 10 || Math.abs(dy) > 10)) {
+      locked.current =
+        Math.abs(dy) / Math.max(Math.abs(dx), 1) > ANGLE_LIMIT ? "vertical" : "horizontal";
+    }
+  }, []);
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (locked.current !== "horizontal") return;
+      const dx = e.changedTouches[0]!.clientX - startX.current;
+      if (Math.abs(dx) < SWIPE_THRESHOLD) return;
+
+      const idx = NAV_ROUTES.indexOf(pathname as (typeof NAV_ROUTES)[number]);
+      if (idx === -1) return;
+
+      const nextIdx = dx > 0 ? idx - 1 : idx + 1; // swipe right = previous
+      if (nextIdx < 0 || nextIdx >= NAV_ROUTES.length) return;
+
+      navigate(NAV_ROUTES[nextIdx]!);
+    },
+    [pathname, navigate],
+  );
+
+  return { onTouchStart, onTouchMove, onTouchEnd };
+}

--- a/client/src/lib/navTabs.ts
+++ b/client/src/lib/navTabs.ts
@@ -1,0 +1,2 @@
+/** Ordered list of main navigation routes (matches BottomNav tab order). */
+export const NAV_ROUTES = ["/", "/trip", "/stats", "/leaderboard", "/profile"] as const;


### PR DESCRIPTION
## Summary
- Swipe left/right to navigate between the 5 main tabs (Accueil → Trajet → Stats → Classement → Profil)
- Matches bottom navbar order, coexists with pull-to-refresh
- Ignores swipes on Leaflet maps, inputs, and `[data-no-swipe]` elements

Closes #83

## Changes
- `client/src/lib/navTabs.ts` — shared route order (single source of truth)
- `client/src/hooks/useSwipeNavigation.ts` — horizontal swipe detection hook
- `client/src/components/layout/AppShell.tsx` — touch handlers on main container
- `client/src/components/layout/BottomNav.tsx` — uses shared `NAV_ROUTES`
- `client/e2e/swipe-navigation.spec.ts` — 3 Playwright e2e tests

## Test plan
- [x] Swipe left on home → navigates to trip
- [x] Swipe right on stats → navigates to trip
- [x] Swipe right on home → stays (boundary check)
- [x] Existing 9 smoke tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.ai/code)