### PR TITLE
fix: retry map follow when style not yet loaded (#234)

### DIFF
--- a/client/e2e/tracking-marker-anchor.spec.ts
+++ b/client/e2e/tracking-marker-anchor.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+
+// Regression test for #234: during an active trip, the rider arrow must stay
+// horizontally centered in the tracking map and anchored toward the bottom
+// (camera padding: top=200, bottom=0). We simulate several GPS updates to
+// exercise the useMapCamera throttle/trailing-edge/retry paths.
+//
+// Headless Chromium has no hardware WebGL by default, so we force software
+// WebGL (swiftshader) just for this test — otherwise the app falls back to
+// MapNoWebGL and there is no maplibregl marker to inspect.
+test.use({
+  launchOptions: {
+    args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader"],
+  },
+});
+
+test("rider arrow stays horizontally centered and anchored toward the bottom during tracking", async ({
+  page,
+}) => {
+  // Path of 6 positions heading east along Paris.
+  await page.addInitScript(() => {
+    const path = [
+      { lat: 48.8566, lng: 2.3522 },
+      { lat: 48.8566, lng: 2.3532 },
+      { lat: 48.8566, lng: 2.3542 },
+      { lat: 48.8566, lng: 2.3552 },
+      { lat: 48.8566, lng: 2.3562 },
+      { lat: 48.8566, lng: 2.3572 },
+    ];
+
+    const makePos = (i: number): GeolocationPosition =>
+      ({
+        coords: {
+          latitude: path[i]!.lat,
+          longitude: path[i]!.lng,
+          accuracy: 5,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: 90,
+          speed: 5,
+        },
+        timestamp: Date.now(),
+        toJSON() {
+          return this;
+        },
+      }) as unknown as GeolocationPosition;
+
+    let watchId = 0;
+    Object.defineProperty(navigator, "geolocation", {
+      value: {
+        watchPosition: (success: PositionCallback) => {
+          const id = ++watchId;
+          path.forEach((_, i) => {
+            setTimeout(() => success(makePos(i)), 200 + i * 400);
+          });
+          return id;
+        },
+        clearWatch: () => {},
+        getCurrentPosition: (success: PositionCallback) => {
+          setTimeout(() => success(makePos(0)), 50);
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  await page.route("**/api/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  await page.getByText("Démarrer").click();
+  await expect(page.getByText("Interrompre")).toBeVisible({ timeout: 5000 });
+
+  const mapContainer = page.locator('[data-testid="tracking-map"]');
+  await expect(mapContainer).toBeVisible({ timeout: 5000 });
+
+  // Give the mocked GPS updates time to drain through the throttle window
+  // plus the flyTo animation (400ms).
+  await page.waitForTimeout(3500);
+
+  const mapBox = await mapContainer.boundingBox();
+  expect(mapBox).not.toBeNull();
+
+  const marker = page.locator(".maplibregl-marker").first();
+  await expect(marker).toBeVisible({ timeout: 3000 });
+  const markerBox = await marker.boundingBox();
+  expect(markerBox).not.toBeNull();
+
+  const mapCenterX = mapBox!.x + mapBox!.width / 2;
+  const mapCenterY = mapBox!.y + mapBox!.height / 2;
+  const markerCenterX = markerBox!.x + markerBox!.width / 2;
+  const markerCenterY = markerBox!.y + markerBox!.height / 2;
+
+  // Horizontal: marker must sit within 15px of the map's horizontal center.
+  expect(Math.abs(markerCenterX - mapCenterX)).toBeLessThan(15);
+
+  // Vertical: padding top=200 / bottom=0 pushes the camera anchor into the
+  // lower half of the map. Marker must be strictly below geometric center.
+  expect(markerCenterY).toBeGreaterThan(mapCenterY);
+
+  // And not too close to the very bottom edge (still inside the visible area).
+  expect(markerCenterY).toBeLessThan(mapBox!.y + mapBox!.height - 20);
+});

--- a/client/src/hooks/__tests__/useMapCamera.test.tsx
+++ b/client/src/hooks/__tests__/useMapCamera.test.tsx
@@ -26,6 +26,30 @@ describe("useMapCamera", () => {
     vi.restoreAllMocks();
   });
 
+  it("retries flyTo when style is not yet loaded instead of silently dropping the update", () => {
+    const flyTo = vi.fn();
+    let styleLoaded = false;
+    const mapRef = createRef<MapRef | null>();
+    mapRef.current = {
+      flyTo,
+      isStyleLoaded: () => styleLoaded,
+    } as unknown as MapRef;
+
+    render(<CameraHarness mapRef={mapRef} position={[48.8566, 2.3522]} />);
+
+    // Style not ready yet — flyTo must not have fired, but a retry should be pending.
+    expect(flyTo).not.toHaveBeenCalled();
+
+    // Style finishes loading after a short delay. The pending retry must catch it.
+    styleLoaded = true;
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(flyTo).toHaveBeenCalledTimes(1);
+    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3522, 48.8566] }));
+  });
+
   it("replays the latest position after the throttle window instead of dropping it", () => {
     const flyTo = vi.fn();
     const mapRef = createRef<MapRef | null>();

--- a/client/src/hooks/useMapCamera.ts
+++ b/client/src/hooks/useMapCamera.ts
@@ -44,12 +44,17 @@ export function useMapCamera(
       return;
     }
 
-    const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return; // map or style not ready; onLoad will replay
-
     const flyCamera = () => {
       const nextMap = mapRef.current;
-      if (!nextMap || !nextMap.isStyleLoaded()) return;
+      if (!nextMap) {
+        // Map unmounted while retry was pending — bail. Next render replays.
+        return;
+      }
+      if (!nextMap.isStyleLoaded()) {
+        // Style still loading (or reloading): retry soon instead of dropping.
+        retryTimerRef.current = setTimeout(flyCamera, 100);
+        return;
+      }
       flyToRef.current = Date.now();
       nextMap.flyTo({
         center: [position[1], position[0]],
@@ -61,18 +66,17 @@ export function useMapCamera(
       });
     };
 
+    clearRetryTimer();
+
     const remaining = 500 - (Date.now() - flyToRef.current);
     if (remaining <= 0) {
-      clearRetryTimer();
       flyCamera();
-      return;
+    } else {
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
+        flyCamera();
+      }, remaining);
     }
-
-    clearRetryTimer();
-    retryTimerRef.current = setTimeout(() => {
-      retryTimerRef.current = null;
-      flyCamera();
-    }, remaining);
 
     return clearRetryTimer;
     // flyToRef is a ref (stable) — mapLoadSeq is intentionally listed


### PR DESCRIPTION
## Summary
- Fixes #234 — tracking map no longer follows the rider arrow.
- `useMapCamera` dropped updates whenever `map.isStyleLoaded()` reported false, relying only on `onLoad` (fires once) to replay. If the style briefly reported unloaded during a trailing-edge retry, the camera stuck until the next GPS tick — and if the rider was stationary, it never recovered.
- Now we schedule a short (100ms) retry inside `flyCamera` when the style isn't ready, so the pending update replays as soon as the style finishes loading.

## Test plan
- [x] New vitest regression `useMapCamera > retries flyTo when style is not yet loaded` — fails on the old implementation, passes on the new one.
- [x] Existing `useMapCamera` throttle/trailing-edge test still passes.
- [ ] Manual: start a tracking session, drag the map, confirm camera re-locks on the next GPS tick and stays locked to the arrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)