### PR TITLE
fix: block saving empty trip in UI

### DIFF
--- a/client/src/components/trip/InterruptMenu.tsx
+++ b/client/src/components/trip/InterruptMenu.tsx
@@ -5,9 +5,16 @@ export interface InterruptMenuProps {
   onStop: () => void;
   onAbandon: () => void;
   onClose: () => void;
+  canStop: boolean;
 }
 
-export function InterruptMenu({ onResume, onStop, onAbandon, onClose }: InterruptMenuProps) {
+export function InterruptMenu({
+  onResume,
+  onStop,
+  onAbandon,
+  onClose,
+  canStop,
+}: InterruptMenuProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-end bg-black/50 px-6 pb-6" data-no-swipe>
       <div
@@ -43,7 +50,9 @@ export function InterruptMenu({ onResume, onStop, onAbandon, onClose }: Interrup
           </button>
           <button
             onClick={onStop}
-            className="flex w-full items-center justify-center gap-3 rounded-2xl bg-surface-high py-4 text-base font-bold text-text active:scale-95"
+            disabled={!canStop}
+            title={canStop ? undefined : "Distance trop courte pour enregistrer"}
+            className="flex w-full items-center justify-center gap-3 rounded-2xl bg-surface-high py-4 text-base font-bold text-text active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Square size={18} fill="currentColor" />
             Terminer

--- a/client/src/components/trip/StoppedSummary.tsx
+++ b/client/src/components/trip/StoppedSummary.tsx
@@ -51,12 +51,18 @@ export function StoppedSummary({
           </button>
           <button
             onClick={onSave}
-            disabled={isSaving}
-            className="flex-1 rounded-xl bg-primary py-4 text-sm font-black uppercase tracking-widest text-bg active:scale-95 disabled:opacity-50"
+            disabled={isSaving || distance < 0.01}
+            title={distance < 0.01 ? "Distance trop courte pour enregistrer" : undefined}
+            className="flex-1 rounded-xl bg-primary py-4 text-sm font-black uppercase tracking-widest text-bg active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSaving ? "..." : "Enregistrer"}
           </button>
         </div>
+        {distance < 0.01 && (
+          <p className="mt-3 text-center text-xs text-text-muted">
+            Trajet trop court pour être enregistré. Utilisez Abandonner.
+          </p>
+        )}
         {sessionPersistFailed && (
           <div className="mt-4 rounded-xl bg-danger/10 p-4">
             <div className="flex items-center gap-3">

--- a/client/src/components/trip/__tests__/InterruptMenu.test.tsx
+++ b/client/src/components/trip/__tests__/InterruptMenu.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InterruptMenu } from "../InterruptMenu";
+
+describe("InterruptMenu", () => {
+  const baseProps = {
+    onResume: vi.fn(),
+    onStop: vi.fn(),
+    onAbandon: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  it("disables Terminer when canStop is false", () => {
+    render(<InterruptMenu {...baseProps} canStop={false} />);
+    const btn = screen.getByRole("button", { name: "Terminer" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("enables Terminer when canStop is true", () => {
+    render(<InterruptMenu {...baseProps} canStop={true} />);
+    const btn = screen.getByRole("button", { name: "Terminer" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+});

--- a/client/src/components/trip/__tests__/StoppedSummary.test.tsx
+++ b/client/src/components/trip/__tests__/StoppedSummary.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StoppedSummary } from "../StoppedSummary";
+
+describe("StoppedSummary", () => {
+  const baseProps = {
+    co2Saved: 0,
+    elapsed: 0,
+    formatTime: (s: number) => `${s}s`,
+    onAbandon: vi.fn(),
+    onSave: vi.fn(),
+    isSaving: false,
+    sessionPersistFailed: false,
+    saveError: "",
+  };
+
+  it("disables Enregistrer when distance is zero", () => {
+    render(<StoppedSummary {...baseProps} distance={0} />);
+    const btn = screen.getByRole("button", { name: /Enregistrer/ }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(screen.getByText(/trop court/i)).toBeTruthy();
+  });
+
+  it("disables Enregistrer when distance is below 0.01 km", () => {
+    render(<StoppedSummary {...baseProps} distance={0.005} />);
+    const btn = screen.getByRole("button", { name: /Enregistrer/ }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("enables Enregistrer when distance is at threshold", () => {
+    render(<StoppedSummary {...baseProps} distance={0.01} />);
+    const btn = screen.getByRole("button", { name: /Enregistrer/ }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+});

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -540,6 +540,7 @@ export function TripPage() {
               onStop={handleStopFromInterrupt}
               onAbandon={handleAbandonFromInterrupt}
               onClose={() => setInterruptMenuOpen(false)}
+              canStop={distance >= 0.01}
             />
           )}
         </>


### PR DESCRIPTION
## Summary
- Saving a 0 km trip triggered `POST /api/trips` → 400 `VALIDATION_ERROR` (`distanceKm: Number must be greater than 0`). Better UX: prevent the save in the UI.
- `InterruptMenu` "Terminer" now disabled when `distance < 0.01` km; users must pick "Abandonner".
- `StoppedSummary` "Enregistrer" same guard + helper text explaining why.
- `ManualEntryForm` already blocked `≤0`, untouched.

## Test plan
- [x] `bunx vitest run src/components/trip/__tests__/InterruptMenu.test.tsx src/components/trip/__tests__/StoppedSummary.test.tsx` → 5/5 pass
- [x] `bun run typecheck` clean
- [ ] Manual: start tracking, immediately interrupt (0 km) → "Terminer" grayed out, "Abandonner" works
- [ ] Manual: start tracking, walk ~20 m, stop → "Enregistrer" enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)