### PR TITLE
fix(s73): filter telemetry from notifier — only process state packets

### DIFF
--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -197,21 +197,26 @@ function useSuper73Controller(
   // Cleanup function returned by startStateNotifications; null = notifier unavailable.
   const notifierCleanupRef = useRef<(() => void) | null>(null);
 
-  // Notifier is passive: logs raw bytes for diagnostic purposes only.
-  // App state is driven exclusively by the poll (readState every 5 s) and
-  // explicit user actions. No setBikeState / writeState here — avoids feedback
-  // loops if the notifier sends a different byte format than readState.
-  //
-  // When ecoride-ble-debug=1: immediately fires a readState ("poll") right
-  // after the notifier so both appear side-by-side in the console.
+  // Notifier handler — only receives state packets (byte[0]=0x03), telemetry
+  // filtered out in startStateNotifications. Safe to update app state here.
+  // When ecoride-ble-debug=1: also fires an immediate poll for side-by-side comparison.
   const notifierHandlerBodyRef = useRef<((state: Super73State) => void) | null>(null);
-  notifierHandlerBodyRef.current = (_state: Super73State) => {
-    if (!isBleDebugEnabled()) return;
-    if (isPollActiveRef.current || !serverRef.current?.connected) return;
-    isPollActiveRef.current = true;
-    void readState(serverRef.current, "poll").finally(() => {
-      isPollActiveRef.current = false;
-    });
+  notifierHandlerBodyRef.current = (state: Super73State) => {
+    setBikeState(state);
+    cacheState(state);
+    if (shouldTriggerEpac(state) && serverRef.current?.connected) {
+      const epacState: Super73State = { ...state, mode: "eco" };
+      void writeState(serverRef.current, epacState).then(() => {
+        setBikeState(epacState);
+        cacheState(epacState);
+      });
+    }
+    if (isBleDebugEnabled() && !isPollActiveRef.current && serverRef.current?.connected) {
+      isPollActiveRef.current = true;
+      void readState(serverRef.current, "poll").finally(() => {
+        isPollActiveRef.current = false;
+      });
+    }
   };
   const stableNotifierHandler = useCallback(
     (state: Super73State) => notifierHandlerBodyRef.current?.(state),

--- a/client/src/lib/__tests__/super73-ble.test.ts
+++ b/client/src/lib/__tests__/super73-ble.test.ts
@@ -10,6 +10,7 @@ import {
   reconnectPairedDevice,
   readState,
   writeState,
+  startStateNotifications,
   type Super73State,
 } from "../super73-ble";
 
@@ -342,6 +343,86 @@ describe("readState", () => {
     expect(registerIdChar.writeValue).toHaveBeenCalledWith(new Uint8Array([3, 0]));
     expect(registerChar.readValue).toHaveBeenCalled();
     expect(state).toEqual({ mode: "sport", assist: 2, light: true, region: "eu" });
+  });
+});
+
+describe("startStateNotifications", () => {
+  function makeNotifierGATT(notifierChar: object) {
+    const service = {
+      getCharacteristic: vi.fn().mockImplementation((uuid: string) => {
+        if (uuid === "0000155e-1212-efde-1523-785feabcd123") return Promise.resolve(notifierChar);
+        return Promise.reject(new Error("Unknown char"));
+      }),
+    };
+    return {
+      connected: true,
+      getPrimaryService: vi.fn().mockResolvedValue(service),
+    } as unknown as BluetoothRemoteGATTServer;
+  }
+
+  function makeNotifierChar() {
+    const listeners: Record<string, EventListener> = {};
+    return {
+      startNotifications: vi.fn().mockResolvedValue(undefined),
+      addEventListener: vi.fn((event: string, cb: EventListener) => {
+        listeners[event] = cb;
+      }),
+      removeEventListener: vi.fn(),
+      emit(bytes: number[]) {
+        const value = new DataView(new Uint8Array(bytes).buffer);
+        const target = { value } as unknown as BluetoothRemoteGATTCharacteristic;
+        listeners["characteristicvaluechanged"]?.({ target } as Event);
+      },
+    };
+  }
+
+  it("calls handler for state packets (byte[0]=0x03)", async () => {
+    const char = makeNotifierChar();
+    const server = makeNotifierGATT(char);
+    const handler = vi.fn();
+
+    await startStateNotifications(server, handler);
+    // EU EPAC, assist=4, light=ON
+    char.emit([0x03, 0x00, 0x04, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00]);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith({ mode: "eco", assist: 4, light: true, region: "eu" });
+  });
+
+  it("ignores telemetry packets (byte[0]=0x02)", async () => {
+    const char = makeNotifierChar();
+    const server = makeNotifierGATT(char);
+    const handler = vi.fn();
+
+    await startStateNotifications(server, handler);
+    char.emit([0x02, 0x01, 0x2e, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]); // speed packet
+    char.emit([0x02, 0x03, 0x00, 0x00, 0x68, 0xbe, 0x0b, 0x00, 0x19, 0x00]); // odometer packet
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores timer packets (byte[0]=0x04)", async () => {
+    const char = makeNotifierChar();
+    const server = makeNotifierGATT(char);
+    const handler = vi.fn();
+
+    await startStateNotifications(server, handler);
+    char.emit([0x04, 0x01, 0x10, 0xb9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns null when notifier characteristic is unavailable", async () => {
+    const service = {
+      getCharacteristic: vi.fn().mockRejectedValue(new Error("not found")),
+    };
+    const server = {
+      connected: true,
+      getPrimaryService: vi.fn().mockResolvedValue(service),
+    } as unknown as BluetoothRemoteGATTServer;
+
+    const result = await startStateNotifications(server, vi.fn());
+    expect(result).toBeNull();
   });
 });
 

--- a/client/src/lib/super73-ble.ts
+++ b/client/src/lib/super73-ble.ts
@@ -213,8 +213,13 @@ export async function startStateNotifications(
     const listener = (event: Event) => {
       const c = event.target as BluetoothRemoteGATTCharacteristic;
       if (!c.value) return;
+      const bytes = new Uint8Array(c.value.buffer);
+      // The S73 notifier multiplexes state packets (byte[0]=0x03) with telemetry
+      // streams (byte[0]=0x02: speed/odometer/cadence, byte[0]=0x04: timer).
+      // Only state packets share the format parsed by parseStateBytes.
+      if (bytes[0] !== 0x03) return;
       try {
-        handler(parseStateBytes(new Uint8Array(c.value.buffer), "notifier"));
+        handler(parseStateBytes(bytes, "notifier"));
       } catch {
         // malformed packet — skip
       }


### PR DESCRIPTION
## Root cause

`REGISTER_NOTIFIER_CHAR` (155e) on the S73 multiplexes 4 packet types on the same characteristic:

| byte[0] | Type | Content |
|---------|------|---------|
| `0x03` | **State** | mode / assist / light / region — identical format to `readState` |
| `0x02` (`01`) | Speed telemetry | bytes[2-3] LE uint16 / 100 = km/h |
| `0x02` (`03`) | Odometer/energy | accumulating counter |
| `0x04` (`01`) | Timer/counter | counts down, changes with motor load |

All non-state packets were being passed to `parseStateBytes`, which reads `byte[5]` as the mode byte. On telemetry packets, `byte[5]` is random data → decoded as garbage mode/region (false US eco, EPAC↔Sport oscillation). This was the root cause of the regression introduced in #260.

## Fix

- `startStateNotifications`: discard packets where `byte[0] !== 0x03` before calling handler
- `useSuper73`: re-enable `setBikeState` + EPAC enforcement in notifier handler (now safe — only valid state packets reach it)
- Debug mode (`ecoride-ble-debug=1`) still triggers an immediate `readState` poll after each notifier for side-by-side comparison

## Tests

4 new regression tests in `super73-ble.test.ts`:
- State packet (`0x03`) passes through to handler ✓
- Speed telemetry (`0x02 0x01`) ignored ✓
- Odometer telemetry (`0x02 0x03`) ignored ✓
- Timer packet (`0x04 0x01`) ignored ✓

Closes the regression from #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)