### PR TITLE
fix: drain offline trip queue after in-session enqueues (#231)

### DIFF
--- a/client/src/hooks/__tests__/useOfflineSync.test.tsx
+++ b/client/src/hooks/__tests__/useOfflineSync.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/lib/api", async () => {
 });
 
 vi.mock("@/lib/offline-queue", () => ({
+  QUEUE_CHANGED_EVENT: "ecoride:queue-changed",
   getPendingTrips: () => getPendingTripsMock(),
   removePendingTrip: (index: number) => removePendingTripMock(index),
   recordRejectedTrip: (trip: unknown, meta: unknown) => recordRejectedTripMock(trip, meta),
@@ -68,6 +69,49 @@ describe("useOfflineSync", () => {
       reason: "Trajet rejeté : chevauchement avec un trajet déjà enregistré.",
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it("syncs trips that are queued after mount while the user stays online", async () => {
+    // Regression test for GitHub #231: trips recorded while the app is already
+    // open (e.g. a GPS trip that falls back to the offline queue because of a
+    // transient failure) must be synced without requiring a full page reload
+    // or an offline → online transition.
+    const pendingTrip = {
+      distanceKm: 4.2,
+      durationSec: 900,
+      startedAt: "2026-04-09T10:00:00.000Z",
+      endedAt: "2026-04-09T10:15:00.000Z",
+      gpsPoints: [
+        { lat: 48.8566, lng: 2.3522, ts: 1744200000000 },
+        { lat: 48.857, lng: 2.353, ts: 1744200010000 },
+      ],
+      idempotencyKey: "33333333-3333-3333-3333-333333333333",
+    };
+
+    // On mount the queue is empty — nothing should sync yet.
+    getPendingTripsMock.mockReturnValue([]);
+    mockApiFetch.mockResolvedValue({ ok: true, data: { trip: { id: "trip-1" } } });
+
+    renderOfflineSync();
+
+    // User is still online — no offline/online transition will happen. The
+    // initial mount fires syncPending() once and finds an empty queue.
+    await waitFor(() => {
+      expect(getPendingTripsMock).toHaveBeenCalled();
+    });
+    expect(mockApiFetch).not.toHaveBeenCalled();
+
+    // Now a trip gets enqueued (e.g. TripPage handleSaveTrip onError path).
+    getPendingTripsMock.mockReturnValue([pendingTrip]);
+    window.dispatchEvent(new Event("ecoride:queue-changed"));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/trips",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(removePendingTripMock).toHaveBeenCalledWith(0);
   });
 
   it("keeps retryable sync failures in the pending queue", async () => {

--- a/client/src/hooks/useOfflineSync.ts
+++ b/client/src/hooks/useOfflineSync.ts
@@ -1,7 +1,12 @@
 import { useEffect, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { ApiError, apiFetch } from "@/lib/api";
-import { getPendingTrips, recordRejectedTrip, removePendingTrip } from "@/lib/offline-queue";
+import {
+  QUEUE_CHANGED_EVENT,
+  getPendingTrips,
+  recordRejectedTrip,
+  removePendingTrip,
+} from "@/lib/offline-queue";
 import type { Trip } from "@ecoride/shared/types";
 
 function isTerminalTripSyncError(error: unknown): error is ApiError {
@@ -57,9 +62,24 @@ export function useOfflineSync() {
     // Try on mount
     syncPending();
 
-    // Try when coming back online
-    const handleOnline = () => syncPending();
-    window.addEventListener("online", handleOnline);
-    return () => window.removeEventListener("online", handleOnline);
+    // Retry whenever something could have unblocked the queue:
+    //   - the browser reports we are back online
+    //   - a new trip was enqueued by handleSaveTrip onError (issue #231 — in
+    //     a running PWA the AppShell never remounts, so without this event
+    //     the queue would sit idle until the next offline → online flip)
+    //   - the PWA comes back to the foreground (tab switch / app resume)
+    const retry = () => syncPending();
+    window.addEventListener("online", retry);
+    window.addEventListener(QUEUE_CHANGED_EVENT, retry);
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") syncPending();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      window.removeEventListener("online", retry);
+      window.removeEventListener(QUEUE_CHANGED_EVENT, retry);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, [syncPending]);
 }

--- a/client/src/lib/offline-queue.ts
+++ b/client/src/lib/offline-queue.ts
@@ -3,6 +3,17 @@ import type { CreateTripRequest } from "@ecoride/shared/api-contracts";
 const STORAGE_KEY = "ecoride-pending-trips";
 const REJECTED_STORAGE_KEY = "ecoride-rejected-trips";
 
+export const QUEUE_CHANGED_EVENT = "ecoride:queue-changed";
+
+function notifyQueueChanged(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new Event(QUEUE_CHANGED_EVENT));
+  } catch {
+    // Event constructor unavailable (very old environments) — no-op.
+  }
+}
+
 export interface RejectedTripRecord {
   trip: CreateTripRequest;
   rejectedAt: string;
@@ -40,6 +51,7 @@ export function queueTrip(data: CreateTripRequest): void {
   const key = crypto.randomUUID();
   pending.push({ ...data, idempotencyKey: key });
   writeQueue(STORAGE_KEY, pending);
+  notifyQueueChanged();
 }
 
 export function getPendingTrips(): CreateTripRequest[] {


### PR DESCRIPTION
## Summary
- `useOfflineSync` only fired `syncPending` at AppShell mount and on `online`, so a trip queued while the PWA stayed open and online would never be retried — the user's stuck "1 trajet en attente" banner (manual trips looked fine because their POST succeeds directly and never enters the queue).
- `queueTrip` now dispatches `ecoride:queue-changed`, and `useOfflineSync` also retries on that event and on `visibilitychange` (PWA resume).
- Added a regression test that enqueues a GPS trip after mount and asserts the sync fires without an offline → online flip.

Closes #231

## Test plan
- [x] `bun run typecheck` (client)
- [x] `bun run test` (client) — 152/152 passing, including the new `useOfflineSync` regression test
- [ ] Manual: reproduce on the PWA — queue a trip while online, confirm it syncs without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)