### PR TITLE
fix: poll deploy status instead of fixed 90s sleep

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -96,10 +96,16 @@ jobs:
 
       - name: Wait and verify
         run: |
-          sleep 90
-          STATUS=$(curl -s \
-            "http://localhost:8000/api/v1/deployments/${{ env.deploy_uuid }}" \
-            -H "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}" \
-            | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('status'))")
-          echo "Status: $STATUS"
-          [ "$STATUS" = "finished" ] || exit 1
+          echo "Waiting for deployment ${{ env.deploy_uuid }} to finish..."
+          for i in $(seq 1 24); do
+            sleep 15
+            STATUS=$(curl -s \
+              "http://localhost:8000/api/v1/deployments/${{ env.deploy_uuid }}" \
+              -H "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}" \
+              | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('status'))")
+            echo "[$((i * 15))s] Status: $STATUS"
+            [ "$STATUS" = "finished" ] && exit 0
+            [ "$STATUS" = "failed" ] && echo "Deployment failed!" && exit 1
+          done
+          echo "Timeout: deployment still $STATUS after 360s"
+          exit 1


### PR DESCRIPTION
## Summary
- Le step «Wait and verify» échouait systématiquement car Coolify prend > 90s pour déployer
- Remplace le `sleep 90` fixe par une boucle de polling toutes les 15s pendant 6 minutes max
- Sort immédiatement dès que le statut est `finished` ou `failed`

## Root cause
`sleep 90` → status `in_progress` → `exit 1` sur tous les commits `fix:` depuis le 28/03

## Test plan
- [ ] Merger ce PR (commit `fix:` → déclenche auto-bump → polling jusqu'à `finished`)
- [ ] Vérifier que le workflow passe vert dans GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)