### PR TITLE
fix: replace stats preset prompt flow

### DIFF
--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -161,6 +161,9 @@ export function StatsPage() {
   const [period, setPeriod] = useState<Period>("week");
   const [metric, setMetric] = useState<Metric>("km");
   const [selectedTrip, setSelectedTrip] = useState<Trip | null>(null);
+  const [tripPresetFormOpen, setTripPresetFormOpen] = useState(false);
+  const [tripPresetLabel, setTripPresetLabel] = useState("");
+  const [tripPresetSaved, setTripPresetSaved] = useState(false);
   const { data: s, isPending: summaryLoading } = useDashboardSummary("month");
   const { data: tripsData, isPending: tripsLoading } = useTrips(1, 10);
   const { data: chartTripsData, isPending: chartLoading } = useChartTrips(period);
@@ -179,21 +182,38 @@ export function StatsPage() {
     }
   }, [selectedTrip]);
 
+  useEffect(() => {
+    if (!selectedTrip) {
+      setTripPresetFormOpen(false);
+      setTripPresetLabel("");
+      setTripPresetSaved(false);
+      return;
+    }
+
+    setTripPresetLabel(tripLabel(selectedTrip.startedAt).replace(/^Trajet /, ""));
+    setTripPresetSaved(false);
+  }, [selectedTrip]);
+
   // Use detailed trip data (with gpsPoints) when available, otherwise fall back to list data
   const displayTrip = tripDetail ?? selectedTrip;
   const gpsPoints = displayTrip?.gpsPoints;
   const hasGpsTrack = Array.isArray(gpsPoints) && gpsPoints.length > 1;
 
   const handleSaveTripPreset = () => {
-    if (!selectedTrip) return;
-    const suggestedLabel = tripLabel(selectedTrip.startedAt).replace(/^Trajet /, "");
-    const label = window.prompt("Nom du trajet pré-enregistré", suggestedLabel);
-    if (!label || !label.trim()) return;
+    if (!selectedTrip || !tripPresetLabel.trim()) return;
 
-    createTripPresetFromTrip.mutate({
-      tripId: selectedTrip.id,
-      label: label.trim(),
-    });
+    createTripPresetFromTrip.mutate(
+      {
+        tripId: selectedTrip.id,
+        label: tripPresetLabel.trim(),
+      },
+      {
+        onSuccess: () => {
+          setTripPresetSaved(true);
+          setTripPresetFormOpen(false);
+        },
+      },
+    );
   };
 
   const isPending = summaryLoading || tripsLoading || chartLoading || achievementsLoading;
@@ -585,15 +605,57 @@ export function StatsPage() {
 
               <div className="space-y-3">
                 <button
-                  onClick={handleSaveTripPreset}
+                  onClick={() => {
+                    setTripPresetSaved(false);
+                    setTripPresetFormOpen((open) => !open);
+                  }}
                   disabled={createTripPresetFromTrip.isPending}
                   className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary/10 py-3 text-sm font-bold text-primary-light active:scale-95 disabled:opacity-50"
                 >
                   <Save size={16} />
-                  {createTripPresetFromTrip.isPending
-                    ? "Enregistrement..."
-                    : "Créer un trajet pré-enregistré"}
+                  {tripPresetFormOpen ? "Masquer le formulaire" : "Créer un trajet pré-enregistré"}
                 </button>
+
+                {tripPresetFormOpen && (
+                  <div className="rounded-xl bg-surface-low p-4">
+                    <label
+                      htmlFor="trip-preset-label-input"
+                      className="mb-2 block text-xs font-bold uppercase tracking-widest text-text-muted"
+                    >
+                      Nom du trajet pré-enregistré
+                    </label>
+                    <input
+                      id="trip-preset-label-input"
+                      type="text"
+                      value={tripPresetLabel}
+                      onChange={(e) => setTripPresetLabel(e.target.value)}
+                      className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                    <div className="mt-3 flex gap-3">
+                      <button
+                        onClick={handleSaveTripPreset}
+                        disabled={createTripPresetFromTrip.isPending || !tripPresetLabel.trim()}
+                        className="flex-1 rounded-lg bg-primary py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
+                      >
+                        {createTripPresetFromTrip.isPending ? "Enregistrement..." : "Enregistrer"}
+                      </button>
+                      <button
+                        onClick={() => setTripPresetFormOpen(false)}
+                        disabled={createTripPresetFromTrip.isPending}
+                        className="flex-1 rounded-lg bg-surface-high py-3 text-sm font-bold text-text-muted active:scale-95 disabled:opacity-50"
+                      >
+                        Annuler
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {tripPresetSaved && (
+                  <div className="rounded-xl bg-primary/10 p-4 text-sm font-medium text-primary-light">
+                    Trajet pré-enregistré créé.
+                  </div>
+                )}
+
                 <button
                   onClick={() => {
                     deleteTrip.mutate(selectedTrip.id, {

--- a/client/src/pages/__tests__/StatsPage.preset.test.tsx
+++ b/client/src/pages/__tests__/StatsPage.preset.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StatsPage } from "../StatsPage";
+
+const createTripPresetFromTripMutate = vi.fn();
+const deleteTripMutate = vi.fn();
+
+vi.mock("react-map-gl/maplibre", () => ({
+  __esModule: true,
+  default: () => null,
+  Source: () => null,
+  Layer: () => null,
+  useMap: () => ({ current: null }),
+}));
+
+vi.mock("@/hooks/queries", () => ({
+  useDashboardSummary: () => ({
+    data: {
+      totalDistanceKm: 12,
+      totalCo2SavedKg: 3,
+      totalMoneySavedEur: 4,
+      totalFuelSavedL: 1,
+      tripCount: 1,
+      currentStreak: 1,
+      longestStreak: 1,
+    },
+    isPending: false,
+  }),
+  useTrips: () => ({
+    data: {
+      trips: [
+        {
+          id: "trip-1",
+          userId: "user-1",
+          distanceKm: 8.4,
+          durationSec: 1500,
+          co2SavedKg: 1.2,
+          moneySavedEur: 2.1,
+          fuelSavedL: 0.5,
+          fuelPriceEur: 1.8,
+          startedAt: "2026-04-08T07:00:00.000Z",
+          endedAt: "2026-04-08T07:25:00.000Z",
+          gpsPoints: null,
+        },
+      ],
+      pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    },
+    isPending: false,
+  }),
+  useTrip: () => ({ data: null }),
+  useChartTrips: () => ({ data: [], isPending: false }),
+  useAchievements: () => ({ data: [], isPending: false }),
+  useDeleteTrip: () => ({ mutate: deleteTripMutate, isPending: false }),
+  useCreateTripPresetFromTrip: () => ({
+    mutate: createTripPresetFromTripMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/trip-utils", () => ({
+  tripLabel: () => "Trajet domicile-travail",
+}));
+
+vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => false }));
+vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));
+
+describe("StatsPage preset creation flow", () => {
+  beforeEach(() => {
+    createTripPresetFromTripMutate.mockReset();
+    deleteTripMutate.mockReset();
+  });
+
+  it("opens an inline form and creates a preset without relying on window.prompt", async () => {
+    render(<StatsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Trajet domicile-travail/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Détail du trajet" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Créer un trajet pré-enregistré" }));
+
+    const input = screen.getByLabelText("Nom du trajet pré-enregistré") as HTMLInputElement;
+    expect(input.value).toBe("domicile-travail");
+
+    fireEvent.change(input, { target: { value: "Maison → Bureau" } });
+    fireEvent.click(screen.getByRole("button", { name: "Enregistrer" }));
+
+    expect(createTripPresetFromTripMutate).toHaveBeenCalledWith(
+      {
+        tripId: "trip-1",
+        label: "Maison → Bureau",
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the fragile `window.prompt()` preset creation flow in Stats with an inline form inside the trip detail sheet
- prefill the suggested label and show clear save/cancel actions so preset creation works reliably on mobile/PWA
- add a regression test covering preset creation from Stats

## Testing
- bun --cwd client test src/pages/__tests__/StatsPage.preset.test.tsx src/pages/__tests__/TripPage.preset.test.tsx src/pages/__tests__/ProfilePage.preset.test.tsx
- bun run typecheck