### PR TITLE
feat: enrich health check endpoints (ECO-5)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,9 @@ import { initCronJobs } from "./cron";
 import { AppError } from "./lib/errors";
 import { rateLimit } from "./lib/rate-limit";
 import { logger } from "./lib/logger";
+import { db } from "./db";
+import { trips, user } from "./db/schema";
+import { sql, count, gte, countDistinct } from "drizzle-orm";
 
 const app = new Hono();
 
@@ -83,7 +86,23 @@ const appVersion = (() => {
     return "unknown";
   }
 })();
-app.get("/api/health", (c) => c.json({ ok: true, status: "healthy", version: appVersion }));
+app.get("/api/health", async (c) => {
+  let dbOk = false;
+  let activeUsers7d = 0;
+  try {
+    await db.execute(sql`SELECT 1`);
+    dbOk = true;
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const [result] = await db
+      .select({ value: countDistinct(trips.userId) })
+      .from(trips)
+      .where(gte(trips.startedAt, sevenDaysAgo));
+    activeUsers7d = result?.value ?? 0;
+  } catch {
+    // db queries failed — return what we have
+  }
+  return c.json({ ok: true, status: "healthy", version: appVersion, db: dbOk, activeUsers7d });
+});
 
 // ---- Auth middleware for all other /api routes ----
 app.use("/api/*", authMiddleware);

--- a/server/src/routes/__tests__/health.test.ts
+++ b/server/src/routes/__tests__/health.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
+
+// Mock db to prevent real Postgres connection
+const mockExecute = vi.fn().mockResolvedValue([{ rows: [{ size_mb: "42.3" }] }]);
+const mockSelect = vi.fn();
+
+vi.mock("../../db", () => ({
+  db: {
+    execute: (...args: unknown[]) => mockExecute(...args),
+    select: (...args: unknown[]) => mockSelect(...args),
+  },
+}));
+vi.mock("../../db/schema", () => ({ trips: {}, user: {} }));
+vi.mock("../../auth/admin", () => ({
+  adminMiddleware: vi.fn(async (_c: unknown, next: () => Promise<void>) => next()),
+}));
+
+import { healthRouter } from "../health.routes";
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/health", healthRouter);
+  return app;
+}
+
+describe("GET /health/detailed", () => {
+  it("returns expected shape with db, users, trips keys", async () => {
+    // selectChain: each .from().where().catch() call
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      catch: vi.fn().mockResolvedValue([{ value: 5 }]),
+    };
+    mockSelect.mockReturnValue(chain);
+
+    const app = buildApp();
+    const res = await app.request("/health/detailed");
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body).toHaveProperty("version");
+    expect(body).toHaveProperty("uptime");
+    expect(body.db).toMatchObject({ connected: expect.any(Boolean) });
+    expect(body.users).toMatchObject({
+      total: expect.any(Number),
+      active7d: expect.any(Number),
+    });
+    expect(body.trips).toMatchObject({
+      total: expect.any(Number),
+      last7d: expect.any(Number),
+    });
+  });
+
+  it("returns db.connected=false when db.execute throws", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("db down"));
+
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      catch: vi.fn().mockResolvedValue([null]),
+    };
+    mockSelect.mockReturnValue(chain);
+
+    const app = buildApp();
+    const res = await app.request("/health/detailed");
+    const body = (await res.json()) as { db: { connected: boolean } };
+
+    expect(res.status).toBe(200);
+    expect(body.db.connected).toBe(false);
+  });
+});

--- a/server/src/routes/health.routes.ts
+++ b/server/src/routes/health.routes.ts
@@ -1,0 +1,71 @@
+import { Hono } from "hono";
+import { sql, count, gte, countDistinct } from "drizzle-orm";
+import { db } from "../db";
+import { user, trips } from "../db/schema";
+import { adminMiddleware } from "../auth/admin";
+import type { AuthEnv } from "../types/context";
+
+const appVersion = (() => {
+  try {
+    return require("../../package.json").version;
+  } catch {
+    return "unknown";
+  }
+})();
+
+const healthRouter = new Hono<AuthEnv>();
+
+// GET /api/health/detailed — Admin-only detailed health check
+healthRouter.get("/detailed", adminMiddleware, async (c) => {
+  let dbConnected = false;
+  let dbSizeMb = 0;
+
+  try {
+    await db.execute(sql`SELECT 1`);
+    dbConnected = true;
+    const [sizeResult] = await db.execute(
+      sql`SELECT round(pg_database_size(current_database()) / 1024.0 / 1024.0, 1) AS size_mb`,
+    );
+    dbSizeMb = Number((sizeResult as any)?.rows?.[0]?.size_mb ?? 0);
+  } catch {
+    // db unreachable
+  }
+
+  const [totalUsersResult] = await db
+    .select({ value: count() })
+    .from(user)
+    .catch(() => [null]);
+  const totalUsers = totalUsersResult?.value ?? 0;
+
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const [active7dResult] = await db
+    .select({ value: countDistinct(trips.userId) })
+    .from(trips)
+    .where(gte(trips.startedAt, sevenDaysAgo))
+    .catch(() => [null]);
+  const activeUsers7d = active7dResult?.value ?? 0;
+
+  const [totalTripsResult] = await db
+    .select({ value: count() })
+    .from(trips)
+    .catch(() => [null]);
+  const totalTrips = totalTripsResult?.value ?? 0;
+
+  const [trips7dResult] = await db
+    .select({ value: count() })
+    .from(trips)
+    .where(gte(trips.startedAt, sevenDaysAgo))
+    .catch(() => [null]);
+  const trips7d = trips7dResult?.value ?? 0;
+
+  return c.json({
+    ok: true,
+    version: appVersion,
+    uptime: process.uptime(),
+    db: { connected: dbConnected, sizeMb: dbSizeMb },
+    users: { total: totalUsers, active7d: activeUsers7d },
+    trips: { total: totalTrips, last7d: trips7d },
+  });
+});
+
+export { healthRouter };

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import { fuelPriceRouter } from "./fuel-price.routes";
 import { pushRouter } from "./push.routes";
 import { adminRouter } from "./admin.routes";
 import { feedbackRouter } from "./feedback.routes";
+import { healthRouter } from "./health.routes";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { announcements } from "../db/schema";
@@ -31,6 +32,7 @@ apiRouter.get("/announcements/active", async (c) => {
   });
 });
 
+apiRouter.route("/health", healthRouter);
 apiRouter.route("/trips", tripsRouter);
 apiRouter.route("/user", usersRouter);
 apiRouter.route("/stats/leaderboard", leaderboardRouter);


### PR DESCRIPTION
## Summary

- Enriches `GET /api/health` (public) with `db: boolean` (live DB ping) and `activeUsers7d: number` (distinct users with a trip in last 7 days)
- Adds `GET /api/health/detailed` (admin-only) returning structured `db`, `users`, and `trips` stats
- Unit tests for the new `/health/detailed` endpoint covering happy path and DB-down graceful fallback

Closes [ECO-5](/ECO/issues/ECO-5)

## Test plan
- [x] `bun run typecheck` — passes (client + server)
- [x] `bun run --filter server test` — 166 tests pass (17 files)
- [x] `/api/health/detailed` returns 200 with correct shape when DB is up
- [x] `/api/health/detailed` returns `db.connected: false` and still 200 when DB throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)