### PR TITLE
feat(s73): reset EPAC depuis le vélo quand assist passe à 3

### DIFF
--- a/client/src/hooks/__tests__/useSuper73.test.tsx
+++ b/client/src/hooks/__tests__/useSuper73.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import {
   Super73Provider,
   useSuper73,
   buildStateFromPreferences,
   resolveAutoModeZone,
   resolveAutoSuper73Mode,
+  shouldTriggerEpac,
+  ASSIST_EPAC_TRIGGER,
 } from "../useSuper73";
 import type { Super73State } from "@/lib/super73-ble";
 
@@ -82,6 +84,33 @@ const baseState: Super73State = {
   region: "eu",
 };
 
+describe("shouldTriggerEpac", () => {
+  it("returns true when assist is ASSIST_EPAC_TRIGGER and mode is not eco", () => {
+    expect(
+      shouldTriggerEpac({ mode: "race", assist: ASSIST_EPAC_TRIGGER, light: false, region: "eu" }),
+    ).toBe(true);
+    expect(
+      shouldTriggerEpac({ mode: "sport", assist: ASSIST_EPAC_TRIGGER, light: false, region: "eu" }),
+    ).toBe(true);
+    expect(
+      shouldTriggerEpac({ mode: "tour", assist: ASSIST_EPAC_TRIGGER, light: false, region: "eu" }),
+    ).toBe(true);
+  });
+
+  it("returns false when mode is already eco", () => {
+    expect(
+      shouldTriggerEpac({ mode: "eco", assist: ASSIST_EPAC_TRIGGER, light: false, region: "eu" }),
+    ).toBe(false);
+  });
+
+  it("returns false when assist is not the trigger level", () => {
+    expect(shouldTriggerEpac({ mode: "race", assist: 0, light: false, region: "eu" })).toBe(false);
+    expect(shouldTriggerEpac({ mode: "race", assist: 1, light: false, region: "eu" })).toBe(false);
+    expect(shouldTriggerEpac({ mode: "race", assist: 2, light: false, region: "eu" })).toBe(false);
+    expect(shouldTriggerEpac({ mode: "race", assist: 4, light: false, region: "eu" })).toBe(false);
+  });
+});
+
 describe("useSuper73 helpers", () => {
   it("builds a preferred state only when preferences differ", () => {
     expect(
@@ -130,6 +159,7 @@ describe("useSuper73 provider", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("shares a single BLE session across multiple consumers", async () => {
@@ -181,6 +211,68 @@ describe("useSuper73 provider", () => {
       expect(screen.getByText("vehicle-light:on")).toBeTruthy();
     });
   });
+
+  it("polls the bike and resets to EPAC when assist reaches the trigger level", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Super73Provider enabled>
+        <Consumer label="vehicle" />
+      </Super73Provider>,
+    );
+
+    fireEvent.click(screen.getByText("vehicle connect"));
+
+    // Flush async connection chain (readState + applyConnectionPreferences)
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(screen.getByText("vehicle:connected")).toBeTruthy();
+
+    // Simulate bike state: rider set assist to 3 while in race mode
+    readStateMock.mockResolvedValue({ ...baseState, mode: "race", assist: 3 });
+    writeStateMock.mockClear();
+
+    // Advance past the poll interval and flush async poll callback
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(writeStateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ mode: "eco", assist: 3 }),
+    );
+    expect(screen.getByText("vehicle-mode:eco")).toBeTruthy();
+  }, 15_000);
+
+  it("does not write when assist is at trigger level but mode is already eco", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Super73Provider enabled>
+        <Consumer label="noop" />
+      </Super73Provider>,
+    );
+
+    fireEvent.click(screen.getByText("noop connect"));
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(screen.getByText("noop:connected")).toBeTruthy();
+
+    // assist=3 but already in eco → no write expected
+    readStateMock.mockResolvedValue({ ...baseState, mode: "eco", assist: 3 });
+    writeStateMock.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(writeStateMock).not.toHaveBeenCalled();
+  }, 15_000);
 
   it("switches automatically to off-road then back to eco when speed crosses thresholds", async () => {
     const { rerender } = render(

--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -18,11 +18,22 @@ import {
   type Super73Mode,
 } from "@/lib/super73-ble";
 
+// When the rider sets assist level to ASSIST_EPAC_TRIGGER from the bike's
+// physical buttons, the app automatically resets the mode to EPAC (eco).
+// This lets the rider switch back to legal-speed mode from the bike itself
+// while the phone is in their pocket.
+export const ASSIST_EPAC_TRIGGER = 3;
+
+export function shouldTriggerEpac(state: Super73State): boolean {
+  return state.assist === ASSIST_EPAC_TRIGGER && state.mode !== "eco";
+}
+
 export type BleStatus = "disconnected" | "connecting" | "connected" | "unsupported" | "error";
 
 const STATE_KEY = "ecoride-super73-state";
 const RECONNECT_DELAY = 2_000;
 const MAX_RECONNECT_ATTEMPTS = 1;
+const EPAC_TRIGGER_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_AUTO_MODE_LOW_SPEED_KMH = 10;
 const DEFAULT_AUTO_MODE_HIGH_SPEED_KMH = 17;
 
@@ -171,6 +182,8 @@ function useSuper73Controller(
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const manualDisconnectRef = useRef(false);
   const lastAutoModeZoneRef = useRef<AutoModeZone>(null);
+  // Prevents re-entrant polling if a poll round takes longer than the interval.
+  const isPollActiveRef = useRef(false);
 
   const applyConnectionPreferences = useCallback(
     async (server: BluetoothRemoteGATTServer, state: Super73State) => {
@@ -403,6 +416,35 @@ function useSuper73Controller(
     preferences.autoModeLowSpeedKmh,
     preferences.autoModeHighSpeedKmh,
   ]);
+
+  // Poll the bike state every EPAC_TRIGGER_POLL_INTERVAL_MS when connected.
+  // If the rider has set assist to ASSIST_EPAC_TRIGGER from the physical buttons,
+  // force the mode back to eco (EPAC). This is the "reset from the bike" gesture.
+  useEffect(() => {
+    if (status !== "connected") return;
+
+    const pollId = setInterval(async () => {
+      if (isPollActiveRef.current || !serverRef.current?.connected) return;
+      isPollActiveRef.current = true;
+      try {
+        const polledState = await readState(serverRef.current);
+        setBikeState(polledState);
+        cacheState(polledState);
+        if (shouldTriggerEpac(polledState)) {
+          const epacState: Super73State = { ...polledState, mode: "eco" };
+          await writeState(serverRef.current, epacState);
+          setBikeState(epacState);
+          cacheState(epacState);
+        }
+      } catch {
+        // Poll silently skipped — will retry on next interval.
+      } finally {
+        isPollActiveRef.current = false;
+      }
+    }, EPAC_TRIGGER_POLL_INTERVAL_MS);
+
+    return () => clearInterval(pollId);
+  }, [status]);
 
   if (!enabled) return NOOP_RESULT;
   if (!isBleSupported()) return NOOP_RESULT;


### PR DESCRIPTION
## Résumé

Permet de repasser en mode EPAC depuis le vélo physique, sans toucher au téléphone.

**Geste :** régler le niveau d'assistance à **3** depuis les boutons du vélo → l'appli détecte le changement et force le mode en **EPAC (eco)** automatiquement.

Le passage en Off-Road reste uniquement depuis l'appli (comportement inchangé).

## Fonctionnement technique

- Quand le S73 est connecté, un polling tourne toutes les **5 secondes**
- Chaque poll lit l'état complet du vélo (`readState`) et met à jour `bikeState` (effet de bord positif : UI toujours en sync)
- Si `assist === 3` **et** `mode !== "eco"` → écrit EPAC immédiatement
- Un mutex `isPollActiveRef` évite la ré-entrance si un poll prend > 5s
- Polling s'arrête proprement à la déconnexion (cleanup `clearInterval`)

## Tests

- `shouldTriggerEpac()` : fonction pure exportée, 3 cas couverts (trigger, déjà eco, autres niveaux)
- Test d'intégration : fake timers + `advanceTimersByTimeAsync` → vérifie que `writeState` est appelé avec `mode: "eco"` après 5s
- Test no-op : assist=3 + mode déjà eco → `writeState` **non** appelé

## Test plan

- [ ] Connecter un S73, passer en Off-Road depuis l'appli
- [ ] Depuis les boutons du vélo, régler l'assistance à 3
- [ ] Vérifier que l'appli repasse en EPAC dans les 5 secondes
- [ ] Vérifier que l'assist à 0, 1, 2, 4 ne déclenche rien
- [ ] Vérifier que le changement Off-Road → EPAC reste inaccessible depuis le vélo (il n'y a pas de "geste inverse")

🤖 Generated with [Claude Code](https://claude.com/claude-code)