### PR TITLE
feat: compact bike control row + fix iOS overscroll

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -39,6 +39,7 @@ html,
 body {
   height: 100%;
   margin: 0;
+  overflow: hidden;
 }
 
 #root {

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -552,9 +552,16 @@ export function ProfilePage() {
 
             <div className="mx-4 h-px bg-white/5" />
 
-            {/* Super73 BLE — toggle + guided pairing */}
+            {/* Super73 BLE — toggle + navigate to /vehicle */}
             <div className="flex w-full items-center justify-between p-4">
-              <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => {
+                  if (user?.super73Enabled) navigate("/vehicle");
+                }}
+                disabled={!user?.super73Enabled}
+                className="flex min-w-0 items-center gap-4 text-left"
+              >
                 <Bluetooth
                   size={20}
                   className={user?.super73Enabled ? "text-primary-light" : "text-text-muted"}
@@ -566,7 +573,10 @@ export function ProfilePage() {
                   )}
                   {user?.super73Enabled && <span className="text-xs text-primary/70">Activé</span>}
                 </div>
-              </div>
+                {user?.super73Enabled && (
+                  <ChevronRight size={18} className="shrink-0 text-text-dim" />
+                )}
+              </button>
               <button
                 onClick={async () => {
                   if (user?.super73Enabled) {
@@ -629,18 +639,6 @@ export function ProfilePage() {
                   </div>
                   <ChevronRight size={18} className="shrink-0 text-text-dim" />
                 </button>
-
-                <div className="mx-4 h-px bg-white/5" />
-                <Link
-                  to="/vehicle"
-                  className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
-                >
-                  <div className="flex items-center gap-4">
-                    <Bike size={20} className="text-primary-light" />
-                    <span className="text-sm font-medium">Contrôle du vélo</span>
-                  </div>
-                  <ChevronRight size={18} className="text-text-dim" />
-                </Link>
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Clicking body of "Vélo connecté" now navigates to /vehicle (toggle stays for on/off)
- Removes separate "Contrôle du vélo" link row
- Fixes iOS overscroll allowing header to slide behind status bar

## Test plan
- [ ] Profile page: tap "Vélo connecté" label → navigates to /vehicle
- [ ] Profile page: tap toggle → enables/disables BLE mode
- [ ] iOS: header no longer scrolls behind status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)