### PR TITLE
chore: add missing DB indexes

### DIFF
--- a/server/src/db/schema/announcements.ts
+++ b/server/src/db/schema/announcements.ts
@@ -1,14 +1,18 @@
-import { pgTable, text, timestamp, uuid, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, uuid, boolean, index } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const announcements = pgTable("announcements", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  adminId: text("admin_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  title: text("title").notNull(),
-  body: text("body").notNull(),
-  url: text("url"),
-  active: boolean("active").notNull().default(true),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const announcements = pgTable(
+  "announcements",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    adminId: text("admin_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    url: text("url"),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("announcements_active_idx").on(table.active)],
+);

--- a/server/src/db/schema/audit-log.ts
+++ b/server/src/db/schema/audit-log.ts
@@ -1,13 +1,17 @@
-import { pgTable, text, timestamp, jsonb, uuid } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, jsonb, uuid, index } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const auditLogs = pgTable("audit_logs", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  action: text("action").notNull(),
-  target: text("target"),
-  metadata: jsonb("metadata"),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const auditLogs = pgTable(
+  "audit_logs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    action: text("action").notNull(),
+    target: text("target"),
+    metadata: jsonb("metadata"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("audit_logs_user_id_idx").on(table.userId)],
+);

--- a/server/src/db/schema/notification-logs.ts
+++ b/server/src/db/schema/notification-logs.ts
@@ -1,16 +1,20 @@
-import { pgTable, text, timestamp, jsonb, uuid, integer } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, jsonb, uuid, integer, index } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
-export const notificationLogs = pgTable("notification_logs", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  adminId: text("admin_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  title: text("title").notNull(),
-  body: text("body").notNull(),
-  url: text("url"),
-  targetUserIds: jsonb("target_user_ids").$type<string[] | null>(),
-  sentCount: integer("sent_count").notNull().default(0),
-  failedCount: integer("failed_count").notNull().default(0),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const notificationLogs = pgTable(
+  "notification_logs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    adminId: text("admin_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    url: text("url"),
+    targetUserIds: jsonb("target_user_ids").$type<string[] | null>(),
+    sentCount: integer("sent_count").notNull().default(0),
+    failedCount: integer("failed_count").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index("notification_logs_created_at_idx").on(table.createdAt)],
+);


### PR DESCRIPTION
## Summary
- Add index on `audit_logs.user_id` (filtered in admin queries)
- Add index on `announcements.active` (filtered in active announcement lookup)
- Add index on `notification_logs.created_at` (ordered in admin notification history)

## Test plan
- [x] `bun run --filter server typecheck` passes
- [x] `bun run --filter server test` passes (240/240)
- Additive-only schema change; no data loss risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)