### PR TITLE
fix: version sur toutes les tabs + masquer les sourcemaps du navigateur

### DIFF
--- a/client/src/components/layout/PageHeader.tsx
+++ b/client/src/components/layout/PageHeader.tsx
@@ -36,10 +36,13 @@ export function PageHeader({ title, subtitle, titleHidden, back, right }: PageHe
               <ArrowLeft size={20} />
             </Link>
           )}
-          <span className="text-xl font-bold tracking-tighter">
-            <span className="text-text">eco</span>
-            <span className="text-primary-light">Ride</span>
-          </span>
+          <div className="flex items-baseline gap-2">
+            <span className="text-xl font-bold tracking-tighter">
+              <span className="text-text">eco</span>
+              <span className="text-primary-light">Ride</span>
+            </span>
+            <span className="text-xs text-text-dim">v{__APP_VERSION__}</span>
+          </div>
         </div>
         {right ? <div className="flex items-center gap-2">{right}</div> : null}
       </header>

--- a/client/src/components/layout/__tests__/PageHeader.test.tsx
+++ b/client/src/components/layout/__tests__/PageHeader.test.tsx
@@ -22,6 +22,13 @@ describe("PageHeader", () => {
     expect(within(banner).getByText("Ride")).toBeTruthy();
   });
 
+  it("always shows the app version next to the logo", () => {
+    renderHeader(<PageHeader title="Accueil" />);
+    const banner = screen.getByRole("banner");
+    // vitest.config.ts defines __APP_VERSION__ as "test"
+    expect(within(banner).getByText("vtest")).toBeTruthy();
+  });
+
   it("hides the title visually when titleHidden is set but keeps it in the DOM for a11y", () => {
     renderHeader(<PageHeader title="Accueil" titleHidden />);
     const h1 = screen.getByRole("heading", { level: 1 });

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -165,10 +165,7 @@ export function ProfilePage() {
 
   return (
     <>
-      <PageHeader
-        title="Profil"
-        right={<span className="text-xs text-text-dim">v{__APP_VERSION__}</span>}
-      />
+      <PageHeader title="Profil" />
 
       <div className="space-y-8 px-6 pb-6">
         {/* User Identity Hero */}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -42,7 +42,13 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(appVersion),
   },
   build: {
-    sourcemap: true,
+    // 'hidden' emits the .map files (so Sentry can still upload source maps
+    // during CI) but strips the `//# sourceMappingURL=` comment from the JS,
+    // so browsers never try to fetch the stripped maps in production. This
+    // avoids the DevTools warning "No sources are declared in this source map"
+    // which appears because @sentry/vite-plugin removes the sources array
+    // after uploading.
+    sourcemap: "hidden",
   },
   plugins: [
     react(),

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify("test"),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## Summary

- **Version sur toutes les tabs** : l'affichage `v{__APP_VERSION__}` passe du slot droit de `ProfilePage` au composant `PageHeader` lui-même → apparaît à l'identique sur toutes les pages (alignée baseline avec le logo).
- **Warning sourcemap navigateur** : `build.sourcemap` passe de `true` à `'hidden'`. Les `.map` sont toujours émis (Sentry les upload en CI) mais le commentaire `//# sourceMappingURL=` est strippé des bundles, donc le navigateur ne tente plus de charger les maps dont les sources ont été retirées par `@sentry/vite-plugin`. Supprime le warning DevTools `No sources are declared in this source map`.
- **vitest.config.ts** : définit `__APP_VERSION__` globalement pour les tests (évite le stub manuel dans chaque test).
- **Test** : nouveau cas dans `PageHeader.test.tsx` qui vérifie la présence de la version dans le landmark banner.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — `PageHeader` 9/9 verts
- [ ] CI Playwright smoke
- [ ] Vérif DevTools : plus de warning sourcemap en prod
- [ ] Vérif visuelle : version affichée identiquement sur Dashboard, Trajet, Stats, Classement, Profil, Admin, Vélo

🤖 Generated with [Claude Code](https://claude.com/claude-code)