### PR TITLE
feat: add distance as a leaderboard category

### DIFF
--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Trophy, Leaf, Flame, MapPin, Zap, Euro } from "lucide-react";
+import { Trophy, Leaf, Flame, MapPin, Zap, Euro, Route } from "lucide-react";
 import { useLeaderboard } from "@/hooks/queries";
 import { useSession } from "@/lib/auth";
 import type { StatsPeriod, LeaderboardCategory } from "@ecoride/shared/api-contracts";
@@ -16,6 +16,7 @@ const categoryOptions: { label: string; value: LeaderboardCategory; icon: typeof
   { label: "Trajets", value: "trips", icon: MapPin },
   { label: "Vitesse", value: "speed", icon: Zap },
   { label: "€", value: "money", icon: Euro },
+  { label: "KM", value: "distance", icon: Route },
 ];
 
 const categorySubtitles: Record<LeaderboardCategory, string> = {
@@ -24,6 +25,7 @@ const categorySubtitles: Record<LeaderboardCategory, string> = {
   trips: "L'activité",
   speed: "La performance",
   money: "Les économies",
+  distance: "La distance",
 };
 
 const categoryUnits: Record<LeaderboardCategory, string> = {
@@ -32,6 +34,7 @@ const categoryUnits: Record<LeaderboardCategory, string> = {
   trips: "TRAJETS",
   speed: "KM/H",
   money: "€",
+  distance: "KM",
 };
 
 const periodSuffixes: Record<StatsPeriod, string> = {

--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -12,7 +12,7 @@ import type { StatsPeriod } from "@ecoride/shared/api-contracts";
 const leaderboardQuery = z.object({
   period: z.enum(["day", "week", "month", "year", "all"]).default("all"),
   limit: z.coerce.number().int().positive().max(100).default(50),
-  category: z.enum(["co2", "streak", "trips", "speed", "money"]).default("co2"),
+  category: z.enum(["co2", "streak", "trips", "speed", "money", "distance"]).default("co2"),
 });
 
 function getPeriodStart(period: StatsPeriod): Date | null {
@@ -115,6 +115,32 @@ leaderboardRouter.get("/", zValidator("query", leaderboardQuery, validationHook)
 
     const ranked = denseRank(entries, (e) => e.totalCo2SavedKg ?? 0);
     const mapped = ranked.map((e) => ({ ...e, value: e.totalCo2SavedKg }));
+
+    const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
+    return c.json({ ok: true, data: { entries: mapped, userRank } });
+  }
+
+  if (category === "distance") {
+    const entries = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        image: user.image,
+        totalCo2SavedKg: sql<number>`coalesce(${sum(trips.co2SavedKg)}, 0)`.mapWith(Number),
+        totalDistanceKm: sql<number>`coalesce(${sum(trips.distanceKm)}, 0)`.mapWith(Number),
+      })
+      .from(user)
+      .leftJoin(trips, joinCondition)
+      .where(and(...conditions))
+      .groupBy(user.id, user.name, user.image)
+      .orderBy(desc(sql`coalesce(${sum(trips.distanceKm)}, 0)`), asc(user.name))
+      .limit(limit);
+
+    const ranked = denseRank(entries, (e) => e.totalDistanceKm ?? 0);
+    const mapped = ranked.map((e) => ({
+      ...e,
+      value: Math.round((e.totalDistanceKm ?? 0) * 10) / 10,
+    }));
 
     const userRank = mapped.find((e) => e.userId === currentUser.id)?.rank ?? null;
     return c.json({ ok: true, data: { entries: mapped, userRank } });

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -71,7 +71,7 @@ export interface FuelPriceQuery {
 
 export type StatsPeriod = "day" | "week" | "month" | "year" | "all";
 
-export type LeaderboardCategory = "co2" | "streak" | "trips" | "speed" | "money";
+export type LeaderboardCategory = "co2" | "streak" | "trips" | "speed" | "money" | "distance";
 
 // ---- Response payloads ----
 


### PR DESCRIPTION
Closes #96

## Summary
Distance (KM) is now a leaderboard category. Users can see who has ridden the most kilometers.

- **Backend**: new `distance` category in leaderboard query (same pattern as CO2)
- **Shared**: `LeaderboardCategory` type updated
- **Frontend**: 6th icon button in the category switcher

Distance was already displayed on Dashboard, Stats, and Profile pages. The leaderboard was the only missing piece.

## Test plan
- [x] TypeScript passes (client + server)
- [x] All 31 Playwright tests pass
- [ ] Manual: Leaderboard → tap KM icon → shows distance ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)