### PR TITLE
feat: persist react query cache for offline read

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,9 @@
       "dependencies": {
         "@ecoride/shared": "workspace:*",
         "@sentry/react": "^10.45.0",
+        "@tanstack/query-sync-storage-persister": "^5.99.0",
         "@tanstack/react-query": "^5.80.7",
+        "@tanstack/react-query-persist-client": "^5.99.0",
         "better-auth": "^1.2.0",
         "lucide-react": "^0.525.0",
         "maplibre-gl": "^5.6.0",
@@ -697,9 +699,15 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.95.0", "", {}, "sha512-H1/CWCe8tGL3YIVeo770Z6kPbt0B3M1d/iQXIIK1qlFiFt6G2neYdkHgLapOC8uMYNt9DmHjmGukEKgdMk1P+A=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
+
+    "@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" } }, "sha512-FzXoxqGYa+ozGNGBIPHJT06rJD4geiHGbVXNS8K7cwN34te64LXlO5Ep+roQYvZjXJFNrLa4W48DIYITpMxzuA=="],
+
+    "@tanstack/query-sync-storage-persister": ["@tanstack/query-sync-storage-persister@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0", "@tanstack/query-persist-client-core": "5.99.0" } }, "sha512-Q7xJ+AiesEEB8ZKGrsv7qJfhyr0eT1Z+84TZxQspGZZnJziOalcLUOLGgHOxPaEQGGcxqM1NbrgGYO/WpnTjeQ=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.95.0", "", { "dependencies": { "@tanstack/query-core": "5.95.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-EMP8B+BK9zvnAemT8M/y3z/WO0NjZ7fIUY3T3wnHYK6AA3qK/k33i7tPgCXCejhX0cd4I6bJIXN2GmjrHjDBzg=="],
+
+    "@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.99.0", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.99.0" }, "peerDependencies": { "@tanstack/react-query": "^5.99.0", "react": "^18 || ^19" } }, "sha512-A3TTaaYZOy6dFUNJj3r10rwmUBWaXqc2N71a7jzpFXilYAYWLKJf9ivT5n5bhXsJnSkdvv1RLifUg/GdvDGaDw=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -1936,6 +1944,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.95.0", "", {}, "sha512-H1/CWCe8tGL3YIVeo770Z6kPbt0B3M1d/iQXIIK1qlFiFt6G2neYdkHgLapOC8uMYNt9DmHjmGukEKgdMk1P+A=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@ecoride/shared": "workspace:*",
     "@sentry/react": "^10.45.0",
+    "@tanstack/query-sync-storage-persister": "^5.99.0",
     "@tanstack/react-query": "^5.80.7",
+    "@tanstack/react-query-persist-client": "^5.99.0",
     "better-auth": "^1.2.0",
     "lucide-react": "^0.525.0",
     "maplibre-gl": "^5.6.0",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,7 +2,9 @@ import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { I18nProvider } from "./i18n/provider";
 import { App } from "./App";
@@ -108,21 +110,39 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 60_000,
+      // Serve from cache when offline instead of spinning indefinitely.
+      networkMode: "offlineFirst",
+      // Keep cache for 24 h so it's still there after a short offline spell.
+      gcTime: 24 * 60 * 60 * 1000,
       retry: 1,
     },
   },
 });
 
+const persister = createSyncStoragePersister({
+  storage: window.localStorage,
+  key: "ecoride-query-cache",
+});
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={{
+          persister,
+          // Invalidate cache on new app version — avoids stale API shape mismatches.
+          buster: __APP_VERSION__,
+          // Keep persisted cache for 24 h.
+          maxAge: 24 * 60 * 60 * 1000,
+        }}
+      >
         <I18nProvider>
           <BrowserRouter>
             <App />
           </BrowserRouter>
         </I18nProvider>
-      </QueryClientProvider>
+      </PersistQueryClientProvider>
     </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Installs `@tanstack/react-query-persist-client` + `@tanstack/query-sync-storage-persister`
- Cache persisted to `localStorage` under `ecoride-query-cache`
- `buster: __APP_VERSION__` → cache auto-invalidated on each deploy (no stale API shape)
- `networkMode: "offlineFirst"` → all queries serve from cache when offline instead of spinning
- `gcTime: 24h` → cache stays alive long enough to be useful after a short offline spell

## Result

All tabs (dashboard, history, leaderboard, badges, profile) now show last known data when the device goes offline, instead of an infinite spinner.

## Test plan

- [ ] Load the app online, navigate to all tabs
- [ ] Disable network (airplane mode or DevTools → offline)
- [ ] Navigate between tabs → should show last known data, not spinners
- [ ] Re-enable network → data refreshes in background (stale-while-revalidate)
- [ ] Deploy a new version → cache is busted, fresh data is fetched

Fixes #243 (partially — read offline only, write queue out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)