### PR TITLE
fix: rotate map to face rider's direction of travel (ECO-20)

### DIFF
--- a/client/e2e/map-rotation.spec.ts
+++ b/client/e2e/map-rotation.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+
+// Regression test for ECO-20: map must rotate to match rider heading during tracking.
+// Before the fix: map.getContainer() had no transform; it always pointed north.
+// After the fix: map.getContainer() gets rotate(-heading deg) applied.
+
+test("map container rotates to match rider heading when tracking", async ({ page }) => {
+  // Override geolocation with a heading value (Playwright's built-in mock does not
+  // support heading/speed, so we inject a full replacement via addInitScript).
+  await page.addInitScript(() => {
+    const mockPos: GeolocationPosition = {
+      coords: {
+        latitude: 48.8566,
+        longitude: 2.3522,
+        accuracy: 5,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: 90, // East — rider is heading east
+        speed: 5, // 18 km/h, above the 1.8 km/h threshold
+      } as GeolocationCoordinates,
+      timestamp: Date.now(),
+    };
+
+    let watchId = 0;
+    Object.defineProperty(navigator, "geolocation", {
+      value: {
+        watchPosition: (success: PositionCallback) => {
+          const id = ++watchId;
+          setTimeout(() => success(mockPos), 50);
+          return id;
+        },
+        clearWatch: () => {},
+        getCurrentPosition: (success: PositionCallback) => {
+          setTimeout(() => success(mockPos), 50);
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  // Start tracking
+  await page.getByText("Démarrer").click();
+  await expect(page.getByText("Terminer")).toBeVisible({ timeout: 5000 });
+
+  // Wait for the GPS callback and React re-render to propagate
+  await page.waitForTimeout(1500);
+
+  // The Leaflet container inside the tracking map div should now be rotated.
+  // rotate(-90deg) because heading = 90 and we apply rotate(-heading).
+  const transform = await page
+    .locator('[data-testid="tracking-map"] .leaflet-container')
+    .evaluate((el: HTMLElement) => el.style.transform);
+
+  expect(transform).toMatch(/rotate\(-90deg\)/);
+});
+
+test("map container has no rotation when heading is null (stationary start)", async ({ page }) => {
+  // Geolocation returns null heading (stationary or unavailable)
+  await page.addInitScript(() => {
+    const mockPos: GeolocationPosition = {
+      coords: {
+        latitude: 48.8566,
+        longitude: 2.3522,
+        accuracy: 5,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null, // No heading — stationary
+        speed: null,
+      } as GeolocationCoordinates,
+      timestamp: Date.now(),
+    };
+
+    let watchId = 0;
+    Object.defineProperty(navigator, "geolocation", {
+      value: {
+        watchPosition: (success: PositionCallback) => {
+          const id = ++watchId;
+          setTimeout(() => success(mockPos), 50);
+          return id;
+        },
+        clearWatch: () => {},
+        getCurrentPosition: (success: PositionCallback) => {
+          setTimeout(() => success(mockPos), 50);
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  await page.getByText("Démarrer").click();
+  await expect(page.getByText("Terminer")).toBeVisible({ timeout: 5000 });
+
+  await page.waitForTimeout(1500);
+
+  // With null heading, the container transform should be empty (north-up).
+  const transform = await page
+    .locator('[data-testid="tracking-map"] .leaflet-container')
+    .evaluate((el: HTMLElement) => el.style.transform);
+
+  expect(transform).toBe("");
+});

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -52,6 +52,24 @@ function createArrowIcon(heading: number) {
   });
 }
 
+function RotateMap({ heading }: { heading: number | null }) {
+  const map = useMap();
+
+  useEffect(() => {
+    const container = map.getContainer();
+    if (heading != null) {
+      container.style.transform = `rotate(${-heading}deg)`;
+      container.style.transformOrigin = "50% 50%";
+      container.style.transition = "transform 0.4s ease-out";
+    } else {
+      container.style.transform = "";
+      container.style.transition = "";
+    }
+  }, [map, heading]);
+
+  return null;
+}
+
 export function TripPage() {
   const [uiState, setUiState] = useState<TripState>("idle");
   const [manualKm, setManualKm] = useState("");
@@ -327,7 +345,7 @@ export function TripPage() {
           </div>
 
           {/* Mini map */}
-          <div className="relative min-h-0 flex-1" data-testid="tracking-map">
+          <div className="relative min-h-0 flex-1 overflow-hidden" data-testid="tracking-map">
             <MapContainer
               center={currentPos as LatLngExpression}
               zoom={15}
@@ -364,6 +382,7 @@ export function TripPage() {
                 />
               )}
               <RecenterMap position={currentPos} offsetBottom />
+              <RotateMap heading={gps.state.heading} />
             </MapContainer>
           </div>
         </>


### PR DESCRIPTION
## Summary

- Adds a `RotateMap` Leaflet component that applies `rotate(-heading deg)` CSS transform to the map container whenever the GPS heading is non-null, keeping the map heading-up instead of always north-up
- Falls back to north-up (`transform: ''`) when heading is null (stationary or GPS unavailable)
- Adds `overflow-hidden` to the tracking map wrapper div to clip rotated corners cleanly
- Resolves [ECO-20](/ECO/issues/ECO-20) (GitHub #145)

## Implementation notes

Standard Leaflet doesn't have a rotation API. The fix rotates `map.getContainer()` via inline style — safe because this app disables `zoomControl` and `attributionControl`, so no UI elements are cut off. The arrow marker already applies `rotate(heading deg)` to its SVG, so the compound rotation (`-heading + heading = 0`) keeps the arrow pointing straight up (direction of travel = top of screen). A smooth 0.4s ease-out transition reduces visual jitter between heading updates.

## Test plan

- [x] `bun run typecheck` passes (client + server)
- [x] `vitest run` passes (78 client + 175 server unit tests)
- [x] `client/e2e/map-rotation.spec.ts` — two new regression tests:
  - heading=90 → `transform: rotate(-90deg)` on `.leaflet-container`
  - heading=null → `transform: ''` (north-up, no rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)