### PR TITLE
feat: replace bare console calls with structured logger (ECO-7)

### DIFF
--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "./lib/logger";
 
 const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
@@ -22,10 +23,12 @@ export type Env = z.infer<typeof envSchema>;
 function loadEnv(): Env {
   const result = envSchema.safeParse(process.env);
   if (!result.success) {
-    console.error("Invalid environment variables:");
-    for (const issue of result.error.issues) {
-      console.error(`  ${issue.path.join(".")}: ${issue.message}`);
-    }
+    logger.error("invalid_env_vars", {
+      issues: result.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      })),
+    });
     process.exit(1);
   }
   return result.data;

--- a/server/src/routes/__tests__/admin.test.ts
+++ b/server/src/routes/__tests__/admin.test.ts
@@ -45,6 +45,20 @@ vi.mock("../../auth/admin", () => ({
   ),
 }));
 
+const mockLoggerError = vi.fn();
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    withContext: vi.fn(() => ({
+      error: mockLoggerError,
+      info: vi.fn(),
+      warn: vi.fn(),
+    })),
+  },
+}));
+
 vi.mock("../../lib/audit", () => ({ logAudit: vi.fn() }));
 vi.mock("../../lib/push", () => ({
   sendPushBroadcast: vi.fn().mockResolvedValue({ sent: 0, failed: 0 }),
@@ -67,6 +81,7 @@ describe("POST /admin/deploy", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
     mockEnv.COOLIFY_WEBHOOK_URL = "https://coolify.example.com/webhook/test";
+    mockLoggerError.mockClear();
   });
 
   it("returns 502 when webhook returns a non-2xx status (regression: was silently ok:true)", async () => {
@@ -84,6 +99,25 @@ describe("POST /admin/deploy", () => {
 
     expect(res.status).toBe(502);
     expect(body.ok).toBe(false);
+  });
+
+  it("logs structured error via logger.withContext when webhook returns non-2xx (regression: was bare console.error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: () => Promise.resolve("Service Unavailable"),
+      }),
+    );
+
+    await buildApp().request("/admin/deploy", { method: "POST" });
+
+    expect(mockLoggerError).toHaveBeenCalledOnce();
+    expect(mockLoggerError).toHaveBeenCalledWith("deploy_webhook_failed", {
+      status: 503,
+      body: "Service Unavailable",
+    });
   });
 
   it("returns ok:true when webhook returns 2xx", async () => {

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -10,6 +10,7 @@ import { rateLimit } from "../lib/rate-limit";
 import { sendPushBroadcast } from "../lib/push";
 import { logAudit } from "../lib/audit";
 import { env } from "../env";
+import { logger } from "../lib/logger";
 import type { AuthEnv } from "../types/context";
 
 const appVersion = (() => {
@@ -367,7 +368,9 @@ adminRouter.post(
 
     if (!deployResponse.ok) {
       const body = await deployResponse.text().catch(() => "");
-      console.error(`[deploy] Coolify webhook HTTP ${deployResponse.status}:`, body);
+      logger
+        .withContext(c.get("requestId") as string | undefined)
+        .error("deploy_webhook_failed", { status: deployResponse.status, body });
       return c.json({ ok: false, error: `Deploy failed: HTTP ${deployResponse.status}` }, 502);
     }
 


### PR DESCRIPTION
## Summary

- Replaces `console.error` in `server/src/routes/admin.routes.ts` with `logger.withContext().error("deploy_webhook_failed", ...)` for structured JSON logging
- Replaces `console.error` in `server/src/env.ts` with `logger.error("invalid_env_vars", ...)` 
- Adds regression test verifying `logger.withContext().error` is called (not bare `console.error`) when the Coolify webhook returns non-2xx

## Test plan

- [x] `grep -r "console\." server/src --include="*.ts" -l` returns only `logger.ts` (+ test file comments)
- [x] All 172 server tests pass (`bunx vitest run`)
- [x] Typecheck clean (`bunx tsc --noEmit`)
- [x] Regression test fails before the fix, passes after

Closes ECO-14 / part of ECO-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)