### PR TITLE
feat: capteur vitesse BLE (CSC) avec fallback GPS

### DIFF
--- a/client/src/components/BleSpeedSensorRow.tsx
+++ b/client/src/components/BleSpeedSensorRow.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useState } from "react";
+import { Bluetooth, BluetoothOff } from "lucide-react";
+import { useT } from "@/i18n/provider";
+import { useBleSpeedSensor } from "@/hooks/useBleSpeedSensor";
+import { isBleSpeedSensorSupported } from "@/lib/ble-speed-sensor";
+
+const WHEEL_PRESETS = [
+  { label: "27,5×2,4", value: 2215 },
+  { label: "700×25c", value: 2096 },
+  { label: "700×32c", value: 2155 },
+];
+
+/**
+ * Settings row (for ProfilePage) that lets the user pair a BLE cycling speed
+ * sensor (CSC standard) and configure the wheel circumference.
+ * Mirrors MapCacheRow in structure.
+ */
+export function BleSpeedSensorRow() {
+  const t = useT();
+  const { state, pair, disconnect, wheelCircumferenceMm, setWheelCircumferenceMm } =
+    useBleSpeedSensor();
+
+  const [inputValue, setInputValue] = useState(String(wheelCircumferenceMm));
+
+  const handlePair = useCallback(async () => {
+    await pair();
+  }, [pair]);
+
+  const handleDisconnect = useCallback(() => {
+    disconnect();
+  }, [disconnect]);
+
+  const handleWheelInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      setInputValue(raw);
+      const parsed = parseInt(raw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        setWheelCircumferenceMm(parsed);
+      }
+    },
+    [setWheelCircumferenceMm],
+  );
+
+  if (!isBleSpeedSensorSupported()) {
+    return (
+      <div className="flex w-full flex-col gap-2 p-4">
+        <div className="flex items-center gap-4">
+          <BluetoothOff size={20} className="text-text-muted" />
+          <span className="text-sm font-medium">{t("profile.bleSpeedSensor.row")}</span>
+        </div>
+        <p className="ml-9 text-xs text-text-dim">{t("vehicle.bleUnsupported.body")}</p>
+      </div>
+    );
+  }
+
+  const statusLabel =
+    state.status === "connected"
+      ? t("profile.bleSpeedSensor.statusConnected", { name: state.deviceName ?? "?" })
+      : state.status === "connecting"
+        ? t("profile.bleSpeedSensor.statusConnecting")
+        : state.status === "error"
+          ? t("profile.bleSpeedSensor.statusError")
+          : t("profile.bleSpeedSensor.statusDisconnected");
+
+  const isPairing = state.status === "connecting";
+  const isConnected = state.status === "connected";
+
+  return (
+    <div className="flex w-full flex-col gap-2 p-4">
+      <div className="flex items-center gap-4">
+        <Bluetooth size={20} className={isConnected ? "text-primary-light" : "text-text-muted"} />
+        <span className="text-sm font-medium">{t("profile.bleSpeedSensor.row")}</span>
+      </div>
+
+      <p className="ml-9 text-xs text-text-dim">{t("profile.bleSpeedSensor.description")}</p>
+
+      <div className="ml-9 flex items-center justify-between gap-3">
+        <span className="text-xs text-text-muted">{statusLabel}</span>
+
+        {isConnected ? (
+          <button
+            type="button"
+            onClick={handleDisconnect}
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-surface-high px-3 py-2 text-xs font-bold text-text-muted active:scale-95"
+          >
+            <BluetoothOff size={14} />
+            {t("profile.bleSpeedSensor.disconnect")}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handlePair}
+            disabled={isPairing}
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-surface-high px-3 py-2 text-xs font-bold text-text-muted active:scale-95 disabled:opacity-50"
+          >
+            <Bluetooth size={14} />
+            {isPairing ? t("profile.bleSpeedSensor.pairing") : t("profile.bleSpeedSensor.pair")}
+          </button>
+        )}
+      </div>
+
+      {/* Wheel circumference */}
+      <div className="ml-9 mt-2 flex flex-col gap-1">
+        <label className="text-xs font-medium text-text-muted">
+          {t("profile.bleSpeedSensor.wheelCircumference")}
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={500}
+            max={4000}
+            value={inputValue}
+            onChange={handleWheelInput}
+            className="w-24 rounded-lg bg-surface-high px-3 py-2 text-xs font-mono text-text focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <div className="flex gap-1">
+            {WHEEL_PRESETS.map((preset) => (
+              <button
+                key={preset.value}
+                type="button"
+                onClick={() => {
+                  setInputValue(String(preset.value));
+                  setWheelCircumferenceMm(preset.value);
+                }}
+                className={`rounded px-2 py-1 text-xs font-bold ${
+                  wheelCircumferenceMm === preset.value
+                    ? "bg-primary text-white"
+                    : "bg-surface-high text-text-muted"
+                } active:scale-95`}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <p className="text-xs text-text-dim">
+          {t("profile.bleSpeedSensor.wheelCircumferenceHelp")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { AnimatedOutlet } from "./AnimatedOutlet";
 import { Super73Provider } from "@/components/Super73Provider";
 import { PullToRefresh } from "@/components/ui/PullToRefresh";
 import { GpsTrackingProvider } from "@/hooks/useGpsTracking";
+import { BleSpeedSensorProvider } from "@/hooks/useBleSpeedSensor";
 import { useOfflineSync } from "@/hooks/useOfflineSync";
 import { useSwipeNavigation } from "@/hooks/useSwipeNavigation";
 
@@ -21,26 +22,28 @@ export function AppShell() {
 
   return (
     <GpsTrackingProvider>
-      <Super73Provider>
-        <div
-          className="flex h-full flex-col bg-bg pt-[env(safe-area-inset-top)]"
-          onTouchStart={swipe.onTouchStart}
-          onTouchMove={swipe.onTouchMove}
-          onTouchEnd={swipe.onTouchEnd}
-        >
-          <main className="flex-1 overflow-hidden pb-24">
-            <PullToRefresh onRefresh={handleRefresh} scrollKey={location.pathname}>
-              <AnimatedOutlet
-                dragX={swipe.dragX}
-                direction={swipe.direction}
-                isAnimating={swipe.isAnimating}
-                onAnimationDone={swipe.onAnimationDone}
-              />
-            </PullToRefresh>
-          </main>
-          <BottomNav />
-        </div>
-      </Super73Provider>
+      <BleSpeedSensorProvider>
+        <Super73Provider>
+          <div
+            className="flex h-full flex-col bg-bg pt-[env(safe-area-inset-top)]"
+            onTouchStart={swipe.onTouchStart}
+            onTouchMove={swipe.onTouchMove}
+            onTouchEnd={swipe.onTouchEnd}
+          >
+            <main className="flex-1 overflow-hidden pb-24">
+              <PullToRefresh onRefresh={handleRefresh} scrollKey={location.pathname}>
+                <AnimatedOutlet
+                  dragX={swipe.dragX}
+                  direction={swipe.direction}
+                  isAnimating={swipe.isAnimating}
+                  onAnimationDone={swipe.onAnimationDone}
+                />
+              </PullToRefresh>
+            </main>
+            <BottomNav />
+          </div>
+        </Super73Provider>
+      </BleSpeedSensorProvider>
     </GpsTrackingProvider>
   );
 }

--- a/client/src/components/trip/TrackingDashboard.tsx
+++ b/client/src/components/trip/TrackingDashboard.tsx
@@ -3,6 +3,7 @@ import { useT } from "@/i18n/provider";
 export interface TrackingDashboardProps {
   isPaused: boolean;
   speedKmh: number | null;
+  bleSpeedKmh: number | null;
   distance: number;
   co2Saved: number;
   elapsed: number;
@@ -12,12 +13,16 @@ export interface TrackingDashboardProps {
 export function TrackingDashboard({
   isPaused,
   speedKmh,
+  bleSpeedKmh,
   distance,
   co2Saved,
   elapsed,
   formatTime,
 }: TrackingDashboardProps) {
   const t = useT();
+  const displaySpeedKmh = bleSpeedKmh ?? speedKmh;
+  const speedSource = bleSpeedKmh != null ? "sensor" : "gps";
+
   return (
     <>
       {/* Speed — hero central */}
@@ -31,12 +36,17 @@ export function TrackingDashboard({
           </span>
         ) : (
           <span className="text-7xl font-black tracking-tighter text-text">
-            {speedKmh != null ? speedKmh.toFixed(0) : "—"}
+            {displaySpeedKmh != null ? displaySpeedKmh.toFixed(0) : "—"}
           </span>
         )}
         <span className="text-sm font-bold uppercase tracking-widest text-text-dim">
           {isPaused ? t("trip.dashboard.pausedUnit") : t("trip.dashboard.speedUnit")}
         </span>
+        {!isPaused && (
+          <span className="mt-1 rounded-full bg-surface-high px-2 py-0.5 text-xs font-bold uppercase tracking-wider text-text-dim">
+            {speedSource === "sensor" ? t("trip.speedSource.sensor") : t("trip.speedSource.gps")}
+          </span>
+        )}
       </div>
 
       {/* Distance / CO₂ / Temps — row */}

--- a/client/src/components/trip/__tests__/TrackingDashboard.test.tsx
+++ b/client/src/components/trip/__tests__/TrackingDashboard.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TrackingDashboard } from "../TrackingDashboard";
+import { I18nProvider } from "@/i18n/provider";
+
+const formatTime = (s: number) => `${s}s`;
+
+const renderWithI18n = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
+
+beforeEach(() => {
+  vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+});
+
+const baseProps = {
+  isPaused: false,
+  speedKmh: null,
+  bleSpeedKmh: null,
+  distance: 0,
+  co2Saved: 0,
+  elapsed: 0,
+  formatTime,
+};
+
+describe("TrackingDashboard — speed source badge", () => {
+  it("shows GPS badge when bleSpeedKmh is null", () => {
+    renderWithI18n(<TrackingDashboard {...baseProps} speedKmh={30} bleSpeedKmh={null} />);
+    expect(screen.getByText("GPS")).toBeTruthy();
+    expect(screen.getByText("30")).toBeTruthy();
+  });
+
+  it("shows Capteur badge and BLE speed when bleSpeedKmh is provided", () => {
+    renderWithI18n(<TrackingDashboard {...baseProps} speedKmh={30} bleSpeedKmh={25} />);
+    expect(screen.getByText("Capteur")).toBeTruthy();
+    // displayed speed should be BLE (25), not GPS (30)
+    expect(screen.getByText("25")).toBeTruthy();
+    expect(screen.queryByText("30")).toBeNull();
+  });
+
+  it("falls back to GPS speed when bleSpeedKmh is null", () => {
+    renderWithI18n(<TrackingDashboard {...baseProps} speedKmh={42} bleSpeedKmh={null} />);
+    expect(screen.getByText("42")).toBeTruthy();
+    expect(screen.getByText("GPS")).toBeTruthy();
+  });
+
+  it("does not show source badge when paused", () => {
+    renderWithI18n(<TrackingDashboard {...baseProps} isPaused speedKmh={20} bleSpeedKmh={15} />);
+    expect(screen.queryByText("GPS")).toBeNull();
+    expect(screen.queryByText("Capteur")).toBeNull();
+  });
+});

--- a/client/src/hooks/__tests__/useBleSpeedSensor.test.tsx
+++ b/client/src/hooks/__tests__/useBleSpeedSensor.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { BleSpeedSensorProvider, useBleSpeedSensor } from "../useBleSpeedSensor";
+
+// ---- Mocks ----
+
+const scanAndConnectMock = vi.fn();
+const reconnectPairedMock = vi.fn();
+const subscribeSpeedMock = vi.fn();
+const clearSelectedMock = vi.fn();
+
+vi.mock("@/lib/ble-speed-sensor", () => ({
+  isBleSpeedSensorSupported: () => true,
+  scanAndConnectSpeedSensor: (...args: unknown[]) => scanAndConnectMock(...args),
+  reconnectPairedSpeedSensor: (...args: unknown[]) => reconnectPairedMock(...args),
+  subscribeSpeedSensor: (...args: unknown[]) => subscribeSpeedMock(...args),
+  clearSelectedDeviceId: () => clearSelectedMock(),
+}));
+
+function makeLocalStorageStub() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const k in store) delete store[k];
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+function buildDevice(name = "TestSensor"): BluetoothDevice {
+  return {
+    id: "sensor-001",
+    name,
+    gatt: {
+      connected: true,
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as BluetoothDevice;
+}
+
+// Consumer component that exposes state via data attributes for querying
+function Consumer() {
+  const sensor = useBleSpeedSensor();
+  return (
+    <div>
+      <span data-testid="status">{sensor.state.status}</span>
+      <span data-testid="speed">{sensor.state.speedKmh ?? "null"}</span>
+      <span data-testid="cadence">{sensor.state.cadenceRpm ?? "null"}</span>
+      <span data-testid="device">{sensor.state.deviceName ?? "null"}</span>
+      <button data-testid="pair" onClick={() => sensor.pair()}>
+        Pair
+      </button>
+      <button data-testid="disconnect" onClick={() => sensor.disconnect()}>
+        Disconnect
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <BleSpeedSensorProvider>
+      <Consumer />
+    </BleSpeedSensorProvider>,
+  );
+}
+
+describe("BleSpeedSensorProvider", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageStub());
+    // Default: no paired device on mount
+    reconnectPairedMock.mockResolvedValue(null);
+    // Default unsubscribe function
+    subscribeSpeedMock.mockResolvedValue(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("starts disconnected", async () => {
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("disconnected");
+    });
+  });
+
+  it("pair() goes to connected and shows device name", async () => {
+    const device = buildDevice("MyCscSensor");
+    scanAndConnectMock.mockResolvedValue(device);
+
+    renderWithProvider();
+
+    await act(async () => {
+      screen.getByTestId("pair").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("connected");
+      expect(screen.getByTestId("device").textContent).toBe("MyCscSensor");
+    });
+  });
+
+  it("pair() emits speed via onSample callback", async () => {
+    const device = buildDevice();
+    scanAndConnectMock.mockResolvedValue(device);
+
+    let capturedOnSample: ((r: { speedKmh: number; cadenceRpm: number | null }) => void) | null =
+      null;
+
+    subscribeSpeedMock.mockImplementation(
+      (
+        _server: unknown,
+        onSample: (r: { speedKmh: number; cadenceRpm: number | null }) => void,
+      ) => {
+        capturedOnSample = onSample;
+        return Promise.resolve(() => {});
+      },
+    );
+
+    renderWithProvider();
+
+    await act(async () => {
+      screen.getByTestId("pair").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("connected");
+    });
+
+    // Simulate an incoming speed sample
+    await act(async () => {
+      capturedOnSample!({ speedKmh: 25.4, cadenceRpm: null });
+    });
+
+    expect(screen.getByTestId("speed").textContent).toBe("25.4");
+  });
+
+  it("gattserverdisconnected clears speed and goes to disconnected", async () => {
+    const device = buildDevice();
+    const listeners: Record<string, EventListener> = {};
+    device.addEventListener = vi.fn((event: string, listener: EventListener) => {
+      listeners[event] = listener;
+    });
+    device.removeEventListener = vi.fn();
+
+    let capturedOnSample: ((r: { speedKmh: number; cadenceRpm: number | null }) => void) | null =
+      null;
+
+    scanAndConnectMock.mockResolvedValue(device);
+    subscribeSpeedMock.mockImplementation(
+      (
+        _server: unknown,
+        onSample: (r: { speedKmh: number; cadenceRpm: number | null }) => void,
+      ) => {
+        capturedOnSample = onSample;
+        return Promise.resolve(() => {});
+      },
+    );
+
+    renderWithProvider();
+
+    await act(async () => {
+      screen.getByTestId("pair").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("connected");
+    });
+
+    // Inject a speed reading
+    await act(async () => {
+      capturedOnSample!({ speedKmh: 18, cadenceRpm: null });
+    });
+
+    expect(screen.getByTestId("speed").textContent).toBe("18");
+
+    // Simulate disconnect event
+    await act(async () => {
+      listeners["gattserverdisconnected"]?.(new Event("gattserverdisconnected"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("speed").textContent).toBe("null");
+    });
+  });
+
+  it("disconnect() clears device and goes to disconnected", async () => {
+    const device = buildDevice();
+    scanAndConnectMock.mockResolvedValue(device);
+
+    renderWithProvider();
+
+    await act(async () => {
+      screen.getByTestId("pair").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("connected");
+    });
+
+    await act(async () => {
+      screen.getByTestId("disconnect").click();
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("disconnected");
+    expect(screen.getByTestId("device").textContent).toBe("null");
+    expect(clearSelectedMock).toHaveBeenCalled();
+  });
+
+  it("pair() cancelled by user stays disconnected", async () => {
+    scanAndConnectMock.mockRejectedValue(new Error("User cancelled the requestDevice() chooser"));
+
+    renderWithProvider();
+
+    await act(async () => {
+      screen.getByTestId("pair").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("disconnected");
+    });
+  });
+});

--- a/client/src/hooks/useBleSpeedSensor.ts
+++ b/client/src/hooks/useBleSpeedSensor.ts
@@ -1,0 +1,291 @@
+import {
+  createContext,
+  createElement,
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  useContext,
+  type ReactNode,
+} from "react";
+import {
+  isBleSpeedSensorSupported,
+  scanAndConnectSpeedSensor,
+  reconnectPairedSpeedSensor,
+  subscribeSpeedSensor,
+  clearSelectedDeviceId,
+} from "@/lib/ble-speed-sensor";
+
+// ---- Types ----
+
+export type BleSpeedSensorStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "unsupported"
+  | "error";
+
+export interface BleSpeedSensorState {
+  status: BleSpeedSensorStatus;
+  speedKmh: number | null;
+  cadenceRpm: number | null;
+  deviceName: string | null;
+  error: string | null;
+}
+
+export interface UseBleSpeedSensorResult {
+  state: BleSpeedSensorState;
+  pair: () => Promise<void>;
+  disconnect: () => void;
+  wheelCircumferenceMm: number;
+  setWheelCircumferenceMm: (mm: number) => void;
+}
+
+// ---- Constants ----
+
+const WHEEL_MM_KEY = "ecoride-ble-wheel-mm";
+// 27.5" × 2.4 (Super73) — fits most cargo/comfort bikes
+const DEFAULT_WHEEL_MM = 2215;
+const RECONNECT_DELAY = 2_000;
+// If no notification arrives within this window, clear displayed speed
+// (sensor goes to sleep at standstill, we should not freeze the last reading)
+const STALE_TIMEOUT_MS = 3_500;
+
+// ---- localStorage helpers ----
+
+function loadWheelMm(): number {
+  try {
+    const raw = localStorage.getItem(WHEEL_MM_KEY);
+    const parsed = raw !== null ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_WHEEL_MM;
+  } catch {
+    return DEFAULT_WHEEL_MM;
+  }
+}
+
+function saveWheelMm(mm: number): void {
+  try {
+    localStorage.setItem(WHEEL_MM_KEY, String(mm));
+  } catch {
+    // ignore
+  }
+}
+
+// ---- Context ----
+
+const NOOP_RESULT: UseBleSpeedSensorResult = {
+  state: {
+    status: "unsupported",
+    speedKmh: null,
+    cadenceRpm: null,
+    deviceName: null,
+    error: null,
+  },
+  pair: async () => {},
+  disconnect: () => {},
+  wheelCircumferenceMm: DEFAULT_WHEEL_MM,
+  setWheelCircumferenceMm: () => {},
+};
+
+const BleSpeedSensorContext = createContext<UseBleSpeedSensorResult>(NOOP_RESULT);
+
+// ---- Controller ----
+
+function useBleSpeedSensorController(): UseBleSpeedSensorResult {
+  const [status, setStatus] = useState<BleSpeedSensorStatus>(() =>
+    isBleSpeedSensorSupported() ? "disconnected" : "unsupported",
+  );
+  const [speedKmh, setSpeedKmh] = useState<number | null>(null);
+  const [cadenceRpm, setCadenceRpm] = useState<number | null>(null);
+  const [deviceName, setDeviceName] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [wheelCircumferenceMm, setWheelCircumferenceMmState] = useState<number>(loadWheelMm);
+
+  const deviceRef = useRef<BluetoothDevice | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const manualDisconnectRef = useRef(false);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const staleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keep a ref so the stale-timeout closure always sees the latest value
+  const wheelMmRef = useRef(wheelCircumferenceMm);
+  wheelMmRef.current = wheelCircumferenceMm;
+
+  const clearStaleTimer = useCallback(() => {
+    if (staleTimerRef.current !== null) {
+      clearTimeout(staleTimerRef.current);
+      staleTimerRef.current = null;
+    }
+  }, []);
+
+  const resetStaleTimer = useCallback(() => {
+    clearStaleTimer();
+    staleTimerRef.current = setTimeout(() => {
+      setSpeedKmh(null);
+      setCadenceRpm(null);
+    }, STALE_TIMEOUT_MS);
+  }, [clearStaleTimer]);
+
+  const stopSubscription = useCallback(() => {
+    if (unsubscribeRef.current) {
+      unsubscribeRef.current();
+      unsubscribeRef.current = null;
+    }
+    clearStaleTimer();
+  }, [clearStaleTimer]);
+
+  const attachDevice = useCallback(
+    async (device: BluetoothDevice) => {
+      deviceRef.current = device;
+      manualDisconnectRef.current = false;
+      setDeviceName(device.name ?? null);
+
+      const server = device.gatt!;
+      const unsub = await subscribeSpeedSensor(
+        server,
+        (sample) => {
+          setSpeedKmh(sample.speedKmh);
+          setCadenceRpm(sample.cadenceRpm);
+          resetStaleTimer();
+        },
+        wheelMmRef.current,
+      );
+
+      unsubscribeRef.current = unsub;
+      setStatus("connected");
+      setError(null);
+    },
+    [resetStaleTimer],
+  );
+
+  const tryReconnect = useCallback(async () => {
+    if (manualDisconnectRef.current) {
+      setStatus("disconnected");
+      return;
+    }
+    setStatus("connecting");
+    try {
+      const device = await reconnectPairedSpeedSensor();
+      if (device) {
+        await attachDevice(device);
+      } else {
+        setStatus("disconnected");
+      }
+    } catch {
+      setStatus("disconnected");
+    }
+  }, [attachDevice]);
+
+  const onDisconnected = useCallback(() => {
+    stopSubscription();
+    setSpeedKmh(null);
+    setCadenceRpm(null);
+    if (manualDisconnectRef.current) {
+      setStatus("disconnected");
+      return;
+    }
+    reconnectTimerRef.current = setTimeout(tryReconnect, RECONNECT_DELAY);
+  }, [tryReconnect, stopSubscription]);
+
+  // Attach disconnect listener whenever the device or status changes
+  useEffect(() => {
+    const device = deviceRef.current;
+    if (!device) return;
+    device.addEventListener("gattserverdisconnected", onDisconnected);
+    return () => {
+      device.removeEventListener("gattserverdisconnected", onDisconnected);
+    };
+  }, [status, onDisconnected]);
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      clearStaleTimer();
+    };
+  }, [clearStaleTimer]);
+
+  // Auto-reconnect on mount if a device was previously paired
+  useEffect(() => {
+    if (!isBleSpeedSensorSupported()) return;
+    if (status !== "disconnected") return;
+    if (deviceRef.current) return;
+
+    let cancelled = false;
+    void (async () => {
+      const device = await reconnectPairedSpeedSensor();
+      if (cancelled || !device) return;
+      setStatus("connecting");
+      try {
+        await attachDevice(device);
+      } catch {
+        setStatus("disconnected");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const pair = useCallback(async () => {
+    if (!isBleSpeedSensorSupported()) return;
+    setStatus("connecting");
+    setError(null);
+    try {
+      const device = await scanAndConnectSpeedSensor();
+      await attachDevice(device);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Connexion échouée";
+      if (msg.includes("cancelled") || msg.includes("NotFoundError")) {
+        setStatus("disconnected");
+      } else {
+        setError(msg);
+        setStatus("error");
+      }
+    }
+  }, [attachDevice]);
+
+  const disconnect = useCallback(() => {
+    manualDisconnectRef.current = true;
+    if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+    stopSubscription();
+    clearSelectedDeviceId();
+    if (deviceRef.current) {
+      deviceRef.current.gatt?.disconnect();
+      deviceRef.current = null;
+    }
+    setSpeedKmh(null);
+    setCadenceRpm(null);
+    setDeviceName(null);
+    setStatus("disconnected");
+  }, [stopSubscription]);
+
+  const setWheelCircumferenceMm = useCallback((mm: number) => {
+    setWheelCircumferenceMmState(mm);
+    saveWheelMm(mm);
+  }, []);
+
+  if (!isBleSpeedSensorSupported()) return NOOP_RESULT;
+
+  return {
+    state: { status, speedKmh, cadenceRpm, deviceName, error },
+    pair,
+    disconnect,
+    wheelCircumferenceMm,
+    setWheelCircumferenceMm,
+  };
+}
+
+// ---- Provider ----
+
+export function BleSpeedSensorProvider({ children }: { children: ReactNode }) {
+  const value = useBleSpeedSensorController();
+  return createElement(BleSpeedSensorContext.Provider, { value }, children);
+}
+
+// ---- Hook ----
+
+export function useBleSpeedSensor(): UseBleSpeedSensorResult {
+  return useContext(BleSpeedSensorContext);
+}

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -518,4 +518,21 @@ export const en: Record<TranslationKey, string> = {
   "super73.full.disconnected": "Disconnected",
   "super73.full.disconnect": "Disconnect",
   "super73.full.connect": "Connect",
+
+  "profile.bleSpeedSensor.row": "BLE Speed Sensor",
+  "profile.bleSpeedSensor.description":
+    "Use a Bluetooth speed sensor (CSC) instead of GPS speed during your trips.",
+  "profile.bleSpeedSensor.pair": "Pair a sensor",
+  "profile.bleSpeedSensor.pairing": "Connecting…",
+  "profile.bleSpeedSensor.disconnect": "Disconnect",
+  "profile.bleSpeedSensor.statusConnected": "Connected — {{name}}",
+  "profile.bleSpeedSensor.statusDisconnected": "No sensor connected",
+  "profile.bleSpeedSensor.statusConnecting": "Connecting…",
+  "profile.bleSpeedSensor.statusError": "Connection error",
+  "profile.bleSpeedSensor.wheelCircumference": "Wheel circumference (mm)",
+  "profile.bleSpeedSensor.wheelCircumferenceHelp":
+    "Measure the wheel perimeter or use a preset: 2215 (27.5×2.4), 2096 (700×25c), 2155 (700×32c).",
+
+  "trip.speedSource.gps": "GPS",
+  "trip.speedSource.sensor": "Sensor",
 };

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -521,6 +521,23 @@ export const fr = {
   "super73.full.disconnected": "Déconnecté",
   "super73.full.disconnect": "Déconnecter",
   "super73.full.connect": "Connecter",
+
+  "profile.bleSpeedSensor.row": "Capteur de vitesse BLE",
+  "profile.bleSpeedSensor.description":
+    "Utilisez un capteur de vitesse Bluetooth (CSC) à la place du GPS pendant vos trajets.",
+  "profile.bleSpeedSensor.pair": "Appairer un capteur",
+  "profile.bleSpeedSensor.pairing": "Connexion...",
+  "profile.bleSpeedSensor.disconnect": "Déconnecter",
+  "profile.bleSpeedSensor.statusConnected": "Connecté — {{name}}",
+  "profile.bleSpeedSensor.statusDisconnected": "Aucun capteur connecté",
+  "profile.bleSpeedSensor.statusConnecting": "Connexion en cours...",
+  "profile.bleSpeedSensor.statusError": "Erreur de connexion",
+  "profile.bleSpeedSensor.wheelCircumference": "Circonférence de roue (mm)",
+  "profile.bleSpeedSensor.wheelCircumferenceHelp":
+    "Mesurez le périmètre de la roue ou utilisez un preset : 2215 (27,5×2,4), 2096 (700×25c), 2155 (700×32c).",
+
+  "trip.speedSource.gps": "GPS",
+  "trip.speedSource.sensor": "Capteur",
 } as const;
 
 export type TranslationKey = keyof typeof fr;

--- a/client/src/lib/__tests__/ble-speed-sensor.test.ts
+++ b/client/src/lib/__tests__/ble-speed-sensor.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { parseCscMeasurement, computeCscSpeed, type CscSample } from "../ble-speed-sensor";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseCscMeasurement,
+  computeCscSpeed,
+  isBleSpeedSensorSupported,
+  scanAndConnectSpeedSensor,
+  reconnectPairedSpeedSensor,
+  subscribeSpeedSensor,
+  clearSelectedDeviceId,
+  type CscSample,
+} from "../ble-speed-sensor";
 
 // Helper: build a DataView for CSC Measurement bytes
 function makeDataView(bytes: number[]): DataView {
@@ -204,5 +213,204 @@ describe("computeCscSpeed", () => {
     const result = computeCscSpeed(prev, curr, WHEEL_MM_700C);
     // 2.096 m/s × 3.6 = 7.546 km/h
     expect(result.speedKmh).toBeCloseTo(7.546, 1);
+  });
+});
+
+// ---- BLE operations (mocked navigator.bluetooth) ----
+
+function makeLocalStorageStub() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const k in store) delete store[k];
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe("isBleSpeedSensorSupported", () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(navigator, "bluetooth");
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(navigator, "bluetooth", originalDescriptor);
+    } else {
+      delete (navigator as Record<string, unknown>)["bluetooth"];
+    }
+  });
+
+  it("returns true when navigator.bluetooth exists", () => {
+    Object.defineProperty(navigator, "bluetooth", { value: {}, configurable: true });
+    expect(isBleSpeedSensorSupported()).toBe(true);
+  });
+
+  it("returns false when navigator.bluetooth is absent", () => {
+    delete (navigator as Record<string, unknown>)["bluetooth"];
+    expect(isBleSpeedSensorSupported()).toBe(false);
+  });
+});
+
+describe("clearSelectedDeviceId", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageStub());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("removes the stored device id from localStorage", () => {
+    localStorage.setItem("ecoride-ble-speed-device-id", "sensor-001");
+    clearSelectedDeviceId();
+    expect(localStorage.removeItem).toHaveBeenCalledWith("ecoride-ble-speed-device-id");
+  });
+});
+
+describe("scanAndConnectSpeedSensor", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageStub());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requests device with CSC service filter, connects, and saves device id", async () => {
+    const gatt = { connect: vi.fn().mockResolvedValue(undefined) };
+    const device = { id: "sensor-001", gatt } as BluetoothDevice;
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { requestDevice: vi.fn().mockResolvedValue(device) },
+      configurable: true,
+    });
+
+    const result = await scanAndConnectSpeedSensor();
+
+    expect(result).toBe(device);
+    expect(navigator.bluetooth.requestDevice).toHaveBeenCalledWith({
+      filters: [{ services: [0x1816] }],
+    });
+    expect(gatt.connect).toHaveBeenCalled();
+    expect(localStorage.setItem).toHaveBeenCalledWith("ecoride-ble-speed-device-id", "sensor-001");
+  });
+
+  it("throws when GATT is not available", async () => {
+    const device = { id: "sensor-001", gatt: null };
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { requestDevice: vi.fn().mockResolvedValue(device) },
+      configurable: true,
+    });
+
+    await expect(scanAndConnectSpeedSensor()).rejects.toThrow("GATT not available");
+  });
+});
+
+describe("reconnectPairedSpeedSensor", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageStub());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when getDevices is unavailable", async () => {
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { requestDevice: vi.fn() },
+      configurable: true,
+    });
+    expect(await reconnectPairedSpeedSensor()).toBeNull();
+  });
+
+  it("reconnects to the stored preferred device id", async () => {
+    const gatt = { connect: vi.fn().mockResolvedValue(undefined) };
+    const device = { id: "sensor-001", name: "XOSS Speed", gatt };
+    localStorage.setItem("ecoride-ble-speed-device-id", "sensor-001");
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { getDevices: vi.fn().mockResolvedValue([device]) },
+      configurable: true,
+    });
+
+    const result = await reconnectPairedSpeedSensor();
+    expect(result).toBe(device);
+    expect(gatt.connect).toHaveBeenCalled();
+  });
+
+  it("returns null when no preferred device found and no fallback", async () => {
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { getDevices: vi.fn().mockResolvedValue([]) },
+      configurable: true,
+    });
+    expect(await reconnectPairedSpeedSensor()).toBeNull();
+  });
+
+  it("returns null when preferred device id is not in paired list", async () => {
+    localStorage.setItem("ecoride-ble-speed-device-id", "sensor-999");
+    const other = { id: "sensor-001", name: "Other", gatt: { connect: vi.fn() } };
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { getDevices: vi.fn().mockResolvedValue([other]) },
+      configurable: true,
+    });
+
+    expect(await reconnectPairedSpeedSensor()).toBeNull();
+    expect(other.gatt.connect).not.toHaveBeenCalled();
+  });
+
+  it("returns null when connect fails (device out of range)", async () => {
+    const gatt = { connect: vi.fn().mockRejectedValue(new Error("connection failed")) };
+    const device = { id: "sensor-001", name: "Wahoo Speed", gatt };
+    localStorage.setItem("ecoride-ble-speed-device-id", "sensor-001");
+    Object.defineProperty(navigator, "bluetooth", {
+      value: { getDevices: vi.fn().mockResolvedValue([device]) },
+      configurable: true,
+    });
+
+    expect(await reconnectPairedSpeedSensor()).toBeNull();
+  });
+});
+
+describe("subscribeSpeedSensor", () => {
+  it("starts notifications and calls onSample with computed speed", async () => {
+    const wheelMm = 2215;
+    const onSample = vi.fn();
+
+    let notifyHandler: ((e: Event) => void) | null = null;
+    const char = {
+      addEventListener: vi.fn((_: string, h: (e: Event) => void) => {
+        notifyHandler = h;
+      }),
+      removeEventListener: vi.fn(),
+      startNotifications: vi.fn().mockResolvedValue(undefined),
+      stopNotifications: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = { getCharacteristic: vi.fn().mockResolvedValue(char) };
+    const server = {
+      getPrimaryService: vi.fn().mockResolvedValue(service),
+    } as unknown as BluetoothRemoteGATTServer;
+
+    const unsub = await subscribeSpeedSensor(server, onSample, wheelMm);
+
+    // First notification: establishes prevSample, no output
+    const payload1 = new DataView(new Uint8Array(wheelOnlyPayload(0, 0)).buffer);
+    notifyHandler!({ target: { value: payload1 } } as unknown as Event);
+    expect(onSample).not.toHaveBeenCalled();
+
+    // Second notification: 1 rev in 1024 ticks (1 s) → ~7.974 km/h
+    const payload2 = new DataView(new Uint8Array(wheelOnlyPayload(1, 1024)).buffer);
+    notifyHandler!({ target: { value: payload2 } } as unknown as Event);
+    expect(onSample).toHaveBeenCalledOnce();
+    expect(onSample.mock.calls[0][0].speedKmh).toBeCloseTo(7.974, 1);
+
+    // Unsubscribe cleans up
+    unsub();
+    expect(char.removeEventListener).toHaveBeenCalled();
   });
 });

--- a/client/src/lib/__tests__/ble-speed-sensor.test.ts
+++ b/client/src/lib/__tests__/ble-speed-sensor.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { parseCscMeasurement, computeCscSpeed, type CscSample } from "../ble-speed-sensor";
+
+// Helper: build a DataView for CSC Measurement bytes
+function makeDataView(bytes: number[]): DataView {
+  return new DataView(new Uint8Array(bytes).buffer);
+}
+
+// Helper: build a CSC Measurement with wheel data
+// flags=0x01 (wheel only), wheelRevs (uint32 LE), wheelEventTime (uint16 LE)
+function wheelOnlyPayload(wheelRevs: number, wheelEventTime: number): number[] {
+  const buf = new Uint8Array(7);
+  buf[0] = 0x01; // flags: wheel data present
+  // uint32 LE wheel revs
+  buf[1] = (wheelRevs >>> 0) & 0xff;
+  buf[2] = (wheelRevs >>> 8) & 0xff;
+  buf[3] = (wheelRevs >>> 16) & 0xff;
+  buf[4] = (wheelRevs >>> 24) & 0xff;
+  // uint16 LE wheel event time
+  buf[5] = wheelEventTime & 0xff;
+  buf[6] = (wheelEventTime >>> 8) & 0xff;
+  return Array.from(buf);
+}
+
+// Helper: CSC Measurement with wheel + crank data
+function wheelAndCrankPayload(
+  wheelRevs: number,
+  wheelEventTime: number,
+  crankRevs: number,
+  crankEventTime: number,
+): number[] {
+  const buf = new Uint8Array(11);
+  buf[0] = 0x03; // flags: wheel + crank
+  buf[1] = (wheelRevs >>> 0) & 0xff;
+  buf[2] = (wheelRevs >>> 8) & 0xff;
+  buf[3] = (wheelRevs >>> 16) & 0xff;
+  buf[4] = (wheelRevs >>> 24) & 0xff;
+  buf[5] = wheelEventTime & 0xff;
+  buf[6] = (wheelEventTime >>> 8) & 0xff;
+  buf[7] = crankRevs & 0xff;
+  buf[8] = (crankRevs >>> 8) & 0xff;
+  buf[9] = crankEventTime & 0xff;
+  buf[10] = (crankEventTime >>> 8) & 0xff;
+  return Array.from(buf);
+}
+
+describe("parseCscMeasurement", () => {
+  it("returns null for empty buffer", () => {
+    expect(parseCscMeasurement(makeDataView([]))).toBeNull();
+  });
+
+  it("returns null when wheel flag is not set (crank only)", () => {
+    // flags = 0x02 (only crank bit set)
+    const payload = [0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    expect(parseCscMeasurement(makeDataView(payload))).toBeNull();
+  });
+
+  it("returns null when wheel flag set but buffer too short", () => {
+    const payload = [0x01, 0, 0]; // only 3 bytes, need at least 7
+    expect(parseCscMeasurement(makeDataView(payload))).toBeNull();
+  });
+
+  it("parses wheel-only frame", () => {
+    const dv = makeDataView(wheelOnlyPayload(100, 2048));
+    const sample = parseCscMeasurement(dv);
+    expect(sample).not.toBeNull();
+    expect(sample!.wheelRevs).toBe(100);
+    expect(sample!.wheelEventTime).toBe(2048);
+    expect(sample!.crankRevs).toBeNull();
+    expect(sample!.crankEventTime).toBeNull();
+  });
+
+  it("parses wheel + crank frame", () => {
+    const dv = makeDataView(wheelAndCrankPayload(200, 4096, 50, 1024));
+    const sample = parseCscMeasurement(dv);
+    expect(sample).not.toBeNull();
+    expect(sample!.wheelRevs).toBe(200);
+    expect(sample!.wheelEventTime).toBe(4096);
+    expect(sample!.crankRevs).toBe(50);
+    expect(sample!.crankEventTime).toBe(1024);
+  });
+});
+
+describe("computeCscSpeed", () => {
+  const WHEEL_MM = 2215; // Super73 27.5×2.4
+
+  it("computes speed for 1 rev/s = 2.215 m/s = 7.974 km/h", () => {
+    const prev: CscSample = {
+      wheelRevs: 0,
+      wheelEventTime: 0,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 1,
+      wheelEventTime: 1024,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM);
+    // 1 rev × 2215 mm = 2.215 m in 1 s → 7.974 km/h
+    expect(result.speedKmh).toBeCloseTo(7.974, 2);
+    expect(result.cadenceRpm).toBeNull();
+  });
+
+  it("returns speedKmh=0 when Δtime is 0", () => {
+    const prev: CscSample = {
+      wheelRevs: 10,
+      wheelEventTime: 500,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 12,
+      wheelEventTime: 500,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM);
+    expect(result.speedKmh).toBe(0);
+  });
+
+  it("returns speedKmh=0 when Δrev is 0 (stationary)", () => {
+    const prev: CscSample = {
+      wheelRevs: 10,
+      wheelEventTime: 500,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 10,
+      wheelEventTime: 600,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM);
+    expect(result.speedKmh).toBe(0);
+  });
+
+  it("handles 16-bit timestamp wraparound", () => {
+    // t1=65000, t2=100 → Δtime = (100 - 65000 + 65536) % 65536 = 636 ticks = 0.621 s
+    const prev: CscSample = {
+      wheelRevs: 0,
+      wheelEventTime: 65000,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 1,
+      wheelEventTime: 100,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM);
+    // 2.215 m / 0.6211 s → 12.842 km/h
+    const deltaTimeSec = 636 / 1024;
+    const expected = (2215 / 1_000_000 / deltaTimeSec) * 3600;
+    expect(result.speedKmh).toBeCloseTo(expected, 1);
+  });
+
+  it("computes cadence from crank data", () => {
+    // Δcrank = 1 rev, Δtime = 1024 ticks (1 s) → 60 rpm
+    const prev: CscSample = { wheelRevs: 0, wheelEventTime: 0, crankRevs: 0, crankEventTime: 0 };
+    const curr: CscSample = {
+      wheelRevs: 1,
+      wheelEventTime: 1024,
+      crankRevs: 1,
+      crankEventTime: 1024,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM);
+    expect(result.cadenceRpm).toBeCloseTo(60, 0);
+  });
+
+  it("returns cadenceRpm=null when crank data missing", () => {
+    const prev: CscSample = {
+      wheelRevs: 0,
+      wheelEventTime: 0,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 2,
+      wheelEventTime: 2048,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    expect(computeCscSpeed(prev, curr, WHEEL_MM).cadenceRpm).toBeNull();
+  });
+
+  it("scales with wheel circumference", () => {
+    const WHEEL_MM_700C = 2096;
+    const prev: CscSample = {
+      wheelRevs: 0,
+      wheelEventTime: 0,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const curr: CscSample = {
+      wheelRevs: 1,
+      wheelEventTime: 1024,
+      crankRevs: null,
+      crankEventTime: null,
+    };
+    const result = computeCscSpeed(prev, curr, WHEEL_MM_700C);
+    // 2.096 m/s × 3.6 = 7.546 km/h
+    expect(result.speedKmh).toBeCloseTo(7.546, 1);
+  });
+});

--- a/client/src/lib/ble-speed-sensor.ts
+++ b/client/src/lib/ble-speed-sensor.ts
@@ -1,0 +1,206 @@
+// BLE protocol layer for CSC (Cycling Speed and Cadence) sensors.
+// Compatible with any Bluetooth SIG standard CSC device (Wahoo, Garmin, XOSS, etc.).
+// Service UUID: 0x1816, Measurement characteristic: 0x2A5B
+
+// ---- Constants ----
+
+const CSC_SERVICE = 0x1816;
+const CSC_MEASUREMENT_CHAR = 0x2a5b;
+
+const BLE_TIMEOUT = 5_000;
+const SELECTED_DEVICE_ID_KEY = "ecoride-ble-speed-device-id";
+
+// ---- Types ----
+
+export interface CscSample {
+  /** Cumulative wheel revolutions at this sample */
+  wheelRevs: number;
+  /** Last wheel event time, in 1/1024 s units (16-bit, wraps at 65536) */
+  wheelEventTime: number;
+  /** Cumulative crank revolutions, if flag bit 1 set */
+  crankRevs: number | null;
+  /** Last crank event time, in 1/1024 s units, if flag bit 1 set */
+  crankEventTime: number | null;
+}
+
+export interface CscSpeedResult {
+  speedKmh: number;
+  cadenceRpm: number | null;
+}
+
+// ---- Pure parsing ----
+
+/**
+ * Parse a raw CSC Measurement DataView notification.
+ * Returns null when there are no wheel revolution data (flag bit 0 not set),
+ * or when this is the first sample (no previous to delta against).
+ *
+ * CSC Measurement format (BT SIG):
+ *   byte 0: flags (bit 0 = wheel data, bit 1 = crank data)
+ *   if bit 0: uint32 LE cumulative wheel revs + uint16 LE last wheel event time (1/1024 s)
+ *   if bit 1: uint16 LE cumulative crank revs + uint16 LE last crank event time (1/1024 s)
+ */
+export function parseCscMeasurement(dv: DataView): CscSample | null {
+  if (dv.byteLength < 1) return null;
+  const flags = dv.getUint8(0);
+  const hasWheel = (flags & 0x01) !== 0;
+  const hasCrank = (flags & 0x02) !== 0;
+
+  if (!hasWheel) return null;
+  if (dv.byteLength < 7) return null;
+
+  const wheelRevs = dv.getUint32(1, true);
+  const wheelEventTime = dv.getUint16(5, true);
+
+  let crankRevs: number | null = null;
+  let crankEventTime: number | null = null;
+
+  if (hasCrank && dv.byteLength >= 11) {
+    crankRevs = dv.getUint16(7, true);
+    crankEventTime = dv.getUint16(9, true);
+  }
+
+  return { wheelRevs, wheelEventTime, crankRevs, crankEventTime };
+}
+
+/**
+ * Compute speed (km/h) and cadence (rpm) from two consecutive CSC samples.
+ * Returns { speedKmh: 0, cadenceRpm: null } when stationary (Δtime === 0).
+ * wheelCircumferenceMm: configured wheel circumference in millimetres.
+ */
+export function computeCscSpeed(
+  prev: CscSample,
+  curr: CscSample,
+  wheelCircumferenceMm: number,
+): CscSpeedResult {
+  // 16-bit timestamp wraps at 65536 (1/1024 s units)
+  const deltaTime = (curr.wheelEventTime - prev.wheelEventTime + 65536) % 65536;
+  const deltaRevs = curr.wheelRevs - prev.wheelRevs;
+
+  let speedKmh = 0;
+  if (deltaTime > 0 && deltaRevs > 0) {
+    const distanceKm = (deltaRevs * wheelCircumferenceMm) / 1_000_000;
+    const timeSeconds = deltaTime / 1024;
+    speedKmh = (distanceKm / timeSeconds) * 3600;
+  }
+
+  let cadenceRpm: number | null = null;
+  if (
+    curr.crankRevs !== null &&
+    prev.crankRevs !== null &&
+    curr.crankEventTime !== null &&
+    prev.crankEventTime !== null
+  ) {
+    const deltaCrankTime = (curr.crankEventTime - prev.crankEventTime + 65536) % 65536;
+    const deltaCrankRevs = curr.crankRevs - prev.crankRevs;
+    if (deltaCrankTime > 0) {
+      cadenceRpm = (deltaCrankRevs / (deltaCrankTime / 1024)) * 60;
+    }
+  }
+
+  return { speedKmh, cadenceRpm };
+}
+
+// ---- Capability check ----
+
+export function isBleSpeedSensorSupported(): boolean {
+  return typeof navigator !== "undefined" && "bluetooth" in navigator;
+}
+
+// ---- BLE operations ----
+
+function withTimeout<T>(promise: Promise<T>, ms = BLE_TIMEOUT): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("BLE timeout")), ms)),
+  ]);
+}
+
+function loadSelectedDeviceId(): string | null {
+  try {
+    return localStorage.getItem(SELECTED_DEVICE_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveSelectedDeviceId(device: BluetoothDevice): void {
+  if (!device.id) return;
+  try {
+    localStorage.setItem(SELECTED_DEVICE_ID_KEY, device.id);
+  } catch {
+    // localStorage unavailable — reconnect falls back to fresh selection
+  }
+}
+
+export function clearSelectedDeviceId(): void {
+  try {
+    localStorage.removeItem(SELECTED_DEVICE_ID_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Open the browser device picker and connect to a CSC speed sensor. */
+export async function scanAndConnectSpeedSensor(): Promise<BluetoothDevice> {
+  const device = await navigator.bluetooth.requestDevice({
+    filters: [{ services: [CSC_SERVICE] }],
+  });
+  if (!device.gatt) throw new Error("GATT not available");
+  await withTimeout(device.gatt.connect());
+  saveSelectedDeviceId(device);
+  return device;
+}
+
+/**
+ * Try to reconnect to a previously paired CSC sensor without showing the picker.
+ * Returns null if no paired device is found or the API is unavailable.
+ */
+export async function reconnectPairedSpeedSensor(): Promise<BluetoothDevice | null> {
+  if (!navigator.bluetooth.getDevices) return null;
+  const devices = await navigator.bluetooth.getDevices();
+  const preferredId = loadSelectedDeviceId();
+  const preferred = preferredId ? (devices.find((d) => d.id === preferredId) ?? null) : null;
+  const target = preferred ?? null;
+  if (!target?.gatt) return null;
+  try {
+    await withTimeout(target.gatt.connect());
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to CSC speed notifications.
+ * Returns an unsubscribe function.
+ */
+export async function subscribeSpeedSensor(
+  server: BluetoothRemoteGATTServer,
+  onSample: (result: CscSpeedResult) => void,
+  wheelCircumferenceMm: number,
+): Promise<() => void> {
+  const service = await withTimeout(server.getPrimaryService(CSC_SERVICE));
+  const char = await withTimeout(service.getCharacteristic(CSC_MEASUREMENT_CHAR));
+
+  let prevSample: CscSample | null = null;
+
+  const handler = (event: Event) => {
+    const dv = (event.target as BluetoothRemoteGATTCharacteristic).value;
+    if (!dv) return;
+    const sample = parseCscMeasurement(dv);
+    if (!sample) return;
+    if (prevSample !== null) {
+      onSample(computeCscSpeed(prevSample, sample, wheelCircumferenceMm));
+    }
+    prevSample = sample;
+  };
+
+  char.addEventListener("characteristicvaluechanged", handler);
+  await withTimeout(char.startNotifications());
+
+  return () => {
+    char.removeEventListener("characteristicvaluechanged", handler);
+    char.stopNotifications().catch(() => {});
+  };
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -39,6 +39,7 @@ import { formatFullDate } from "@/lib/format-utils";
 import { isBleSupported, scanAndConnect } from "@/lib/super73-ble";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { MapCacheRow } from "@/components/MapCacheRow";
+import { BleSpeedSensorRow } from "@/components/BleSpeedSensorRow";
 import { useT } from "@/i18n/provider";
 
 const allBadgeIds = Object.keys(BADGES) as BadgeId[];
@@ -723,6 +724,10 @@ export function ProfilePage() {
             <div className="mx-4 h-px bg-white/5" />
 
             <MapCacheRow />
+
+            <div className="mx-4 h-px bg-white/5" />
+
+            <BleSpeedSensorRow />
 
             <div className="mx-4 h-px bg-white/5" />
 

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -27,6 +27,7 @@ import { useMapOrientation } from "@/hooks/useMapOrientation";
 import { MapOrientationButton } from "@/components/trip/MapOrientationButton";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useT } from "@/i18n/provider";
+import { useBleSpeedSensor } from "@/hooks/useBleSpeedSensor";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -50,6 +51,7 @@ export function TripPage() {
   const { data: profileData } = useProfile();
   const { data: tripPresetsData } = useTripPresets();
   const gps = useAppGpsTracking();
+  const bleSensor = useBleSpeedSensor();
   const { orientation, toggle: toggleOrientation } = useMapOrientation();
   const isPov = orientation === "pov";
 
@@ -282,6 +284,7 @@ export function TripPage() {
           <TrackingDashboard
             isPaused={gps.state.isPaused}
             speedKmh={gps.state.speedKmh}
+            bleSpeedKmh={bleSensor.state.speedKmh}
             distance={distance}
             co2Saved={co2Saved}
             elapsed={elapsed}


### PR DESCRIPTION
Closes #241

## Résumé

- Couche protocole `ble-speed-sensor.ts` — service CSC standard (`0x1816` / `0x2A5B`), compatible Wahoo, Garmin, XOSS, etc. Note : le Super73 n'expose pas nativement le CSC — il a été utilisé comme patron architectural uniquement
- Hook React `useBleSpeedSensor` calqué sur `useSuper73` : auto-reconnexion au montage, listener `gattserverdisconnected` → speed nulle → reprise GPS, timeout stale 3,5 s si capteur s'endort
- `BleSpeedSensorRow` dans la page Profil : bouton pairing, presets de circonférence, statut
- `TrackingDashboard` : badge discret `GPS` / `Capteur` sous le chiffre de vitesse
- Circonférence de roue en `localStorage` (défaut 2215 mm Super73, presets 27,5×2,4 / 700×25c / 700×32c)
- iOS Safari non supporté → message `vehicle.bleUnsupported`

## Tests

- 12 tests unitaires `parseCscMeasurement` + `computeCscSpeed` (wraparound 16 bits, stationnaire, cadence)
- 6 tests hook `useBleSpeedSensor` (mock `navigator.bluetooth`)
- 4 tests composant `TrackingDashboard` (source badge GPS vs Capteur)

## Plan de test

- [ ] `bun run typecheck` → 0 erreurs
- [ ] `bun run test` → 22 nouveaux tests verts, failures TripPage pre-existantes
- [ ] Test manuel avec capteur CSC réel : pairing `/profile`, badge `Capteur` pendant trajet, retour `GPS` sur déconnexion < 4 s
- [ ] Test iOS Safari : section affiche le message `bleUnsupported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)