### PR TITLE
feat(s73): use S73 BLE wheel speed for auto-mode instead of GPS

### DIFF
--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -141,6 +141,8 @@ export function resolveAutoSuper73Mode(zone: AutoModeZone): Super73Mode | null {
 export interface UseSuper73Result {
   status: BleStatus;
   bikeState: Super73State | null;
+  /** Speed in km/h from the S73 wheel sensor (02 01 BLE packet). Null when not connected. */
+  bikeSpeedKmh: number | null;
   error: string | null;
   tripModeSelection: Super73TripModeSelection;
   connect: () => Promise<void>;
@@ -158,6 +160,7 @@ export interface UseSuper73Result {
 const NOOP_RESULT: UseSuper73Result = {
   status: "unsupported",
   bikeState: null,
+  bikeSpeedKmh: null,
   error: null,
   tripModeSelection: "eco",
   connect: async () => {},
@@ -182,6 +185,7 @@ function useSuper73Controller(
     !enabled ? "disconnected" : isBleSupported() ? "disconnected" : "unsupported",
   );
   const [bikeState, setBikeState] = useState<Super73State | null>(loadCachedState);
+  const [bikeSpeedKmh, setBikeSpeedKmh] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tripModeSelection, setTripModeSelection] = useState<Super73TripModeSelection>("eco");
   const [epacPollFallbackWarning, setEpacPollFallbackWarning] = useState(false);
@@ -250,6 +254,7 @@ function useSuper73Controller(
       notifierCleanupRef.current = await startStateNotifications(
         device.gatt!,
         stableNotifierHandler,
+        setBikeSpeedKmh,
       );
       setStatus("connected");
     },
@@ -281,6 +286,7 @@ function useSuper73Controller(
     notifierCleanupRef.current = null;
     serverRef.current = null;
     lastAutoModeZoneRef.current = null;
+    setBikeSpeedKmh(null);
     if (manualDisconnectRef.current) {
       setStatus("disconnected");
       return;
@@ -405,7 +411,7 @@ function useSuper73Controller(
       const highSpeedThresholdKmh =
         preferences.autoModeHighSpeedKmh ?? DEFAULT_AUTO_MODE_HIGH_SPEED_KMH;
       const zone = resolveAutoModeZone(
-        tracking.speedKmh,
+        bikeSpeedKmh ?? tracking.speedKmh,
         lowSpeedThresholdKmh,
         highSpeedThresholdKmh,
       );
@@ -439,8 +445,11 @@ function useSuper73Controller(
     const lowSpeedThresholdKmh = preferences.autoModeLowSpeedKmh ?? DEFAULT_AUTO_MODE_LOW_SPEED_KMH;
     const highSpeedThresholdKmh =
       preferences.autoModeHighSpeedKmh ?? DEFAULT_AUTO_MODE_HIGH_SPEED_KMH;
+    // Prefer bike wheel speed (more accurate at low speed, no GPS noise).
+    // Fall back to GPS speed when BLE speed is unavailable.
+    const effectiveSpeedKmh = bikeSpeedKmh ?? tracking.speedKmh;
     const zone = resolveAutoModeZone(
-      tracking.speedKmh,
+      effectiveSpeedKmh,
       lowSpeedThresholdKmh,
       highSpeedThresholdKmh,
     );
@@ -458,6 +467,7 @@ function useSuper73Controller(
   }, [
     tripModeSelection,
     tracking.isTracking,
+    bikeSpeedKmh,
     tracking.speedKmh,
     bikeState,
     status,
@@ -506,6 +516,7 @@ function useSuper73Controller(
   return {
     status,
     bikeState,
+    bikeSpeedKmh,
     error,
     tripModeSelection,
     connect,

--- a/client/src/lib/__tests__/super73-ble.test.ts
+++ b/client/src/lib/__tests__/super73-ble.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   parseStateBytes,
+  parseSpeedPacket,
   buildWriteCommand,
   decodeMode,
   encodeMode,
@@ -346,6 +347,48 @@ describe("readState", () => {
   });
 });
 
+describe("parseSpeedPacket", () => {
+  it("parses a speed packet correctly (37 km/h)", () => {
+    // 0x0eba = 3770 → 37.70 km/h (observed at ~37 km/h in field test)
+    expect(
+      parseSpeedPacket(new Uint8Array([0x02, 0x01, 0xba, 0x0e, 0, 0, 0, 0, 0, 0])),
+    ).toBeCloseTo(37.7);
+  });
+
+  it("parses a speed packet correctly (49.4 km/h)", () => {
+    // 0x134c = 4940 → 49.40 km/h (observed at ~50 km/h in field test)
+    expect(
+      parseSpeedPacket(new Uint8Array([0x02, 0x01, 0x4c, 0x13, 0, 0, 0, 0, 0, 0])),
+    ).toBeCloseTo(49.4);
+  });
+
+  it("returns 0 for a stopped bike", () => {
+    expect(parseSpeedPacket(new Uint8Array([0x02, 0x01, 0x00, 0x00, 0, 0, 0, 0, 0, 0]))).toBe(0);
+  });
+
+  it("returns null for a state packet (byte[0]=0x03)", () => {
+    expect(
+      parseSpeedPacket(new Uint8Array([0x03, 0x00, 0x04, 0x00, 0x01, 0x04, 0, 0, 0, 0])),
+    ).toBeNull();
+  });
+
+  it("returns null for a timer packet (byte[0]=0x04)", () => {
+    expect(parseSpeedPacket(new Uint8Array([0x04, 0x01, 0x10, 0xb9, 0, 0, 0, 0, 0, 0]))).toBeNull();
+  });
+
+  it("returns null for an odometer packet (byte[0]=0x02, byte[1]=0x03)", () => {
+    expect(
+      parseSpeedPacket(
+        new Uint8Array([0x02, 0x03, 0x10, 0x0e, 0x58, 0xcc, 0xdf, 0x00, 0x19, 0x00]),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a too-short buffer", () => {
+    expect(parseSpeedPacket(new Uint8Array([0x02, 0x01, 0x10]))).toBeNull();
+  });
+});
+
 describe("startStateNotifications", () => {
   function makeNotifierGATT(notifierChar: object) {
     const service = {
@@ -410,6 +453,32 @@ describe("startStateNotifications", () => {
     char.emit([0x04, 0x01, 0x10, 0xb9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("calls onSpeed for speed packets (byte[0]=0x02, byte[1]=0x01)", async () => {
+    const char = makeNotifierChar();
+    const server = makeNotifierGATT(char);
+    const onState = vi.fn();
+    const onSpeed = vi.fn();
+
+    await startStateNotifications(server, onState, onSpeed);
+    // 0x0eba = 3770 → 37.70 km/h
+    char.emit([0x02, 0x01, 0xba, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+    expect(onState).not.toHaveBeenCalled();
+    expect(onSpeed).toHaveBeenCalledOnce();
+    expect(onSpeed).toHaveBeenCalledWith(expect.closeTo(37.7, 1));
+  });
+
+  it("does not call onSpeed for odometer packets (byte[0]=0x02, byte[1]=0x03)", async () => {
+    const char = makeNotifierChar();
+    const server = makeNotifierGATT(char);
+    const onSpeed = vi.fn();
+
+    await startStateNotifications(server, vi.fn(), onSpeed);
+    char.emit([0x02, 0x03, 0x10, 0x0e, 0x58, 0xcc, 0xdf, 0x00, 0x19, 0x00]);
+
+    expect(onSpeed).not.toHaveBeenCalled();
   });
 
   it("returns null when notifier characteristic is unavailable", async () => {

--- a/client/src/lib/super73-ble.ts
+++ b/client/src/lib/super73-ble.ts
@@ -197,14 +197,29 @@ export async function writeState(
 }
 
 /**
+ * Parse a speed telemetry packet (byte[0]=0x02, byte[1]=0x01).
+ * bytes[2-3] as little-endian uint16 / 100 = speed in km/h.
+ * Returns null for non-speed packets.
+ */
+export function parseSpeedPacket(bytes: Uint8Array): number | null {
+  if (bytes.length < 4 || bytes[0] !== 0x02 || bytes[1] !== 0x01) return null;
+  const raw = bytes[2]! | (bytes[3]! << 8);
+  return raw / 100;
+}
+
+/**
  * Subscribe to state change notifications pushed by the bike.
  * Returns a cleanup function on success, or null if the firmware doesn't support it.
- * Note: REGISTER_NOTIFIER_CHAR existence is documented but unconfirmed in practice —
- * the caller should treat null as "notifier unavailable" and fall back to polling.
+ *
+ * The S73 notifier multiplexes packet types on a single characteristic:
+ *   byte[0]=0x03 → state packet (mode/assist/light/region) — calls onState
+ *   byte[0]=0x02, byte[1]=0x01 → speed telemetry (km/h)   — calls onSpeed
+ *   byte[0]=0x02 other / 0x04  → odometer / timer          — ignored
  */
 export async function startStateNotifications(
   server: BluetoothRemoteGATTServer,
-  handler: (state: Super73State) => void,
+  onState: (state: Super73State) => void,
+  onSpeed?: (speedKmh: number) => void,
 ): Promise<(() => void) | null> {
   try {
     const service = await withTimeout(server.getPrimaryService(METRICS_SERVICE));
@@ -214,14 +229,15 @@ export async function startStateNotifications(
       const c = event.target as BluetoothRemoteGATTCharacteristic;
       if (!c.value) return;
       const bytes = new Uint8Array(c.value.buffer);
-      // The S73 notifier multiplexes state packets (byte[0]=0x03) with telemetry
-      // streams (byte[0]=0x02: speed/odometer/cadence, byte[0]=0x04: timer).
-      // Only state packets share the format parsed by parseStateBytes.
-      if (bytes[0] !== 0x03) return;
-      try {
-        handler(parseStateBytes(bytes, "notifier"));
-      } catch {
-        // malformed packet — skip
+      if (bytes[0] === 0x03) {
+        try {
+          onState(parseStateBytes(bytes, "notifier"));
+        } catch {
+          // malformed packet — skip
+        }
+      } else if (onSpeed) {
+        const speedKmh = parseSpeedPacket(bytes);
+        if (speedKmh !== null) onSpeed(speedKmh);
       }
     };
     char.addEventListener("characteristicvaluechanged", listener);


### PR DESCRIPTION
## Summary

- Auto-mode now uses the S73's own wheel speed sensor (BLE `02 01` packets) instead of GPS speed
- GPS speed kept as fallback when S73 is not connected
- `bikeSpeedKmh` exposed in `UseSuper73Result` for future UI use (e.g. show bike speed in tracking dashboard)

## Why

Auto-mode is 100% S73-specific (only active when connected). GPS speed is noisy at low speeds — exactly where the auto-mode thresholds (default 10/17 km/h) are most sensitive. The S73 wheel sensor gives accurate speed with no GPS dropout, tunnel blackout, or tree-canopy noise.

Reverse-engineered from field test logs: `02 01` notifier packets, bytes[2-3] as LE uint16 / 100 = km/h. Validated at 37 km/h (EPAC) and ~50 km/h (Off-Road).

## Changes

- `parseSpeedPacket()` — new exported fn, decodes `02 01` packets
- `startStateNotifications()` — optional `onSpeed` callback; routes `02 01` → speed, `03 xx` → state, everything else ignored
- `bikeSpeedKmh` state in `useSuper73Controller`, reset to `null` on disconnect
- Auto-mode effect + `cycleTripModeSelection`: `bikeSpeedKmh ?? tracking.speedKmh`

## Tests

9 new: `parseSpeedPacket` (7 cases) + `onSpeed` callback routing (2).
55 tests total passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)