### PR TITLE
feat(commu): classement en premier + courbe évolution communauté

### DIFF
--- a/client/e2e/community-banner.spec.ts
+++ b/client/e2e/community-banner.spec.ts
@@ -59,6 +59,20 @@ test.describe("Community impact banner", () => {
         });
       }
 
+      if (url.includes("/api/stats/community/timeline")) {
+        const searchParams = new URL(url).searchParams;
+        const period = searchParams.get("period") ?? "all";
+        const category = searchParams.get("category") ?? "co2";
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { period, category, points: [] },
+          }),
+        });
+      }
+
       if (url.includes("/api/stats/community")) {
         const searchParams = new URL(url).searchParams;
         const period = searchParams.get("period") ?? "all";

--- a/client/e2e/leaderboard-period.spec.ts
+++ b/client/e2e/leaderboard-period.spec.ts
@@ -54,6 +54,21 @@ test.describe("Leaderboard period filter", () => {
         });
       }
 
+      // Stub community timeline so CommunityChart doesn't crash
+      if (url.includes("/api/stats/community/timeline")) {
+        const searchParams = new URL(url).searchParams;
+        const period = searchParams.get("period") ?? "all";
+        const category = searchParams.get("category") ?? "co2";
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { period, category, points: [] },
+          }),
+        });
+      }
+
       // Stub community stats so CommunityImpactBanner doesn't crash
       if (url.includes("/api/stats/community")) {
         return route.fulfill({

--- a/client/e2e/smoke.spec.ts
+++ b/client/e2e/smoke.spec.ts
@@ -89,6 +89,20 @@ for (const { path, name } of PAGES) {
         });
       }
 
+      if (url.includes("/api/stats/community/timeline")) {
+        const searchParams = new URL(url).searchParams;
+        const period = searchParams.get("period") ?? "all";
+        const category = searchParams.get("category") ?? "co2";
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            data: { period, category, points: [] },
+          }),
+        });
+      }
+
       if (url.includes("/api/stats/community")) {
         return route.fulfill({
           status: 200,

--- a/client/e2e/snapshot.spec.ts
+++ b/client/e2e/snapshot.spec.ts
@@ -35,6 +35,20 @@ test("community banner snapshot", async ({ page }) => {
         }),
       });
     }
+    if (url.includes("/api/stats/community/timeline")) {
+      const searchParams = new URL(url).searchParams;
+      const period = searchParams.get("period") ?? "all";
+      const category = searchParams.get("category") ?? "co2";
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: { period, category, points: [] },
+        }),
+      });
+    }
+
     if (url.includes("/api/stats/community")) {
       return route.fulfill({
         status: 200,

--- a/client/src/components/leaderboard/CommunityChart.tsx
+++ b/client/src/components/leaderboard/CommunityChart.tsx
@@ -1,0 +1,123 @@
+import { AreaChart, Area, XAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { useCommunityTimeline } from "@/hooks/queries";
+import { useT } from "@/i18n/provider";
+import type { StatsPeriod, LeaderboardCategory } from "@ecoride/shared/api-contracts";
+
+interface Props {
+  period: StatsPeriod;
+  category: LeaderboardCategory;
+  unit: string;
+  categoryLabel: string;
+}
+
+interface TooltipPayloadItem {
+  value?: number;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string;
+  unit: string;
+  formatValue: (v: number) => string;
+}
+
+function formatDateLabel(dateStr: string, period: StatsPeriod): string {
+  const date = new Date(dateStr + "T00:00:00Z");
+  if (period === "all") {
+    return date.toLocaleDateString("fr-FR", { month: "short", timeZone: "UTC" });
+  }
+  if (period === "week") {
+    return date.toLocaleDateString("fr-FR", { weekday: "short", timeZone: "UTC" });
+  }
+  // month: just the day number
+  return String(date.getUTCDate());
+}
+
+function CustomTooltip({ active, payload, label, unit, formatValue }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0]?.value ?? 0;
+  return (
+    <div className="rounded-xl border border-border bg-surface-container px-3 py-2 shadow-lg">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-text-muted">{label}</p>
+      <p className="text-sm font-black text-primary-light">
+        {formatValue(value)} {unit}
+      </p>
+    </div>
+  );
+}
+
+export function CommunityChart({ period, category, unit, categoryLabel }: Props) {
+  const t = useT();
+  const { data, isPending } = useCommunityTimeline(period, category);
+
+  const formatValue = (v: number) => {
+    switch (category) {
+      case "co2":
+        return v.toFixed(1);
+      case "money":
+        return v.toFixed(2);
+      case "speed":
+        return Math.round(v).toString();
+      default:
+        return Math.round(v).toString();
+    }
+  };
+
+  if (isPending || !data) {
+    return (
+      <div className="mt-4">
+        <div className="mb-3 h-3 w-32 animate-pulse rounded bg-surface-container" />
+        <div className="h-40 animate-pulse rounded-xl bg-surface-container" />
+      </div>
+    );
+  }
+
+  const tickInterval = period === "month" ? 4 : 0;
+
+  const points = data.points.map((p) => ({
+    date: p.date,
+    label: formatDateLabel(p.date, period),
+    value: p.value,
+  }));
+
+  return (
+    <div className="mt-4">
+      <h2 className="mb-3 text-[10px] font-bold uppercase tracking-wider text-text-muted">
+        {t("community.chart.title")}
+        {" · "}
+        <span className="text-primary-light">{categoryLabel}</span>
+      </h2>
+      <ResponsiveContainer width="100%" height={160}>
+        <AreaChart data={points} margin={{ top: 8, right: 4, left: 4, bottom: 0 }}>
+          <defs>
+            <linearGradient id="communityChartGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#54e98a" stopOpacity={0.25} />
+              <stop offset="100%" stopColor="#54e98a" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="label"
+            tick={{ fill: "#8a9ba8", fontSize: 10, fontWeight: 600 }}
+            tickLine={false}
+            axisLine={false}
+            interval={tickInterval}
+          />
+          <Tooltip
+            content={<CustomTooltip unit={unit} formatValue={formatValue} />}
+            cursor={{ stroke: "#54e98a", strokeWidth: 1, strokeDasharray: "4 4" }}
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="#54e98a"
+            strokeWidth={2}
+            fill="url(#communityChartGradient)"
+            dot={false}
+            activeDot={{ r: 4, fill: "#54e98a", stroke: "#1e272e", strokeWidth: 2 }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -4,6 +4,7 @@ import type { Trip, Achievement, TripPreset } from "@ecoride/shared/types";
 import type {
   StatsSummaryResponse,
   CommunityStatsResponse,
+  CommunityTimelineResponse,
   LeaderboardEntry,
   CreateTripRequest,
   CreateTripPresetRequest,
@@ -104,6 +105,20 @@ export function useCommunityStats(period: StatsPeriod = "all") {
         `/stats/community?period=${period}`,
       ).then((r) => r.data),
     staleTime: 5 * 60 * 1000, // aligned with server cache TTL
+  });
+}
+
+export function useCommunityTimeline(
+  period: StatsPeriod = "all",
+  category: LeaderboardCategory = "co2",
+) {
+  return useQuery({
+    queryKey: ["community-timeline", period, category],
+    queryFn: () =>
+      apiFetch<{ ok: boolean; data: CommunityTimelineResponse }>(
+        `/stats/community/timeline?period=${period}&category=${category}`,
+      ).then((r) => r.data),
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -533,6 +533,7 @@ export const en: Record<TranslationKey, string> = {
   "community.unit.users": "riders",
   "community.comparisons.flights": "= {{count}} Paris-NY flights avoided",
   "community.comparisons.trees": "= {{count}} trees absorbing CO₂ for 1 year",
+  "community.chart.title": "Trend",
 
   "trip.navigation.addDestination": "Add a destination",
   "trip.navigation.clear": "Clear",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -536,6 +536,7 @@ export const fr = {
   "community.unit.users": "cyclistes",
   "community.comparisons.flights": "= {{count}} vols Paris-NY évités",
   "community.comparisons.trees": "= {{count}} arbres absorbant 1 an",
+  "community.chart.title": "Évolution",
 
   "trip.navigation.addDestination": "Ajouter une destination",
   "trip.navigation.clear": "Effacer",

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -4,6 +4,7 @@ import { useLeaderboard } from "@/hooks/queries";
 import { useSession } from "@/lib/auth";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { CommunityImpactBanner } from "@/components/leaderboard/CommunityImpactBanner";
+import { CommunityChart } from "@/components/leaderboard/CommunityChart";
 import { useT } from "@/i18n/provider";
 import type { StatsPeriod, LeaderboardCategory } from "@ecoride/shared/api-contracts";
 import type { TranslationKey } from "@/i18n/locales/fr";
@@ -106,7 +107,8 @@ export function LeaderboardPage() {
       />
 
       <div className="px-6 pb-6">
-        <section className="mb-10">
+        {/* Controls: period + category — shared by leaderboard and community section */}
+        <section className="mb-6">
           {/* Period switcher */}
           <div className="mt-4 flex gap-2" data-testid="period-switcher">
             {periodValues.map((value) => {
@@ -126,9 +128,6 @@ export function LeaderboardPage() {
               );
             })}
           </div>
-
-          {/* Community impact banner — shared period with the leaderboard */}
-          <CommunityImpactBanner period={period} />
 
           {/* Category switcher — icons only, label below */}
           <div className="mt-3 flex flex-col gap-2">
@@ -158,6 +157,7 @@ export function LeaderboardPage() {
           </div>
         </section>
 
+        {/* Leaderboard */}
         {entries.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-6 py-20">
             <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
@@ -287,6 +287,17 @@ export function LeaderboardPage() {
             </div>
           </>
         )}
+
+        {/* Community impact + chart */}
+        <section className="mt-8">
+          <CommunityImpactBanner period={period} />
+          <CommunityChart
+            period={period}
+            category={category}
+            unit={unit}
+            categoryLabel={t(categoryLabelKeys[category])}
+          />
+        </section>
       </div>
     </>
   );

--- a/client/src/pages/__tests__/LeaderboardPage.i18n.test.tsx
+++ b/client/src/pages/__tests__/LeaderboardPage.i18n.test.tsx
@@ -38,6 +38,7 @@ vi.mock("@/hooks/queries", () => ({
     isPending: false,
   }),
   useCommunityStats: () => ({ data: undefined, isPending: true }),
+  useCommunityTimeline: () => ({ data: undefined, isPending: true }),
 }));
 
 vi.mock("@/lib/auth", () => ({

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -8,7 +8,12 @@ import { validationHook } from "../lib/validation";
 import { computeStreak } from "../lib/streaks";
 import { rateLimit } from "../lib/rate-limit";
 import type { AuthEnv } from "../types/context";
-import type { StatsPeriod, CommunityStatsResponse } from "@ecoride/shared/api-contracts";
+import type {
+  StatsPeriod,
+  LeaderboardCategory,
+  CommunityStatsResponse,
+  CommunityTimelineResponse,
+} from "@ecoride/shared/api-contracts";
 
 const statsQuery = z.object({
   period: z.enum(["day", "week", "month", "year", "all"]).default("month"),
@@ -121,6 +126,119 @@ statsRouter.get(
     };
 
     communityCache.set(period, { data, cachedAt: Date.now() });
+
+    return c.json({ ok: true, data });
+  },
+);
+
+// ---- Community timeline ----
+
+const timelineQuery = z.object({
+  period: z.enum(["week", "month", "all"]).default("all"),
+  category: z.enum(["co2", "trips", "distance", "money", "speed", "streak"]).default("co2"),
+});
+
+type TimelineCacheKey = `${string}-${string}`;
+type TimelineCacheEntry = { data: CommunityTimelineResponse; cachedAt: number };
+const timelineCache = new Map<TimelineCacheKey, TimelineCacheEntry>();
+
+statsRouter.get(
+  "/community/timeline",
+  rateLimit({ maxRequests: 30, windowMs: 60_000, prefix: "stats-timeline" }),
+  zValidator("query", timelineQuery, validationHook),
+  async (c) => {
+    const { period, category } = c.req.valid("query") as {
+      period: StatsPeriod;
+      category: LeaderboardCategory;
+    };
+
+    const cacheKey: TimelineCacheKey = `${period}-${category}`;
+    const cached = timelineCache.get(cacheKey);
+    if (cached && Date.now() - cached.cachedAt < COMMUNITY_CACHE_TTL_MS) {
+      return c.json({ ok: true, data: cached.data });
+    }
+
+    const isAll = period === "all";
+    const now = new Date();
+
+    // Determine window start
+    let windowStart: Date;
+    if (isAll) {
+      windowStart = new Date(Date.UTC(now.getUTCFullYear() - 1, now.getUTCMonth(), 1));
+    } else if (period === "month") {
+      windowStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    } else {
+      windowStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    }
+
+    // SQL expressions — literals to avoid parameterization
+    const dayLabel = isAll
+      ? sql<string>`to_char(date_trunc('month', ${trips.startedAt}), 'YYYY-MM-DD')`
+      : sql<string>`to_char(date_trunc('day', ${trips.startedAt}), 'YYYY-MM-DD')`;
+
+    const dayLabelGroup = isAll
+      ? sql`to_char(date_trunc('month', ${trips.startedAt}), 'YYYY-MM-DD')`
+      : sql`to_char(date_trunc('day', ${trips.startedAt}), 'YYYY-MM-DD')`;
+
+    let valueExpr;
+    switch (category) {
+      case "co2":
+        valueExpr = sql<number>`coalesce(sum(${trips.co2SavedKg}), 0)`.mapWith(Number);
+        break;
+      case "money":
+        valueExpr = sql<number>`coalesce(sum(${trips.moneySavedEur}), 0)`.mapWith(Number);
+        break;
+      case "distance":
+        valueExpr = sql<number>`coalesce(sum(${trips.distanceKm}), 0)`.mapWith(Number);
+        break;
+      case "trips":
+        valueExpr = sql<number>`count(*)`.mapWith(Number);
+        break;
+      case "speed":
+        valueExpr =
+          sql<number>`case when sum(${trips.durationSec}) > 0 then sum(${trips.distanceKm}) / (sum(${trips.durationSec}) / 3600.0) else 0 end`.mapWith(
+            Number,
+          );
+        break;
+      case "streak":
+        valueExpr = sql<number>`count(distinct ${trips.userId})`.mapWith(Number);
+        break;
+      default:
+        valueExpr = sql<number>`coalesce(sum(${trips.co2SavedKg}), 0)`.mapWith(Number);
+    }
+
+    const rows = await db
+      .select({ day: dayLabel, value: valueExpr })
+      .from(trips)
+      .where(gte(trips.startedAt, windowStart))
+      .groupBy(dayLabelGroup)
+      .orderBy(dayLabelGroup);
+
+    // Fill gaps with 0
+    const map = new Map(rows.map((r) => [r.day ?? "", r.value]));
+    const points: CommunityTimelineResponse["points"] = [];
+
+    const cursor = new Date(windowStart);
+    cursor.setUTCHours(0, 0, 0, 0);
+
+    while (cursor <= now) {
+      const key = isAll
+        ? `${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, "0")}-01`
+        : cursor.toISOString().slice(0, 10);
+
+      if (points.at(-1)?.date !== key) {
+        points.push({ date: key, value: map.get(key) ?? 0 });
+      }
+
+      if (isAll) {
+        cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+      } else {
+        cursor.setUTCDate(cursor.getUTCDate() + 1);
+      }
+    }
+
+    const data: CommunityTimelineResponse = { period, category, points };
+    timelineCache.set(cacheKey, { data, cachedAt: Date.now() });
 
     return c.json({ ok: true, data });
   },

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -58,6 +58,9 @@ export const API_ROUTES = {
 
   // Navigation
   NAVIGATION_ROUTE: { method: "POST", path: "/api/navigation/route" },
+
+  // Community timeline
+  STATS_COMMUNITY_TIMELINE: { method: "GET", path: "/api/stats/community/timeline" },
 } as const;
 
 // ---- Request payloads ----
@@ -221,6 +224,17 @@ export interface FuelPriceResponse {
   fuelType: FuelType;
   stationName?: string;
   updatedAt: string;
+}
+
+export interface CommunityTimelinePoint {
+  date: string; // YYYY-MM-DD
+  value: number;
+}
+
+export interface CommunityTimelineResponse {
+  period: StatsPeriod;
+  category: LeaderboardCategory;
+  points: CommunityTimelinePoint[];
 }
 
 // ---- Error handling ----


### PR DESCRIPTION
## Résumé

- Réorganise l'onglet **Commu** : sélecteurs → classement → impact communauté → courbe
- Ajoute `mt-8` entre les boutons période/catégorie et la section \"Impact de la communauté\"
- Nouveau composant `CommunityChart` (recharts `AreaChart`) en bas de page, réactif au filtre période ET catégorie
- Nouvel endpoint `GET /api/stats/community/timeline` avec gap-filling et cache TTL 5 min

## Détail de la courbe

| Période | Granularité | Labels |
|---------|-------------|--------|
| Semaine | 7 points quotidiens | Jours abrégés |
| Mois | 30 points quotidiens | Numéro du jour |
| Tout | ~13 points mensuels | Mois abrégé |

## Test plan

- [ ] Vérifier que le classement apparaît bien avant l'impact communauté
- [ ] Changer de période → courbe et stats se mettent à jour
- [ ] Changer de catégorie → courbe et titre se mettent à jour
- [ ] Vérifier le skeleton de chargement de la courbe
- [ ] Tester le tooltip au survol / tap sur un point

🤖 Generated with [Claude Code](https://claude.com/claude-code)