### PR TITLE
feat: offline map tile caching (#242)

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/client/src/components/MapCacheRow.tsx
+++ b/client/src/components/MapCacheRow.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
+import { Map as MapIcon, Trash2 } from "lucide-react";
+import { useT } from "@/i18n/provider";
+import { clearTileCache, formatBytes, getTileCacheInfo } from "@/lib/tile-cache";
+
+/**
+ * Settings row (for ProfilePage) that shows the offline map tile cache size
+ * and lets the user clear it. Loads the stats on mount and refreshes after
+ * clearing.
+ */
+export function MapCacheRow() {
+  const t = useT();
+  const [entries, setEntries] = useState(0);
+  const [approxBytes, setApproxBytes] = useState<number | null>(null);
+  const [clearing, setClearing] = useState(false);
+  const [justCleared, setJustCleared] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const info = await getTileCacheInfo();
+    setEntries(info.entries);
+    setApproxBytes(info.approxBytes);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleClear = useCallback(async () => {
+    if (!window.confirm(t("profile.mapCache.clearConfirm"))) return;
+    setClearing(true);
+    try {
+      await clearTileCache();
+      await refresh();
+      setJustCleared(true);
+      setTimeout(() => setJustCleared(false), 2000);
+    } finally {
+      setClearing(false);
+    }
+  }, [refresh, t]);
+
+  const entriesLabel =
+    entries === 0
+      ? t("profile.mapCache.empty")
+      : entries === 1
+        ? t("profile.mapCache.entriesOne", { count: entries })
+        : t("profile.mapCache.entriesMany", { count: entries });
+
+  return (
+    <div className="flex w-full flex-col gap-2 p-4">
+      <div className="flex items-center gap-4">
+        <MapIcon size={20} className="text-text-muted" />
+        <span className="text-sm font-medium">{t("profile.mapCache.row")}</span>
+      </div>
+      <p className="ml-9 text-xs text-text-dim">{t("profile.mapCache.description")}</p>
+      <div className="ml-9 flex items-center justify-between gap-3">
+        <div className="min-w-0 text-xs text-text-muted">
+          <div>{entriesLabel}</div>
+          {approxBytes !== null && approxBytes > 0 && (
+            <div className="text-text-dim">
+              {t("profile.mapCache.approxSize", { size: formatBytes(approxBytes) })}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={clearing || entries === 0}
+          className="flex shrink-0 items-center gap-2 rounded-lg bg-surface-high px-3 py-2 text-xs font-bold text-text-muted active:scale-95 disabled:opacity-50"
+        >
+          <Trash2 size={14} />
+          {justCleared
+            ? t("profile.mapCache.cleared")
+            : clearing
+              ? t("profile.mapCache.clearing")
+              : t("profile.mapCache.clear")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/__tests__/MapCacheRow.test.tsx
+++ b/client/src/components/__tests__/MapCacheRow.test.tsx
@@ -1,0 +1,87 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MapCacheRow } from "../MapCacheRow";
+import { I18nProvider } from "@/i18n/provider";
+
+function renderRow() {
+  return render(
+    <I18nProvider>
+      <MapCacheRow />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("MapCacheRow", () => {
+  it("renders the empty state when no tiles are cached", async () => {
+    vi.stubGlobal("caches", {
+      keys: async () => [] as string[],
+      open: async () => ({ keys: async () => [] as Request[] }),
+      delete: async () => true,
+    });
+
+    renderRow();
+
+    await waitFor(() => {
+      expect(screen.getByText("Aucune carte en cache")).toBeTruthy();
+    });
+    // Clear button disabled when nothing to clear
+    const clearBtn = screen.getByRole("button", { name: /Vider le cache/ }) as HTMLButtonElement;
+    expect(clearBtn.disabled).toBe(true);
+  });
+
+  it("renders the cached tile count and a working clear button", async () => {
+    const deleteSpy = vi.fn().mockResolvedValue(true);
+    let keyCount = 12;
+    vi.stubGlobal("caches", {
+      keys: async () => ["ecoride-map-tiles-v1"],
+      open: async () => ({
+        keys: async () => Array.from({ length: keyCount }, () => ({}) as unknown as Request),
+      }),
+      delete: async (name: string) => {
+        deleteSpy(name);
+        keyCount = 0;
+        return true;
+      },
+    });
+    window.confirm = () => true;
+
+    renderRow();
+
+    await waitFor(() => {
+      expect(screen.getByText(/12 tuiles en cache/)).toBeTruthy();
+    });
+
+    const clearBtn = screen.getByRole("button", { name: /Vider le cache/ });
+    fireEvent.click(clearBtn);
+
+    await waitFor(() => {
+      expect(deleteSpy).toHaveBeenCalledWith("ecoride-map-tiles-v1");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Aucune carte en cache")).toBeTruthy();
+    });
+  });
+
+  it("uses the singular form when exactly one tile is cached", async () => {
+    vi.stubGlobal("caches", {
+      keys: async () => ["ecoride-map-tiles-v1"],
+      open: async () => ({ keys: async () => [{} as unknown as Request] }),
+      delete: async () => true,
+    });
+
+    renderRow();
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 tuile en cache/)).toBeTruthy();
+    });
+  });
+});

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -482,6 +482,18 @@ export const en: Record<TranslationKey, string> = {
   "privacy.sections.contact.linkLabel": "issue on GitHub",
   "privacy.sections.contact.bodyAfter": ".",
 
+  "profile.mapCache.row": "Offline maps",
+  "profile.mapCache.description": "Maps you've already viewed stay available without a connection.",
+  "profile.mapCache.entriesOne": "{{count}} tile cached",
+  "profile.mapCache.entriesMany": "{{count}} tiles cached",
+  "profile.mapCache.empty": "No map tiles cached",
+  "profile.mapCache.approxSize": "Storage used: {{size}}",
+  "profile.mapCache.clear": "Clear cache",
+  "profile.mapCache.clearConfirm":
+    "Clear the offline map cache? Tiles will be re-downloaded the next time you view them.",
+  "profile.mapCache.clearing": "Clearing…",
+  "profile.mapCache.cleared": "Cache cleared",
+
   "shared.errorBoundary.title": "Something went wrong",
   "shared.errorBoundary.body": "Something broke. Try reloading the page.",
   "shared.errorBoundary.reload": "Reload",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -484,6 +484,19 @@ export const fr = {
   "privacy.sections.contact.linkLabel": "issue sur GitHub",
   "privacy.sections.contact.bodyAfter": ".",
 
+  "profile.mapCache.row": "Cartes hors-ligne",
+  "profile.mapCache.description":
+    "Les cartes que vous avez déjà consultées restent affichables sans connexion.",
+  "profile.mapCache.entriesOne": "{{count}} tuile en cache",
+  "profile.mapCache.entriesMany": "{{count}} tuiles en cache",
+  "profile.mapCache.empty": "Aucune carte en cache",
+  "profile.mapCache.approxSize": "Espace utilisé: {{size}}",
+  "profile.mapCache.clear": "Vider le cache",
+  "profile.mapCache.clearConfirm":
+    "Vider le cache des cartes hors-ligne ? Les tuiles seront re-téléchargées à la prochaine consultation.",
+  "profile.mapCache.clearing": "Suppression...",
+  "profile.mapCache.cleared": "Cache vidé",
+
   "shared.errorBoundary.title": "Une erreur est survenue",
   "shared.errorBoundary.body": "Quelque chose s'est mal passé. Essayez de recharger la page.",
   "shared.errorBoundary.reload": "Recharger",

--- a/client/src/lib/__tests__/tile-cache.test.ts
+++ b/client/src/lib/__tests__/tile-cache.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAP_TILE_CACHE_NAME, clearTileCache, formatBytes, getTileCacheInfo } from "../tile-cache";
+
+interface FakeCache {
+  keys: () => Promise<Request[]>;
+}
+
+interface FakeCacheStorage {
+  keys: () => Promise<string[]>;
+  open: (name: string) => Promise<FakeCache>;
+  delete: (name: string) => Promise<boolean>;
+}
+
+function makeCaches(config: {
+  cacheNames: string[];
+  entryCount: number;
+  deleteResult?: boolean;
+}): FakeCacheStorage {
+  return {
+    keys: async () => config.cacheNames,
+    open: async () => ({
+      // getTileCacheInfo only reads .length — avoid constructing real Request
+      // objects (relative URLs throw under bun test env).
+      keys: async () => Array.from({ length: config.entryCount }, () => ({}) as unknown as Request),
+    }),
+    delete: async () => config.deleteResult ?? true,
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getTileCacheInfo", () => {
+  it("returns zero entries when caches API is unavailable", async () => {
+    vi.stubGlobal("caches", undefined);
+    vi.stubGlobal("navigator", { ...navigator, storage: undefined });
+    const info = await getTileCacheInfo();
+    expect(info).toEqual({ entries: 0, approxBytes: null });
+  });
+
+  it("returns zero entries when the tile cache does not exist yet", async () => {
+    vi.stubGlobal("caches", makeCaches({ cacheNames: ["workbox-precache"], entryCount: 0 }));
+    vi.stubGlobal("navigator", { ...navigator, storage: undefined });
+    const info = await getTileCacheInfo();
+    expect(info.entries).toBe(0);
+  });
+
+  it("returns the key count of the ecoride tile cache", async () => {
+    vi.stubGlobal(
+      "caches",
+      makeCaches({ cacheNames: ["workbox-precache", MAP_TILE_CACHE_NAME], entryCount: 42 }),
+    );
+    vi.stubGlobal("navigator", { ...navigator, storage: undefined });
+    const info = await getTileCacheInfo();
+    expect(info.entries).toBe(42);
+  });
+
+  it("surfaces navigator.storage.estimate.usage when available", async () => {
+    vi.stubGlobal("caches", makeCaches({ cacheNames: [MAP_TILE_CACHE_NAME], entryCount: 5 }));
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      storage: { estimate: async () => ({ usage: 1_234_567, quota: 50_000_000 }) },
+    });
+    const info = await getTileCacheInfo();
+    expect(info.entries).toBe(5);
+    expect(info.approxBytes).toBe(1_234_567);
+  });
+
+  it("does not throw when caches.open rejects", async () => {
+    vi.stubGlobal("caches", {
+      keys: async () => [MAP_TILE_CACHE_NAME],
+      open: async () => {
+        throw new Error("boom");
+      },
+      delete: async () => true,
+    });
+    vi.stubGlobal("navigator", { ...navigator, storage: undefined });
+    const info = await getTileCacheInfo();
+    expect(info).toEqual({ entries: 0, approxBytes: null });
+  });
+});
+
+describe("clearTileCache", () => {
+  it("returns false when caches API is unavailable", async () => {
+    vi.stubGlobal("caches", undefined);
+    expect(await clearTileCache()).toBe(false);
+  });
+
+  it("delegates to caches.delete with the tile cache name", async () => {
+    const deleteSpy = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal("caches", {
+      keys: async () => [],
+      open: async () => ({ keys: async () => [] }),
+      delete: deleteSpy,
+    });
+    const result = await clearTileCache();
+    expect(result).toBe(true);
+    expect(deleteSpy).toHaveBeenCalledWith(MAP_TILE_CACHE_NAME);
+  });
+
+  it("returns false when caches.delete throws", async () => {
+    vi.stubGlobal("caches", {
+      keys: async () => [],
+      open: async () => ({ keys: async () => [] }),
+      delete: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(await clearTileCache()).toBe(false);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats small byte counts as bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(500)).toBe("500 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(1024 * 500)).toBe("500 KB");
+  });
+
+  it("formats megabytes with one decimal", () => {
+    expect(formatBytes(1024 * 1024 * 2.5)).toBe("2.5 MB");
+  });
+});

--- a/client/src/lib/tile-cache.ts
+++ b/client/src/lib/tile-cache.ts
@@ -1,0 +1,70 @@
+/**
+ * Offline map tile cache (feature #242).
+ *
+ * The service worker runtime cache name must stay in sync with the one
+ * declared in vite.config.ts (VitePWA.workbox.runtimeCaching[0].cacheName).
+ * Renaming it means users lose their downloaded tiles, so treat this string
+ * as part of the public storage contract.
+ */
+export const MAP_TILE_CACHE_NAME = "ecoride-map-tiles-v1";
+
+export interface TileCacheInfo {
+  /** Number of cached tile / style / sprite / glyph entries. */
+  entries: number;
+  /** Rough on-disk footprint in bytes, or null if navigator.storage.estimate is unavailable. */
+  approxBytes: number | null;
+}
+
+/**
+ * Inspect the map tile Cache Storage bucket. Returns zeros if the cache
+ * doesn't exist yet (e.g., user never opened a map). Never throws.
+ */
+export async function getTileCacheInfo(): Promise<TileCacheInfo> {
+  let entries = 0;
+  try {
+    if (typeof caches !== "undefined") {
+      const names = await caches.keys();
+      if (names.includes(MAP_TILE_CACHE_NAME)) {
+        const cache = await caches.open(MAP_TILE_CACHE_NAME);
+        const keys = await cache.keys();
+        entries = keys.length;
+      }
+    }
+  } catch {
+    // Swallow — the row just shows 0 entries.
+  }
+
+  let approxBytes: number | null = null;
+  try {
+    if (typeof navigator !== "undefined" && navigator.storage?.estimate) {
+      const estimate = await navigator.storage.estimate();
+      // The estimate covers the whole origin, not just the tile cache. It is
+      // still the most useful signal we can surface — we label it "approx".
+      approxBytes = estimate.usage ?? null;
+    }
+  } catch {
+    // Ignore — approxBytes stays null.
+  }
+
+  return { entries, approxBytes };
+}
+
+/**
+ * Delete the map tile cache. Safe to call even if the cache does not exist.
+ * Returns true if a cache was deleted.
+ */
+export async function clearTileCache(): Promise<boolean> {
+  try {
+    if (typeof caches === "undefined") return false;
+    return await caches.delete(MAP_TILE_CACHE_NAME);
+  } catch {
+    return false;
+  }
+}
+
+/** Format a byte count as a short human-readable string (KB/MB). */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { I18nProvider } from "./i18n/provider";
 import { App } from "./App";
 import { hasBlockingTripDataForUpdate } from "@/lib/update-guard";
+import { MAP_TILE_CACHE_NAME } from "@/lib/tile-cache";
 import "./app.css";
 
 // ---------------------------------------------------------------------------
@@ -43,10 +44,12 @@ window.addEventListener("unhandledrejection", (event) => {
 const CACHE_VERSION_KEY = "ecoride-version";
 const PENDING_VERSION_KEY = "ecoride-pending-version";
 
-// Purge all SW caches when app version changes
+// Purge SW caches when app version changes — except the offline map tile
+// cache (feature #242), which is expensive to rebuild and unrelated to the
+// app bundle version. Users keep their downloaded tiles across deploys.
 async function purgeAndReload() {
   const names = await caches.keys();
-  await Promise.all(names.map((n) => caches.delete(n)));
+  await Promise.all(names.filter((n) => n !== MAP_TILE_CACHE_NAME).map((n) => caches.delete(n)));
   const regs = await navigator.serviceWorker?.getRegistrations();
   if (regs) await Promise.all(regs.map((r) => r.unregister()));
   window.location.reload();

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -38,6 +38,7 @@ import { signOut } from "@/lib/auth";
 import { formatFullDate } from "@/lib/format-utils";
 import { isBleSupported, scanAndConnect } from "@/lib/super73-ble";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { MapCacheRow } from "@/components/MapCacheRow";
 import { useT } from "@/i18n/provider";
 
 const allBadgeIds = Object.keys(BADGES) as BadgeId[];
@@ -718,6 +719,10 @@ export function ProfilePage() {
                 )}
               </div>
             )}
+
+            <div className="mx-4 h-px bg-white/5" />
+
+            <MapCacheRow />
 
             <div className="mx-4 h-px bg-white/5" />
 

--- a/client/src/pages/__tests__/ProfilePage.preset.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.preset.test.tsx
@@ -106,6 +106,7 @@ vi.mock("@/hooks/usePushNotifications", () => ({
 vi.mock("@/lib/auth", () => ({ signOut: vi.fn() }));
 vi.mock("@/lib/super73-ble", () => ({ isBleSupported: () => false, scanAndConnect: vi.fn() }));
 vi.mock("@/components/LanguageSwitcher", () => ({ LanguageSwitcher: () => null }));
+vi.mock("@/components/MapCacheRow", () => ({ MapCacheRow: () => null }));
 
 describe("ProfilePage preset management", () => {
   beforeEach(() => {

--- a/client/src/pages/__tests__/ProfilePage.super73-settings.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.super73-settings.test.tsx
@@ -101,6 +101,7 @@ vi.mock("@/hooks/usePushNotifications", () => ({
 vi.mock("@/lib/auth", () => ({ signOut: vi.fn() }));
 vi.mock("@/lib/super73-ble", () => ({ isBleSupported: () => true, scanAndConnect: vi.fn() }));
 vi.mock("@/components/LanguageSwitcher", () => ({ LanguageSwitcher: () => null }));
+vi.mock("@/components/MapCacheRow", () => ({ MapCacheRow: () => null }));
 
 describe("ProfilePage Super73 settings", () => {
   beforeEach(() => {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -94,6 +94,28 @@ export default defineConfig({
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
         navigateFallbackDenylist: [/^\/api\//],
         importScripts: ["/sw-api-guard.js"],
+        // Feature #242 — passive map tile caching. Tiles and style assets
+        // already fetched by the user are stored so the map keeps rendering
+        // offline and on bad connections. No bulk prefetch (would violate
+        // the CARTO basemap ToS) — only what the user has actually loaded.
+        // The cache name is referenced from src/lib/tile-cache.ts and is
+        // preserved across version bumps in main.tsx so users don't lose
+        // their downloaded tiles on every deploy.
+        runtimeCaching: [
+          {
+            urlPattern: ({ url }) => /(^|\.)basemaps\.cartocdn\.com$/i.test(url.hostname),
+            handler: "CacheFirst",
+            options: {
+              cacheName: "ecoride-map-tiles-v1",
+              expiration: {
+                maxEntries: 400,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+                purgeOnQuotaError: true,
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
     }),
     ...sentryPlugin,


### PR DESCRIPTION
**Closes #242.**

## Summary
Adds passive service-worker caching of CARTO basemap tiles, style, glyphs and sprites so maps keep rendering offline and on bad connections. **No bulk prefetch** — only what the user has actually loaded — which keeps us within the CARTO basemap ToS.

## Implementation
- \`vite.config.ts\` — workbox \`runtimeCaching\` entry matching \`*.basemaps.cartocdn.com\` with \`CacheFirst\` strategy, 400 max entries, 30-day expiration, \`purgeOnQuotaError\`
- Cache name \`ecoride-map-tiles-v1\` exported from \`client/src/lib/tile-cache.ts\` and **preserved across app version bumps** in \`main.tsx\` — deploys no longer wipe the user's downloaded tiles
- \`tile-cache.ts\` — \`getTileCacheInfo()\` (entry count + \`navigator.storage.estimate\` usage) and \`clearTileCache()\` helpers, both null-safe
- \`MapCacheRow\` component — new "Cartes hors-ligne" / "Offline maps" row in the ProfilePage settings section, shows cached tile count and total storage, with a "Vider le cache" / "Clear cache" button and \`window.confirm\` guard
- 10 new translation keys under \`profile.mapCache.*\` in both \`fr.ts\` and \`en.ts\`
- \`client/.gitignore\` created to exclude the Playwright \`test-results/\` directory

## Tests
- **11 unit tests** for \`tile-cache\` (empty state, happy path, missing cache, error paths in \`caches.open\` and \`caches.delete\`, byte formatter, \`navigator.storage.estimate\` path)
- **3 component tests** for \`MapCacheRow\` (empty state with disabled button, full state + click clears, singular/plural forms)
- Existing \`ProfilePage.preset\` and \`ProfilePage.super73-settings\` tests mock \`MapCacheRow\` alongside their pre-existing \`LanguageSwitcher\` stub

## Not in scope (documented, out of v1)
- Bulk "download area" selection — would conflict with CARTO basemap ToS (passive caching only)
- In-map "served from cache" badge — MapLibre does not emit a reliable signal without deeper SW integration
- Cache hit-rate / stats page

## Test plan
- [x] \`bun run typecheck\` clean on both workspaces
- [x] 209/212 client tests pass (3 remaining failures are the pre-existing macOS-bun \`TripPage.*.test.tsx\` \`localStorage\` flake; green on Linux CI)
- [ ] CI green

## Manual verification (reviewer)
1. Open the app in a fresh incognito session, load the Trip or Stats map
2. Open DevTools → Application → Cache Storage → \`ecoride-map-tiles-v1\` should populate
3. Go offline, reload the page, map should still render using cached tiles
4. In Profile → Cartes hors-ligne, verify the tile count + storage estimate appear
5. Click "Vider le cache", confirm, row should return to the empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)