### PR TITLE
feat: add trip data import to mirror export

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -543,6 +543,42 @@ export function useExportData() {
   });
 }
 
+export function useImportData() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const text = await file.text();
+      let payload: unknown;
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        throw new Error("Fichier JSON invalide");
+      }
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        !Array.isArray((payload as { trips?: unknown }).trips)
+      ) {
+        throw new Error("Format d'export non reconnu");
+      }
+      return apiFetch<{
+        ok: boolean;
+        data: { imported: number; skipped: number };
+      }>("/user/import", {
+        method: "POST",
+        body: JSON.stringify({ trips: (payload as { trips: unknown[] }).trips }),
+      }).then((r) => r.data);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["profile"] });
+      qc.invalidateQueries({ queryKey: ["trips"] });
+      qc.invalidateQueries({ queryKey: ["achievements"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["leaderboard"] });
+    },
+  });
+}
+
 export function useSubmitFeedback() {
   return useMutation({
     mutationFn: (data: { type: "bug" | "feature"; title: string; description: string }) =>

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate, Link } from "react-router";
 import {
   User as UserIcon,
@@ -12,6 +12,7 @@ import {
   Check,
   Droplets,
   Download,
+  Upload,
   Trash2,
   Shield,
   MessageSquarePlus,
@@ -28,6 +29,7 @@ import {
   useDeleteAccount,
   useDeleteTripPreset,
   useExportData,
+  useImportData,
   useSubmitFeedback,
 } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
@@ -48,7 +50,9 @@ export function ProfilePage() {
   const deleteAccount = useDeleteAccount();
   const deleteTripPreset = useDeleteTripPreset();
   const exportData = useExportData();
+  const importData = useImportData();
   const submitFeedback = useSubmitFeedback();
+  const importFileRef = useRef<HTMLInputElement>(null);
 
   const userFuelType = profileData?.user?.fuelType ?? "sp95";
   const { data: fuelPrice, isPending: fuelPriceLoading } = useFuelPrice(userFuelType);
@@ -126,6 +130,30 @@ export function ProfilePage() {
 
   const handleExportData = () => {
     exportData.mutate();
+  };
+
+  const handleImportClick = () => {
+    importFileRef.current?.click();
+  };
+
+  const handleImportFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    const confirmed = window.confirm(
+      "Importer les trajets depuis ce fichier ? Les valeurs historiques (CO₂, €, carburant) seront conservées telles quelles. Les doublons sont ignorés.",
+    );
+    if (!confirmed) return;
+    importData.mutate(file, {
+      onSuccess: (data) => {
+        window.alert(
+          `Import terminé : ${data.imported} trajet(s) importé(s), ${data.skipped} doublon(s) ignoré(s).`,
+        );
+      },
+      onError: (err) => {
+        window.alert(`Échec de l'import : ${err instanceof Error ? err.message : String(err)}`);
+      },
+    });
   };
 
   const handleDeleteTripPreset = (tripPresetId: string, label: string) => {
@@ -704,6 +732,24 @@ export function ProfilePage() {
             <div className="flex items-center justify-center gap-2">
               <Download size={16} />
               {exportData.isPending ? "Export en cours..." : "Exporter mes données"}
+            </div>
+          </button>
+
+          <input
+            ref={importFileRef}
+            type="file"
+            accept="application/json,.json"
+            onChange={handleImportFile}
+            className="hidden"
+          />
+          <button
+            onClick={handleImportClick}
+            disabled={importData.isPending}
+            className="mt-4 w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Upload size={16} />
+              {importData.isPending ? "Import en cours..." : "Importer mes données"}
             </div>
           </button>
 

--- a/client/src/pages/__tests__/ProfilePage.preset.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.preset.test.tsx
@@ -71,6 +71,7 @@ vi.mock("@/hooks/queries", () => ({
   useDeleteAccount: () => ({ mutate: vi.fn(), isPending: false }),
   useDeleteTripPreset: () => ({ mutate: deleteTripPresetMock, isPending: false }),
   useExportData: () => ({ mutate: vi.fn(), isPending: false }),
+  useImportData: () => ({ mutate: vi.fn(), isPending: false }),
   useSubmitFeedback: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
 }));
 

--- a/client/src/pages/__tests__/ProfilePage.super73-settings.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.super73-settings.test.tsx
@@ -57,6 +57,7 @@ vi.mock("@/hooks/queries", () => ({
   useDeleteAccount: () => ({ mutate: vi.fn(), isPending: false }),
   useDeleteTripPreset: () => ({ mutate: vi.fn(), isPending: false }),
   useExportData: () => ({ mutate: vi.fn(), isPending: false }),
+  useImportData: () => ({ mutate: vi.fn(), isPending: false }),
   useSubmitFeedback: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
 }));
 

--- a/server/src/routes/__tests__/users-import.test.ts
+++ b/server/src/routes/__tests__/users-import.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../../types/context";
+
+const mocks = vi.hoisted(() => {
+  const selectWhere = vi.fn();
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const evaluateAndUnlockBadges = vi.fn().mockResolvedValue([]);
+  const logAudit = vi.fn();
+  const withContext = vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }));
+
+  return {
+    select,
+    selectFrom,
+    selectWhere,
+    insert,
+    insertValues,
+    evaluateAndUnlockBadges,
+    logAudit,
+    withContext,
+  };
+});
+
+vi.mock("../../db", () => ({
+  db: {
+    select: mocks.select,
+    insert: mocks.insert,
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../../db/schema", () => ({
+  trips: {
+    userId: {},
+    startedAt: {},
+    distanceKm: {},
+    co2SavedKg: {},
+    moneySavedEur: {},
+    fuelSavedL: {},
+  },
+  achievements: { userId: {} },
+}));
+
+vi.mock("../../db/schema/auth", () => ({
+  user: { id: {}, updatedAt: {} },
+}));
+
+vi.mock("../../lib/badges", () => ({
+  evaluateAndUnlockBadges: mocks.evaluateAndUnlockBadges,
+}));
+
+vi.mock("../../lib/audit", () => ({
+  logAudit: (...args: unknown[]) => mocks.logAudit(...args),
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: mocks.withContext,
+  },
+}));
+
+import { usersRouter } from "../users.routes";
+
+function buildApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", { id: "user-1" } as AuthEnv["Variables"]["user"]);
+    await next();
+  });
+  app.route("/user", usersRouter);
+  return app;
+}
+
+function sampleTrip(overrides: Record<string, unknown> = {}) {
+  return {
+    distanceKm: 12.345,
+    durationSec: 1800,
+    co2SavedKg: 1.617,
+    moneySavedEur: 2.34,
+    fuelSavedL: 0.7,
+    fuelPriceEur: 1.82,
+    startedAt: "2026-01-01T10:00:00.000Z",
+    endedAt: "2026-01-01T10:30:00.000Z",
+    gpsPoints: null,
+    idempotencyKey: null,
+    ...overrides,
+  };
+}
+
+describe("POST /user/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValue([]);
+  });
+
+  it("preserves historical co2/money/fuel values as-is (no recalculation)", async () => {
+    const res = await buildApp().request("/user/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trips: [sampleTrip()] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { imported: number; skipped: number } };
+    expect(body.data).toEqual({ imported: 1, skipped: 0 });
+
+    expect(mocks.insertValues).toHaveBeenCalledTimes(1);
+    const inserted = mocks.insertValues.mock.calls[0]![0][0];
+    expect(inserted).toMatchObject({
+      userId: "user-1",
+      distanceKm: 12.345,
+      durationSec: 1800,
+      co2SavedKg: 1.617,
+      moneySavedEur: 2.34,
+      fuelSavedL: 0.7,
+      fuelPriceEur: 1.82,
+    });
+    expect(inserted.startedAt).toBeInstanceOf(Date);
+    expect(inserted.startedAt.toISOString()).toBe("2026-01-01T10:00:00.000Z");
+  });
+
+  it("skips trips whose startedAt already exists for this user", async () => {
+    mocks.selectWhere.mockResolvedValueOnce([{ startedAt: new Date("2026-01-01T10:00:00.000Z") }]);
+
+    const res = await buildApp().request("/user/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        trips: [
+          sampleTrip(),
+          sampleTrip({
+            startedAt: "2026-01-02T10:00:00.000Z",
+            endedAt: "2026-01-02T10:30:00.000Z",
+          }),
+        ],
+      }),
+    });
+
+    const body = (await res.json()) as { data: { imported: number; skipped: number } };
+    expect(body.data).toEqual({ imported: 1, skipped: 1 });
+    expect(mocks.insertValues).toHaveBeenCalledTimes(1);
+    const inserted = mocks.insertValues.mock.calls[0]![0];
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].startedAt.toISOString()).toBe("2026-01-02T10:00:00.000Z");
+  });
+
+  it("rejects invalid payloads (missing required field)", async () => {
+    const res = await buildApp().request("/user/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        trips: [{ ...sampleTrip(), distanceKm: undefined }],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("handles an empty trips array without hitting the DB", async () => {
+    const res = await buildApp().request("/user/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trips: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { imported: number; skipped: number } };
+    expect(body.data).toEqual({ imported: 0, skipped: 0 });
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.evaluateAndUnlockBadges).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/users.routes.ts
+++ b/server/src/routes/users.routes.ts
@@ -1,13 +1,17 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { eq, sum, count } from "drizzle-orm";
+import { and, eq, sum, count, inArray } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { trips, achievements } from "../db/schema";
 import { updateUserSchema } from "../validators/users";
+import { importDataSchema } from "../validators/trips";
 import { validationHook } from "../lib/validation";
 import { forbidden } from "../lib/errors";
 import { logAudit } from "../lib/audit";
+import { evaluateAndUnlockBadges } from "../lib/badges";
+import { reportBackgroundError } from "../lib/background";
+import { logger } from "../lib/logger";
 import type { AuthEnv } from "../types/context";
 
 const usersRouter = new Hono<AuthEnv>();
@@ -94,6 +98,68 @@ usersRouter.get("/export", async (c) => {
   c.header("Content-Disposition", 'attachment; filename="ecoride-data-export.json"');
   c.header("Content-Type", "application/json");
   return c.json(exportData);
+});
+
+// POST /api/user/import — Restore exported trips (preserves historical values)
+usersRouter.post("/import", zValidator("json", importDataSchema, validationHook), async (c) => {
+  const currentUser = c.get("user");
+  const { trips: incoming } = c.req.valid("json");
+
+  if (incoming.length === 0) {
+    return c.json({ ok: true, data: { imported: 0, skipped: 0 } });
+  }
+
+  // Dedupe against existing trips by startedAt timestamp for this user.
+  const incomingStarts = incoming.map((t) => new Date(t.startedAt));
+  const existing = await db
+    .select({ startedAt: trips.startedAt })
+    .from(trips)
+    .where(and(eq(trips.userId, currentUser.id), inArray(trips.startedAt, incomingStarts)));
+
+  const existingSet = new Set(existing.map((r) => r.startedAt.getTime()));
+
+  const toInsert = incoming
+    .filter((t) => !existingSet.has(new Date(t.startedAt).getTime()))
+    .map((t) => ({
+      userId: currentUser.id,
+      distanceKm: t.distanceKm,
+      durationSec: t.durationSec,
+      co2SavedKg: t.co2SavedKg,
+      moneySavedEur: t.moneySavedEur,
+      fuelSavedL: t.fuelSavedL,
+      fuelPriceEur: t.fuelPriceEur ?? null,
+      startedAt: new Date(t.startedAt),
+      endedAt: new Date(t.endedAt),
+      gpsPoints: t.gpsPoints ?? null,
+      idempotencyKey: t.idempotencyKey ?? null,
+    }));
+
+  if (toInsert.length > 0) {
+    await db.insert(trips).values(toInsert);
+  }
+
+  // Re-evaluate badges since trip aggregates changed. Fire-and-forget so the
+  // import response is fast; badge engine is idempotent.
+  const requestLogger = logger.withContext(
+    c.get("requestId") as string | undefined,
+    currentUser.id,
+  );
+  reportBackgroundError(
+    evaluateAndUnlockBadges(currentUser.id),
+    requestLogger,
+    "import_badges_failed",
+    { imported: toInsert.length },
+  );
+
+  logAudit(currentUser.id, "data_import", undefined, {
+    imported: toInsert.length,
+    skipped: incoming.length - toInsert.length,
+  });
+
+  return c.json({
+    ok: true,
+    data: { imported: toInsert.length, skipped: incoming.length - toInsert.length },
+  });
 });
 
 // DELETE /api/user/profile — Delete account (GDPR right to erasure)

--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -32,3 +32,28 @@ export const createTripSchema = z
   });
 
 export type CreateTripInput = z.infer<typeof createTripSchema>;
+
+const importTripSchema = z
+  .object({
+    distanceKm: z.number().positive().max(500),
+    durationSec: z.number().int().min(1).max(86400),
+    co2SavedKg: z.number().nonnegative(),
+    moneySavedEur: z.number().nonnegative(),
+    fuelSavedL: z.number().nonnegative(),
+    fuelPriceEur: z.number().positive().nullable().optional(),
+    startedAt: z.string().datetime(),
+    endedAt: z.string().datetime(),
+    gpsPoints: z.array(gpsPointSchema).max(10000).nullable().optional(),
+    idempotencyKey: z.string().nullable().optional(),
+  })
+  .refine((data) => new Date(data.startedAt) < new Date(data.endedAt), {
+    message: "startedAt must be before endedAt",
+    path: ["startedAt"],
+  });
+
+export const importDataSchema = z.object({
+  trips: z.array(importTripSchema).max(5000),
+});
+
+export type ImportTripInput = z.infer<typeof importTripSchema>;
+export type ImportDataInput = z.infer<typeof importDataSchema>;


### PR DESCRIPTION
## Summary
- New `POST /api/user/import` endpoint that accepts an exported JSON and restores trips with their historical co2/money/fuel values preserved as-is (no recalculation with current ADEME/fuel factors — the goal is historical restore, not rewriting history).
- Dedupe by `userId + startedAt` so re-running the import is idempotent. Badges are re-evaluated after insert (derived state).
- Client: `useImportData` hook + "Importer mes données" button in ProfilePage next to the existing export button.

## Test plan
- [x] Server vitest: 4 new tests cover value preservation, dedup, invalid payload rejection, empty-array no-op
- [x] Server full suite: 264 passing
- [x] Server + client typecheck clean
- [x] Profile page test mocks updated for the new hook
- [ ] Manual: export from one account, import into another, verify trip totals and dates match the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)