### PR TITLE
fix: add COOLIFY_API_TOKEN support for deploy webhook auth

### DIFF
--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -13,6 +13,7 @@ const envSchema = z.object({
   VAPID_SUBJECT: z.string().default("mailto:noreply@example.com"),
   FRONTEND_URL: z.string().url().default("http://localhost:5173"),
   COOLIFY_WEBHOOK_URL: z.string().url().optional(),
+  COOLIFY_API_TOKEN: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
 });
 

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -350,9 +350,17 @@ adminRouter.post(
       return c.json({ ok: false, error: "Deploy not configured" }, 503);
     }
 
+    const fetchHeaders: Record<string, string> = {};
+    if (env.COOLIFY_API_TOKEN) {
+      fetchHeaders["Authorization"] = `Bearer ${env.COOLIFY_API_TOKEN}`;
+    }
+
     let deployResponse: Response;
     try {
-      deployResponse = await fetch(env.COOLIFY_WEBHOOK_URL, { method: "GET" });
+      deployResponse = await fetch(env.COOLIFY_WEBHOOK_URL, {
+        method: "GET",
+        headers: fetchHeaders,
+      });
     } catch {
       return c.json({ ok: false, error: "Deploy failed" }, 502);
     }


### PR DESCRIPTION
## Problem
The admin deploy button was returning 502 because the backend `fetch(COOLIFY_WEBHOOK_URL)` call had no auth header. Coolify's API requires a `Bearer` token in the `Authorization` header.

## Solution
- Add `COOLIFY_API_TOKEN` optional env var
- When present, pass it as `Authorization: Bearer` header in the deploy webhook fetch call
- The `COOLIFY_WEBHOOK_URL` stays as a plain URL (no credentials embedded)

## Env vars needed in prod
```
COOLIFY_WEBHOOK_URL=http://coolify:8080/api/v1/deploy?uuid=cr92jivsr4aypchftn3y2t74&force=false
COOLIFY_API_TOKEN=24|f303e3a2d3dbe19adef35363cdf92bfab3c16c034bb3d063630250ead62695f925ec85920ad82985
```