### PR TITLE
fix: harmoniser les headers des pages via un composant partagé

### DIFF
--- a/client/e2e/smoke.spec.ts
+++ b/client/e2e/smoke.spec.ts
@@ -232,8 +232,8 @@ test.describe("admin dashboard", () => {
     const errorBoundary = page.getByText("Une erreur est survenue");
     await expect(errorBoundary).not.toBeVisible({ timeout: 3000 });
 
-    // Should show the admin page title in the sticky banner
-    const adminHeader = page.getByRole("banner").getByText("Admin", { exact: true });
-    await expect(adminHeader).toBeVisible({ timeout: 5000 });
+    // Should show the admin page title as the unique <h1>
+    const adminHeading = page.getByRole("heading", { level: 1, name: "Admin" });
+    await expect(adminHeading).toBeVisible({ timeout: 5000 });
   });
 });

--- a/client/src/components/layout/PageHeader.tsx
+++ b/client/src/components/layout/PageHeader.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { ArrowLeft } from "lucide-react";
+
+interface PageHeaderProps {
+  /** Page title — always rendered as the unique <h1> of the page */
+  title: string;
+  /** Optional subtitle shown under the title */
+  subtitle?: ReactNode;
+  /**
+   * If true, the title is visually hidden but still present for screen readers.
+   * Use for pages where the visual title would be redundant (e.g. the home
+   * dashboard where the logo already identifies the app).
+   */
+  titleHidden?: boolean;
+  /** Back button. If provided, an ArrowLeft link is rendered in the header bar. */
+  back?: { to: string; label?: string };
+  /** Slot rendered on the right side of the sticky header bar. */
+  right?: ReactNode;
+}
+
+export function PageHeader({ title, subtitle, titleHidden, back, right }: PageHeaderProps) {
+  return (
+    <>
+      <header
+        role="banner"
+        className="sticky top-0 z-40 flex items-center justify-between gap-3 bg-bg/80 px-6 py-4 backdrop-blur-xl"
+      >
+        <div className="flex items-center gap-3">
+          {back && (
+            <Link
+              to={back.to}
+              aria-label={back.label ?? "Retour"}
+              className="rounded-lg p-1 text-text-muted transition-colors hover:text-text active:scale-95"
+            >
+              <ArrowLeft size={20} />
+            </Link>
+          )}
+          <span className="text-xl font-bold tracking-tighter">
+            <span className="text-text">eco</span>
+            <span className="text-primary-light">Ride</span>
+          </span>
+        </div>
+        {right ? <div className="flex items-center gap-2">{right}</div> : null}
+      </header>
+
+      {titleHidden ? (
+        <h1 className="sr-only">{title}</h1>
+      ) : (
+        <div className="px-6 pb-2 pt-4">
+          <h1 className="text-4xl font-extrabold tracking-tighter text-text">{title}</h1>
+          {subtitle ? <p className="mt-1 text-sm font-medium text-text-dim">{subtitle}</p> : null}
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/components/layout/__tests__/PageHeader.test.tsx
+++ b/client/src/components/layout/__tests__/PageHeader.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { PageHeader } from "../PageHeader";
+
+function renderHeader(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("PageHeader", () => {
+  it("renders the title as the unique <h1> of the page", () => {
+    renderHeader(<PageHeader title="Statistiques" />);
+    const headings = screen.getAllByRole("heading", { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.textContent).toBe("Statistiques");
+  });
+
+  it("always renders the ecoRide logo inside a banner landmark", () => {
+    renderHeader(<PageHeader title="Accueil" />);
+    const banner = screen.getByRole("banner");
+    expect(within(banner).getByText("eco")).toBeTruthy();
+    expect(within(banner).getByText("Ride")).toBeTruthy();
+  });
+
+  it("hides the title visually when titleHidden is set but keeps it in the DOM for a11y", () => {
+    renderHeader(<PageHeader title="Accueil" titleHidden />);
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1.textContent).toBe("Accueil");
+    expect(h1.className).toContain("sr-only");
+  });
+
+  it("renders a back link with the given destination and accessible label", () => {
+    renderHeader(<PageHeader title="Admin" back={{ to: "/", label: "Retour à l'accueil" }} />);
+    const link = screen.getByRole("link", { name: "Retour à l'accueil" });
+    expect(link.getAttribute("href")).toBe("/");
+  });
+
+  it("falls back to 'Retour' as the default back link label", () => {
+    renderHeader(<PageHeader title="Admin" back={{ to: "/" }} />);
+    expect(screen.getByRole("link", { name: "Retour" })).toBeTruthy();
+  });
+
+  it("does not render a back link when the back prop is omitted", () => {
+    renderHeader(<PageHeader title="Statistiques" />);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders the right slot inside the sticky banner", () => {
+    renderHeader(<PageHeader title="Profil" right={<span data-testid="version">v2.28.0</span>} />);
+    const banner = screen.getByRole("banner");
+    expect(within(banner).getByTestId("version").textContent).toBe("v2.28.0");
+  });
+
+  it("renders the subtitle below the title when provided", () => {
+    renderHeader(<PageHeader title="Classement" subtitle="Top CO₂ économisé" />);
+    expect(screen.getByText("Top CO₂ économisé")).toBeTruthy();
+  });
+});

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate, Link } from "react-router";
+import { useNavigate } from "react-router";
 import {
   Shield,
   Users,
@@ -9,12 +9,12 @@ import {
   CalendarDays,
   Database,
   Clock,
-  ArrowLeft,
   Bike,
   Check,
   Rocket,
   X,
 } from "lucide-react";
+import { PageHeader } from "@/components/layout/PageHeader";
 import {
   useAdminHealth,
   useAdminStats,
@@ -106,24 +106,11 @@ export function AdminPage() {
 
   return (
     <>
-      {/* Header */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center gap-3 bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <Link to="/" className="rounded-lg p-1 text-text-muted hover:text-text" aria-label="Retour">
-          <ArrowLeft size={20} />
-        </Link>
-        <div className="flex items-center gap-2">
-          <Shield size={20} className="text-primary-light" />
-          <span className="text-xl font-bold tracking-tighter">
-            <span className="text-text">Admin</span>
-            <span className="text-text-dim"> — </span>
-            <span className="text-text">eco</span>
-            <span className="text-primary-light">Ride</span>
-          </span>
-        </div>
-      </header>
+      <PageHeader
+        title="Admin"
+        back={{ to: "/" }}
+        right={<Shield size={18} className="text-primary-light" aria-hidden="true" />}
+      />
 
       <div className="space-y-6 px-6 pb-6">
         {/* System Info Card */}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ import {
 import { useDashboardSummary, useProfile, useActiveAnnouncement } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { getPendingTrips, getRejectedTrips } from "@/lib/offline-queue";
+import { PageHeader } from "@/components/layout/PageHeader";
 import appLogo from "/pwa-192x192.png?url";
 
 interface Milestone {
@@ -170,16 +171,7 @@ export function DashboardPage() {
 
   return (
     <>
-      {/* Header */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <span className="text-2xl font-black tracking-tighter">
-          <span className="text-text">eco</span>
-          <span className="text-primary-light">Ride</span>
-        </span>
-      </header>
+      <PageHeader title="Accueil" titleHidden />
 
       {/* Admin announcement banner (swipable) */}
       {showAnn && (

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Trophy, Leaf, Flame, MapPin, Zap, Euro, Route } from "lucide-react";
 import { useLeaderboard } from "@/hooks/queries";
 import { useSession } from "@/lib/auth";
+import { PageHeader } from "@/components/layout/PageHeader";
 import type { StatsPeriod, LeaderboardCategory } from "@ecoride/shared/api-contracts";
 
 const periodOptions = [
@@ -85,26 +86,13 @@ export function LeaderboardPage() {
 
   return (
     <>
-      {/* Header */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <span className="text-lg font-bold tracking-tight">
-          <span className="text-text">eco</span>
-          <span className="text-primary-light">Ride</span>
-        </span>
-      </header>
+      <PageHeader
+        title="Classement"
+        subtitle={`${categorySubtitles[category]}${periodSuffixes[period] ?? ""}`}
+      />
 
       <div className="px-6 pb-6">
-        {/* Title */}
         <section className="mb-10">
-          <h2 className="mb-2 text-4xl font-extrabold tracking-tighter">Classement</h2>
-          <p className="text-sm font-medium text-text-dim">
-            {categorySubtitles[category]}
-            {periodSuffixes[period] ?? ""}
-          </p>
-
           {/* Period switcher */}
           <div className="mt-4 flex gap-2" data-testid="period-switcher">
             {periodOptions.map((opt) => (

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -18,6 +18,7 @@ import {
   MessageSquarePlus,
   Bluetooth,
 } from "lucide-react";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
 import type { FuelType, BadgeId } from "@ecoride/shared/types";
 import {
@@ -164,19 +165,10 @@ export function ProfilePage() {
 
   return (
     <>
-      {/* Header */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <div className="flex items-baseline gap-2">
-          <span className="text-xl font-bold tracking-tighter">
-            <span className="text-text">eco</span>
-            <span className="text-primary-light">Ride</span>
-          </span>
-          <span className="text-xs text-text-dim">v{__APP_VERSION__}</span>
-        </div>
-      </header>
+      <PageHeader
+        title="Profil"
+        right={<span className="text-xs text-text-dim">v{__APP_VERSION__}</span>}
+      />
 
       <div className="space-y-8 px-6 pb-6">
         {/* User Identity Hero */}
@@ -195,7 +187,7 @@ export function ProfilePage() {
             </div>
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight text-text">{user.name}</h1>
+            <h2 className="text-3xl font-bold tracking-tight text-text">{user.name}</h2>
             <div className="mt-1 inline-flex items-center rounded-full bg-primary/15 px-3 py-1 text-xs font-bold uppercase tracking-widest text-primary-light">
               Eco Rider
             </div>

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -28,6 +28,7 @@ import {
   SPEED_LEGEND,
 } from "@/lib/speedGeoJSON";
 import { MapNoWebGL } from "@/components/MapNoWebGL";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 type Period = "week" | "month" | "year";
 type Metric = "km" | "co2" | "eur";
@@ -322,17 +323,7 @@ export function StatsPage() {
         </div>
       )}
 
-      {/* Header */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <span className="text-lg font-bold tracking-tight text-primary-light">Stats</span>
-        <span className="text-xl font-bold tracking-tighter">
-          <span className="text-text">eco</span>
-          <span className="text-primary-light">Ride</span>
-        </span>
-      </header>
+      <PageHeader title="Statistiques" />
 
       <div className="space-y-12 px-6 pb-6">
         {s.tripCount === 0 ? (

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -25,6 +25,7 @@ import { useManualTrip } from "@/hooks/useManualTrip";
 import { useMapCamera } from "@/hooks/useMapCamera";
 import { useMapOrientation } from "@/hooks/useMapOrientation";
 import { MapOrientationButton } from "@/components/trip/MapOrientationButton";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -256,23 +257,19 @@ export function TripPage() {
       className="relative flex h-[calc(100dvh_-_6rem)] flex-col overflow-hidden"
       data-testid="trip-page-root"
     >
-      {/* Header with persistent GPS indicator */}
-      <header
-        role="banner"
-        className="sticky top-0 z-40 flex items-center justify-between bg-bg/80 px-6 py-4 backdrop-blur-xl"
-      >
-        <span className="text-lg font-bold tracking-tight">
-          <span className="text-text">eco</span>
-          <span className="text-primary-light">Ride</span>
-        </span>
-        <GpsStatusBadge
-          uiState={uiState}
-          gpsAccuracy={gps.state.lastAccuracy}
-          idleAccuracy={idleAccuracy}
-          isTracking={gps.state.isTracking}
-          gpsStatus={gpsStatus}
-        />
-      </header>
+      <PageHeader
+        title="Trajet"
+        titleHidden
+        right={
+          <GpsStatusBadge
+            uiState={uiState}
+            gpsAccuracy={gps.state.lastAccuracy}
+            idleAccuracy={idleAccuracy}
+            isTracking={gps.state.isTracking}
+            gpsStatus={gpsStatus}
+          />
+        }
+      />
 
       {/* Fix 1.3: Recovery banner for interrupted trip */}
       {recovery.pendingBackup && uiState === "idle" && (

--- a/client/src/pages/VehiclePage.tsx
+++ b/client/src/pages/VehiclePage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
-import { ChevronLeft, Sun, SunDim, Check } from "lucide-react";
+import { Sun, SunDim, Check } from "lucide-react";
 import { useProfile, useUpdateProfile } from "@/hooks/queries";
 import { useSuper73 } from "@/hooks/useSuper73";
 import { isBleSupported } from "@/lib/super73-ble";
 import { Super73ModeButton } from "@/components/Super73ModeButton";
+import { PageHeader } from "@/components/layout/PageHeader";
 import type { Super73Mode } from "@ecoride/shared/types";
 
 const ASSIST_LEVELS = [0, 1, 2, 3, 4] as const;
@@ -94,303 +95,295 @@ export function VehiclePage() {
   const bleSupported = isBleSupported();
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6">
-      {/* Back button */}
-      <button
-        onClick={() => navigate("/profile")}
-        className="flex h-12 items-center gap-1.5 self-start rounded-xl px-3 text-sm font-medium text-text-muted active:scale-95"
-      >
-        <ChevronLeft size={20} />
-        Profil
-      </button>
-
-      <h1 className="text-2xl font-black tracking-tight">
-        <span className="text-text">Mon </span>
-        <span className="text-primary-light">Vélo</span>
-      </h1>
-
-      {!bleSupported && (
-        <div className="rounded-xl bg-warning/10 px-4 py-3">
-          <p className="text-sm font-medium text-warning">
-            Bluetooth non supporté par ce navigateur.
-          </p>
-          <p className="mt-1 text-xs text-text-muted">
-            Sur iOS, utilisez Bluefy. Sur desktop, utilisez Chrome.
-          </p>
-        </div>
-      )}
-
-      {/* Connection + Mode selector */}
-      <section className="rounded-2xl bg-surface-container p-4">
-        <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
-          Connexion & Mode
-        </h2>
-        <Super73ModeButton enabled={enabled} />
-      </section>
-
-      <section className="rounded-2xl bg-surface-container p-4">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-sm font-bold uppercase tracking-wider text-text-muted">
-              Mode auto en trajet
-            </h2>
-            <p className="mt-1 text-xs text-text-dim">
-              Passe en Off-Road à basse vitesse et en EPAC à vitesse plus élevée pendant un trajet.
+    <>
+      <PageHeader title="Mon vélo" back={{ to: "/profile", label: "Retour au profil" }} />
+      <div className="flex flex-col gap-6 px-6 pb-6">
+        {!bleSupported && (
+          <div className="rounded-xl bg-warning/10 px-4 py-3">
+            <p className="text-sm font-medium text-warning">
+              Bluetooth non supporté par ce navigateur.
+            </p>
+            <p className="mt-1 text-xs text-text-muted">
+              Sur iOS, utilisez Bluefy. Sur desktop, utilisez Chrome.
             </p>
           </div>
-          {saveSuccess && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-1 text-xs font-bold text-primary-light">
-              <Check size={12} />
-              Sauvé
-            </span>
-          )}
-        </div>
+        )}
 
-        <div className="space-y-4">
-          <label className="flex items-center justify-between gap-4 rounded-2xl bg-surface-high px-4 py-3">
+        {/* Connection + Mode selector */}
+        <section className="rounded-2xl bg-surface-container p-4">
+          <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
+            Connexion & Mode
+          </h2>
+          <Super73ModeButton enabled={enabled} />
+        </section>
+
+        <section className="rounded-2xl bg-surface-container p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
             <div>
-              <span className="block text-sm font-semibold text-text">
-                Mode auto selon la vitesse
-              </span>
-              <span className="block text-xs text-text-dim">
-                Hystérésis actuelle: Off-Road à 10 km/h ou moins, EPAC à 17 km/h ou plus.
-              </span>
+              <h2 className="text-sm font-bold uppercase tracking-wider text-text-muted">
+                Mode auto en trajet
+              </h2>
+              <p className="mt-1 text-xs text-text-dim">
+                Passe en Off-Road à basse vitesse et en EPAC à vitesse plus élevée pendant un
+                trajet.
+              </p>
             </div>
-            <button
-              type="button"
-              onClick={() => setAutoModeEnabled((current) => !current)}
-              className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors ${
-                autoModeEnabled ? "bg-primary" : "bg-surface"
-              }`}
-              aria-label={autoModeEnabled ? "Désactiver le mode auto" : "Activer le mode auto"}
-            >
-              <span
-                className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
-                  autoModeEnabled ? "translate-x-6" : "translate-x-1"
-                }`}
-              />
-            </button>
-          </label>
-
-          <button
-            type="button"
-            onClick={handleSaveAutoMode}
-            disabled={updateProfile.isPending}
-            className="w-full rounded-2xl bg-primary px-4 py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
-          >
-            {updateProfile.isPending ? "Sauvegarde..." : "Enregistrer le mode auto"}
-          </button>
-        </div>
-      </section>
-
-      {/* Default settings */}
-      <section className="rounded-2xl bg-surface-container p-4">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-sm font-bold uppercase tracking-wider text-text-muted">
-              Réglages par défaut
-            </h2>
-            <p className="mt-1 text-xs text-text-dim">Appliqués automatiquement à la connexion.</p>
-          </div>
-          {defaultsSaved && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-1 text-xs font-bold text-primary-light">
-              <Check size={12} />
-              Sauvé
-            </span>
-          )}
-        </div>
-
-        <div className="space-y-3">
-          <div className="grid grid-cols-2 gap-3">
-            <label className="block">
-              <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
-                Mode
+            {saveSuccess && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-1 text-xs font-bold text-primary-light">
+                <Check size={12} />
+                Sauvé
               </span>
-              <select
-                value={defaultMode}
-                onChange={(e) => setDefaultMode(e.target.value as Super73Mode)}
-                className="w-full rounded-lg bg-surface-high px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-              >
-                {SUPER73_DEFAULT_MODES.map((mode) => (
-                  <option key={mode} value={mode}>
-                    {mode === "race" ? "Off-Road" : mode === "eco" ? "EPAC" : mode}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="block">
-              <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
-                Assistance
-              </span>
-              <select
-                value={defaultAssist}
-                onChange={(e) =>
-                  setDefaultAssist(Number(e.target.value) as (typeof ASSIST_LEVELS)[number])
-                }
-                className="w-full rounded-lg bg-surface-high px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-              >
-                {ASSIST_LEVELS.map((level) => (
-                  <option key={level} value={level}>
-                    {level}
-                  </option>
-                ))}
-              </select>
-            </label>
+            )}
           </div>
 
-          <label className="flex items-center justify-between gap-3 rounded-lg bg-surface-high px-3 py-2.5">
-            <div className="min-w-0">
-              <span className="block text-sm font-medium text-text">Lumières</span>
-              <span className="block text-xs text-text-dim">Auto à la connexion</span>
-            </div>
-            <button
-              type="button"
-              onClick={() => setDefaultLight((current) => !current)}
-              className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors ${
-                defaultLight ? "bg-primary" : "bg-surface"
-              }`}
-              aria-label={
-                defaultLight
-                  ? "Désactiver les lumières par défaut"
-                  : "Activer les lumières par défaut"
-              }
-            >
-              <span
-                className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
-                  defaultLight ? "translate-x-6" : "translate-x-1"
-                }`}
-              />
-            </button>
-          </label>
-
-          <div className="rounded-lg bg-surface-high p-3">
-            <div>
-              <p className="text-sm font-medium text-text">Seuils mode auto</p>
-              <p className="text-xs text-text-dim">Bascule de mode selon la vitesse</p>
-            </div>
-            <div className="mt-2 grid grid-cols-2 gap-3">
-              <label className="block">
-                <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
-                  Off-Road
+          <div className="space-y-4">
+            <label className="flex items-center justify-between gap-4 rounded-2xl bg-surface-high px-4 py-3">
+              <div>
+                <span className="block text-sm font-semibold text-text">
+                  Mode auto selon la vitesse
                 </span>
-                <input
-                  type="number"
-                  min="1"
-                  max="80"
-                  step="0.5"
-                  value={autoModeLowSpeed}
-                  onChange={(e) => setAutoModeLowSpeed(e.target.value)}
-                  className="w-full rounded-lg bg-surface px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </label>
-              <label className="block">
-                <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
-                  EPAC
+                <span className="block text-xs text-text-dim">
+                  Hystérésis actuelle: Off-Road à 10 km/h ou moins, EPAC à 17 km/h ou plus.
                 </span>
-                <input
-                  type="number"
-                  min="1"
-                  max="80"
-                  step="0.5"
-                  value={autoModeHighSpeed}
-                  onChange={(e) => setAutoModeHighSpeed(e.target.value)}
-                  className="w-full rounded-lg bg-surface px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </label>
-            </div>
-            <p className="mt-2 text-xs text-text-dim">
-              Off-Road si vitesse ≤ seuil bas, EPAC si vitesse ≥ seuil haut.
-            </p>
-          </div>
-
-          {invalidThresholds && (
-            <p className="text-xs text-danger">
-              Le seuil Off-Road doit être strictement inférieur au seuil EPAC.
-            </p>
-          )}
-
-          <button
-            type="button"
-            onClick={handleSaveDefaults}
-            disabled={updateProfile.isPending || invalidThresholds}
-            className="w-full rounded-2xl bg-primary px-4 py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
-          >
-            {updateProfile.isPending ? "Sauvegarde..." : "Enregistrer les réglages"}
-          </button>
-        </div>
-      </section>
-
-      {/* Assist level */}
-      {ble.status === "connected" && ble.bikeState && (
-        <>
-          <section className="rounded-2xl bg-surface-container p-4">
-            <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
-              Niveau d'assistance
-            </h2>
-            <div className="flex gap-2">
-              {ASSIST_LEVELS.map((level) => (
-                <button
-                  key={level}
-                  onClick={() => ble.setAssist(level)}
-                  className={`flex-1 rounded-2xl py-5 text-center text-xl font-bold transition-colors active:scale-95 ${
-                    ble.bikeState?.assist === level
-                      ? "bg-primary text-bg"
-                      : "bg-surface-high text-text-muted"
+              </div>
+              <button
+                type="button"
+                onClick={() => setAutoModeEnabled((current) => !current)}
+                className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors ${
+                  autoModeEnabled ? "bg-primary" : "bg-surface"
+                }`}
+                aria-label={autoModeEnabled ? "Désactiver le mode auto" : "Activer le mode auto"}
+              >
+                <span
+                  className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
+                    autoModeEnabled ? "translate-x-6" : "translate-x-1"
                   }`}
-                >
-                  {level}
-                </button>
-              ))}
-            </div>
-          </section>
+                />
+              </button>
+            </label>
 
-          {/* Lights */}
-          <section className="rounded-2xl bg-surface-container p-4">
-            <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
-              Lumières
-            </h2>
             <button
-              onClick={() => ble.setLight(!ble.bikeState?.light)}
-              className={`flex w-full items-center justify-between rounded-2xl px-6 py-5 transition-colors active:scale-[0.98] ${
-                ble.bikeState?.light
-                  ? "bg-primary/20 text-primary-light"
-                  : "bg-surface-high text-text-muted"
-              }`}
+              type="button"
+              onClick={handleSaveAutoMode}
+              disabled={updateProfile.isPending}
+              className="w-full rounded-2xl bg-primary px-4 py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
             >
-              <span className="text-base font-bold">
-                {ble.bikeState?.light ? "Allumées" : "Éteintes"}
-              </span>
-              {ble.bikeState?.light ? <Sun size={24} /> : <SunDim size={24} />}
+              {updateProfile.isPending ? "Sauvegarde..." : "Enregistrer le mode auto"}
             </button>
-          </section>
+          </div>
+        </section>
 
-          {/* Info */}
-          <section className="rounded-2xl bg-surface-container p-4">
-            <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
-              Informations
-            </h2>
-            <div className="space-y-2 text-sm text-text-muted">
-              <div className="flex justify-between">
-                <span>Région</span>
-                <span className="font-medium text-text">
-                  {ble.bikeState?.region === "eu" ? "Europe (EPAC)" : "USA"}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span>Mode actuel</span>
-                <span className="font-medium text-text">
-                  {ble.bikeState?.mode === "race" ? "Off-Road" : ble.bikeState?.mode}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span>Assistance</span>
-                <span className="font-medium text-text">{ble.bikeState?.assist}/4</span>
-              </div>
+        {/* Default settings */}
+        <section className="rounded-2xl bg-surface-container p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-bold uppercase tracking-wider text-text-muted">
+                Réglages par défaut
+              </h2>
+              <p className="mt-1 text-xs text-text-dim">
+                Appliqués automatiquement à la connexion.
+              </p>
             </div>
-          </section>
-        </>
-      )}
-    </div>
+            {defaultsSaved && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-1 text-xs font-bold text-primary-light">
+                <Check size={12} />
+                Sauvé
+              </span>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="block">
+                <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
+                  Mode
+                </span>
+                <select
+                  value={defaultMode}
+                  onChange={(e) => setDefaultMode(e.target.value as Super73Mode)}
+                  className="w-full rounded-lg bg-surface-high px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+                >
+                  {SUPER73_DEFAULT_MODES.map((mode) => (
+                    <option key={mode} value={mode}>
+                      {mode === "race" ? "Off-Road" : mode === "eco" ? "EPAC" : mode}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
+                  Assistance
+                </span>
+                <select
+                  value={defaultAssist}
+                  onChange={(e) =>
+                    setDefaultAssist(Number(e.target.value) as (typeof ASSIST_LEVELS)[number])
+                  }
+                  className="w-full rounded-lg bg-surface-high px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+                >
+                  {ASSIST_LEVELS.map((level) => (
+                    <option key={level} value={level}>
+                      {level}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <label className="flex items-center justify-between gap-3 rounded-lg bg-surface-high px-3 py-2.5">
+              <div className="min-w-0">
+                <span className="block text-sm font-medium text-text">Lumières</span>
+                <span className="block text-xs text-text-dim">Auto à la connexion</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDefaultLight((current) => !current)}
+                className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors ${
+                  defaultLight ? "bg-primary" : "bg-surface"
+                }`}
+                aria-label={
+                  defaultLight
+                    ? "Désactiver les lumières par défaut"
+                    : "Activer les lumières par défaut"
+                }
+              >
+                <span
+                  className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
+                    defaultLight ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </label>
+
+            <div className="rounded-lg bg-surface-high p-3">
+              <div>
+                <p className="text-sm font-medium text-text">Seuils mode auto</p>
+                <p className="text-xs text-text-dim">Bascule de mode selon la vitesse</p>
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-3">
+                <label className="block">
+                  <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
+                    Off-Road
+                  </span>
+                  <input
+                    type="number"
+                    min="1"
+                    max="80"
+                    step="0.5"
+                    value={autoModeLowSpeed}
+                    onChange={(e) => setAutoModeLowSpeed(e.target.value)}
+                    className="w-full rounded-lg bg-surface px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-[11px] font-bold uppercase tracking-widest text-text-dim">
+                    EPAC
+                  </span>
+                  <input
+                    type="number"
+                    min="1"
+                    max="80"
+                    step="0.5"
+                    value={autoModeHighSpeed}
+                    onChange={(e) => setAutoModeHighSpeed(e.target.value)}
+                    className="w-full rounded-lg bg-surface px-3 py-2.5 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </label>
+              </div>
+              <p className="mt-2 text-xs text-text-dim">
+                Off-Road si vitesse ≤ seuil bas, EPAC si vitesse ≥ seuil haut.
+              </p>
+            </div>
+
+            {invalidThresholds && (
+              <p className="text-xs text-danger">
+                Le seuil Off-Road doit être strictement inférieur au seuil EPAC.
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={handleSaveDefaults}
+              disabled={updateProfile.isPending || invalidThresholds}
+              className="w-full rounded-2xl bg-primary px-4 py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
+            >
+              {updateProfile.isPending ? "Sauvegarde..." : "Enregistrer les réglages"}
+            </button>
+          </div>
+        </section>
+
+        {/* Assist level */}
+        {ble.status === "connected" && ble.bikeState && (
+          <>
+            <section className="rounded-2xl bg-surface-container p-4">
+              <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
+                Niveau d'assistance
+              </h2>
+              <div className="flex gap-2">
+                {ASSIST_LEVELS.map((level) => (
+                  <button
+                    key={level}
+                    onClick={() => ble.setAssist(level)}
+                    className={`flex-1 rounded-2xl py-5 text-center text-xl font-bold transition-colors active:scale-95 ${
+                      ble.bikeState?.assist === level
+                        ? "bg-primary text-bg"
+                        : "bg-surface-high text-text-muted"
+                    }`}
+                  >
+                    {level}
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            {/* Lights */}
+            <section className="rounded-2xl bg-surface-container p-4">
+              <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
+                Lumières
+              </h2>
+              <button
+                onClick={() => ble.setLight(!ble.bikeState?.light)}
+                className={`flex w-full items-center justify-between rounded-2xl px-6 py-5 transition-colors active:scale-[0.98] ${
+                  ble.bikeState?.light
+                    ? "bg-primary/20 text-primary-light"
+                    : "bg-surface-high text-text-muted"
+                }`}
+              >
+                <span className="text-base font-bold">
+                  {ble.bikeState?.light ? "Allumées" : "Éteintes"}
+                </span>
+                {ble.bikeState?.light ? <Sun size={24} /> : <SunDim size={24} />}
+              </button>
+            </section>
+
+            {/* Info */}
+            <section className="rounded-2xl bg-surface-container p-4">
+              <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-text-muted">
+                Informations
+              </h2>
+              <div className="space-y-2 text-sm text-text-muted">
+                <div className="flex justify-between">
+                  <span>Région</span>
+                  <span className="font-medium text-text">
+                    {ble.bikeState?.region === "eu" ? "Europe (EPAC)" : "USA"}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Mode actuel</span>
+                  <span className="font-medium text-text">
+                    {ble.bikeState?.mode === "race" ? "Off-Road" : ble.bikeState?.mode}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Assistance</span>
+                  <span className="font-medium text-text">{ble.bikeState?.assist}/4</span>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #239

## Summary

- Nouveau composant `client/src/components/layout/PageHeader.tsx` qui normalise le header sticky, expose exactement un `<h1>` par page, et unifie le back button + slot droit
- Refactor de 7 pages (Dashboard, Trip, Stats, Leaderboard, Profile, Admin, Vehicle) → suppression des 7 headers artisanaux qui divergeaient (5 tailles de logo différentes, titres tantôt `<h1>`/`<h2>`/absents, bouton retour en 3 styles)
- Test unitaire de régression sur `PageHeader` (8 cas)

## Incohérences corrigées

Avant le PR :

| Page | Logo | Titre body |
|---|---|---|
| Dashboard | `text-2xl font-black` | absent |
| Stats | `text-xl` + label "Stats" | absent |
| Leaderboard | `text-lg` | `<h2>` `text-4xl` |
| Profile | `text-xl` + version | `<h1>` nom user `text-3xl` |
| Trip | `text-lg` | absent |
| Admin | `text-xl` + back custom | dans le header |
| Vehicle | **pas de sticky header** | `<h1>` custom `text-2xl` |

Après : tous les pages passent par `<PageHeader title="..." />` avec logo unique (`text-xl font-bold tracking-tighter`) et un `<h1>` unique (visible ou `sr-only`).

## Choix notables

- **Dashboard et Trip** gardent le logo comme ancrage visuel (titre `sr-only` pour l'a11y) — ces pages sont full-bleed et un titre visible casserait le layout
- **ProfilePage** : le nom user passe de `<h1>` → `<h2>` (le `<h1>` "Profil" vient maintenant du PageHeader, évite deux h1)
- **Admin** et **Vehicle** utilisent le back button intégré (`back={{ to: "/..." }}`) — style uniforme
- **PrivacyPage** et **NotFoundPage** hors scope : standalone, en dehors de l'AppShell, layout distinct

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 erreurs (36 warnings pré-existants, aucun nouveau)
- [x] `bun run test` — 174 passed, 3 échecs pré-existants vérifiés sur `main` stashé (localStorage mock jsdom, sans lien avec ce PR) + 8 nouveaux tests `PageHeader` tous verts
- [ ] CI Playwright smoke pour vérifier qu'aucune page ne crashe
- [ ] Vérif visuelle mobile : navigation entre les 7 tabs — header identique partout

🤖 Generated with [Claude Code](https://claude.com/claude-code)