### PR TITLE
feat(leaderboard): proportional layout + restore page title

### DIFF
--- a/client/src/components/leaderboard/CommunityChart.tsx
+++ b/client/src/components/leaderboard/CommunityChart.tsx
@@ -66,9 +66,9 @@ export function CommunityChart({ period, category, unit, categoryLabel }: Props)
 
   if (isPending || !data) {
     return (
-      <div className="mt-4">
+      <div className="flex h-full flex-col">
         <div className="mb-3 h-3 w-32 animate-pulse rounded bg-surface-container" />
-        <div className="h-40 animate-pulse rounded-xl bg-surface-container" />
+        <div className="flex-1 min-h-0 animate-pulse rounded-xl bg-surface-container" />
       </div>
     );
   }
@@ -82,13 +82,13 @@ export function CommunityChart({ period, category, unit, categoryLabel }: Props)
   }));
 
   return (
-    <div className="mt-4">
+    <div className="flex h-full flex-col">
       <h2 className="mb-3 text-[10px] font-bold uppercase tracking-wider text-text-muted">
         {t("community.chart.title")}
         {" · "}
         <span className="text-primary-light">{categoryLabel}</span>
       </h2>
-      <ResponsiveContainer width="100%" height={110}>
+      <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={points} margin={{ top: 8, right: 4, left: 4, bottom: 0 }}>
           <defs>
             <linearGradient id="communityChartGradient" x1="0" y1="0" x2="0" y2="1">

--- a/client/src/lib/__tests__/badges.test.ts
+++ b/client/src/lib/__tests__/badges.test.ts
@@ -1,27 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { evaluateBadges } from "../badges";
 
+const zero = { totalTrips: 0, totalKm: 0, totalCo2Kg: 0, totalMoneySaved: 0, currentStreak: 0 };
+
 describe("evaluateBadges", () => {
   it("all badges locked at zero stats", () => {
-    const badges = evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 });
+    const badges = evaluateBadges(zero);
     expect(badges.every((b) => !b.unlocked)).toBe(true);
     expect(badges.every((b) => b.progressRatio === 0)).toBe(true);
   });
   it("unlocks first trip badge at 1 trip", () => {
-    const badges = evaluateBadges({ totalTrips: 1, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 });
+    const badges = evaluateBadges({ ...zero, totalTrips: 1 });
     const first = badges.find((b) => b.id === "first_trip");
     expect(first?.unlocked).toBe(true);
     expect(first?.progressRatio).toBe(1);
   });
   it("shows progress toward 10 trips at 5 trips", () => {
-    const b = evaluateBadges({ totalTrips: 5, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }).find(
-      (b) => b.id === "trips_10",
-    );
+    const b = evaluateBadges({ ...zero, totalTrips: 5 }).find((b) => b.id === "trips_10");
     expect(b?.unlocked).toBe(false);
     expect(b?.progressRatio).toBeCloseTo(0.5);
   });
   it("unlocks badge at exact threshold", () => {
     const badges = evaluateBadges({
+      ...zero,
       totalTrips: 10,
       totalKm: 100,
       totalCo2Kg: 10,
@@ -33,14 +34,21 @@ describe("evaluateBadges", () => {
     expect(badges.find((b) => b.id === "streak_7")?.unlocked).toBe(true);
   });
   it("caps progress_ratio at 1", () => {
-    const b = evaluateBadges({ totalTrips: 200, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }).find(
-      (b) => b.id === "trips_100",
-    );
+    const b = evaluateBadges({ ...zero, totalTrips: 200 }).find((b) => b.id === "trips_100");
     expect(b?.progressRatio).toBe(1);
   });
-  it("returns all 12 badge definitions", () => {
-    expect(
-      evaluateBadges({ totalTrips: 0, totalKm: 0, totalCo2Kg: 0, currentStreak: 0 }),
-    ).toHaveLength(12);
+  it("unlocks money_100 badge at 100 EUR saved", () => {
+    const badges = evaluateBadges({ ...zero, totalMoneySaved: 100 });
+    const b = badges.find((b) => b.id === "money_100");
+    expect(b?.unlocked).toBe(true);
+    expect(b?.progressRatio).toBe(1);
+  });
+  it("shows progress toward money_100 at 50 EUR", () => {
+    const b = evaluateBadges({ ...zero, totalMoneySaved: 50 }).find((b) => b.id === "money_100");
+    expect(b?.unlocked).toBe(false);
+    expect(b?.progressRatio).toBeCloseTo(0.5);
+  });
+  it("returns all 13 badge definitions", () => {
+    expect(evaluateBadges(zero)).toHaveLength(13);
   });
 });

--- a/client/src/lib/badges.ts
+++ b/client/src/lib/badges.ts
@@ -10,7 +10,8 @@ type BadgeId =
   | "co2_100kg"
   | "co2_1t"
   | "streak_7"
-  | "streak_30";
+  | "streak_30"
+  | "money_100";
 
 interface BadgeMeta {
   label: string;
@@ -30,6 +31,7 @@ const BADGES: Record<BadgeId, BadgeMeta> = {
   co2_1t: { label: "1 tonne CO₂ économisée", icon: "🌲" },
   streak_7: { label: "7 jours de streak", icon: "🔥" },
   streak_30: { label: "30 jours de streak", icon: "⚡" },
+  money_100: { label: "100 € économisés", icon: "💰" },
 };
 
 export interface BadgeStatus {
@@ -44,7 +46,7 @@ export interface BadgeStatus {
 
 interface BadgeThreshold {
   id: BadgeId;
-  category: "trips" | "distance" | "co2" | "streak";
+  category: "trips" | "distance" | "co2" | "streak" | "money";
   threshold: number;
 }
 
@@ -61,12 +63,14 @@ const BADGE_THRESHOLDS: BadgeThreshold[] = [
   { id: "co2_1t", category: "co2", threshold: 1000 },
   { id: "streak_7", category: "streak", threshold: 7 },
   { id: "streak_30", category: "streak", threshold: 30 },
+  { id: "money_100", category: "money", threshold: 100 },
 ];
 
 export interface UserStats {
   totalTrips: number;
   totalKm: number;
   totalCo2Kg: number;
+  totalMoneySaved: number;
   currentStreak: number;
 }
 
@@ -74,6 +78,7 @@ const CATEGORY_TO_STAT: Record<string, keyof UserStats> = {
   trips: "totalTrips",
   distance: "totalKm",
   co2: "totalCo2Kg",
+  money: "totalMoneySaved",
   streak: "currentStreak",
 };
 

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -68,7 +68,7 @@ export function LeaderboardPage() {
   if (isPending || !data) {
     return (
       <div className="flex h-full flex-col">
-        <PageHeader title={t("leaderboard.header.title")} titleHidden />
+        <PageHeader title={t("leaderboard.header.title")} />
         <div
           className="flex flex-1 items-center justify-center"
           role="status"
@@ -87,7 +87,7 @@ export function LeaderboardPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <PageHeader title={t("leaderboard.header.title")} titleHidden />
+      <PageHeader title={t("leaderboard.header.title")} />
 
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden px-6">
         {/* Controls: period + category */}
@@ -151,13 +151,19 @@ export function LeaderboardPage() {
           </div>
         ) : (
           <>
-            {/* Podium — compact */}
-            <section className="mb-3 grid grid-cols-3 items-end gap-3 shrink-0">
+            {/* Podium — proportional to available height (~22%) */}
+            <section className="flex-[22] min-h-0 mb-3 grid grid-cols-3 items-end gap-3">
               {/* Rank 2 */}
               {top3[1] && (
                 <div className="flex flex-col items-center">
                   <div className="relative mb-2">
-                    <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border-2 border-text-dim bg-surface-high">
+                    <div
+                      className="flex items-center justify-center overflow-hidden rounded-full border-2 border-text-dim bg-surface-high"
+                      style={{
+                        width: "clamp(2.75rem, 9svh, 4rem)",
+                        height: "clamp(2.75rem, 9svh, 4rem)",
+                      }}
+                    >
                       <span className="text-lg font-bold text-text-muted">
                         {top3[1].name.charAt(0)}
                       </span>
@@ -179,7 +185,13 @@ export function LeaderboardPage() {
               {top3[0] && (
                 <div className="flex flex-col items-center">
                   <div className="relative mb-2">
-                    <div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-full border-4 border-primary shadow-[0_0_20px_rgba(84,233,138,0.3)] bg-surface-high">
+                    <div
+                      className="flex items-center justify-center overflow-hidden rounded-full border-4 border-primary shadow-[0_0_20px_rgba(84,233,138,0.3)] bg-surface-high"
+                      style={{
+                        width: "clamp(3.25rem, 11svh, 5rem)",
+                        height: "clamp(3.25rem, 11svh, 5rem)",
+                      }}
+                    >
                       <span className="text-2xl font-bold text-primary-light">
                         {top3[0].name.charAt(0)}
                       </span>
@@ -201,7 +213,13 @@ export function LeaderboardPage() {
               {top3[2] && (
                 <div className="flex flex-col items-center">
                   <div className="relative mb-2">
-                    <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border-2 border-surface-highest bg-surface-high">
+                    <div
+                      className="flex items-center justify-center overflow-hidden rounded-full border-2 border-surface-highest bg-surface-high"
+                      style={{
+                        width: "clamp(2.75rem, 9svh, 4rem)",
+                        height: "clamp(2.75rem, 9svh, 4rem)",
+                      }}
+                    >
                       <span className="text-lg font-bold text-text-muted">
                         {top3[2].name.charAt(0)}
                       </span>
@@ -220,8 +238,8 @@ export function LeaderboardPage() {
               )}
             </section>
 
-            {/* Leaderboard List — fills remaining space, clips overflow */}
-            <div className="flex flex-1 min-h-0 flex-col gap-1.5 overflow-hidden">
+            {/* Leaderboard List — proportional (~33%), clips overflow */}
+            <div className="flex-[33] min-h-0 flex flex-col gap-1.5 overflow-hidden">
               {rest.map((entry) => {
                 const isMe = entry.userId === currentUserId;
                 return (
@@ -266,19 +284,21 @@ export function LeaderboardPage() {
                 );
               })}
             </div>
+
+            {/* Community impact + chart — proportional (~45%), chart fills remaining height */}
+            <section className="flex-[45] min-h-0 mt-3 pb-3 flex flex-col">
+              <CommunityImpactBanner period={period} />
+              <div className="flex-1 min-h-0">
+                <CommunityChart
+                  period={period}
+                  category={category}
+                  unit={unit}
+                  categoryLabel={t(categoryLabelKeys[category])}
+                />
+              </div>
+            </section>
           </>
         )}
-
-        {/* Community impact + chart */}
-        <section className="mt-3 shrink-0 pb-3">
-          <CommunityImpactBanner period={period} />
-          <CommunityChart
-            period={period}
-            category={category}
-            unit={unit}
-            categoryLabel={t(categoryLabelKeys[category])}
-          />
-        </section>
       </div>
     </div>
   );

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -138,9 +138,9 @@ export function LeaderboardPage() {
           </div>
         </section>
 
-        {/* Leaderboard */}
+        {/* Leaderboard — podium + list (or empty state) */}
         {entries.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-6">
+          <div className="flex flex-[55] flex-col items-center justify-center gap-6">
             <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
               <Trophy size={40} className="text-primary-light" />
             </div>
@@ -284,21 +284,21 @@ export function LeaderboardPage() {
                 );
               })}
             </div>
-
-            {/* Community impact + chart — proportional (~45%), chart fills remaining height */}
-            <section className="flex-[45] min-h-0 mt-3 pb-3 flex flex-col">
-              <CommunityImpactBanner period={period} />
-              <div className="flex-1 min-h-0">
-                <CommunityChart
-                  period={period}
-                  category={category}
-                  unit={unit}
-                  categoryLabel={t(categoryLabelKeys[category])}
-                />
-              </div>
-            </section>
           </>
         )}
+
+        {/* Community impact + chart — always visible, proportional (~45%) */}
+        <section className="flex-[45] min-h-0 mt-3 pb-3 flex flex-col">
+          <CommunityImpactBanner period={period} />
+          <div className="flex-1 min-h-0">
+            <CommunityChart
+              period={period}
+              category={category}
+              unit={unit}
+              categoryLabel={t(categoryLabelKeys[category])}
+            />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/client/src/pages/__tests__/TripPage.interrupt.test.tsx
+++ b/client/src/pages/__tests__/TripPage.interrupt.test.tsx
@@ -68,6 +68,12 @@ vi.mock("@/hooks/useGpsTracking", () => ({
   getTrackingSession: () => null,
 }));
 
+vi.mock("@/lib/stopped-session", () => ({
+  getStoppedSession: () => null,
+  setStoppedSession: vi.fn(),
+  clearStoppedSession: vi.fn(),
+  hasStoppedSession: () => false,
+}));
 vi.mock("@/lib/offline-queue", () => ({ queueTrip: vi.fn() }));
 vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => false }));
 vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));

--- a/client/src/pages/__tests__/TripPage.preset.test.tsx
+++ b/client/src/pages/__tests__/TripPage.preset.test.tsx
@@ -77,6 +77,12 @@ vi.mock("@/hooks/useGpsTracking", () => ({
   getTrackingSession: () => null,
 }));
 
+vi.mock("@/lib/stopped-session", () => ({
+  getStoppedSession: () => null,
+  setStoppedSession: vi.fn(),
+  clearStoppedSession: vi.fn(),
+  hasStoppedSession: () => false,
+}));
 vi.mock("@/lib/offline-queue", () => ({ queueTrip: vi.fn() }));
 vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => false }));
 vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));

--- a/server/src/lib/__tests__/badges-db.test.ts
+++ b/server/src/lib/__tests__/badges-db.test.ts
@@ -12,7 +12,7 @@ vi.mock("../../db", () => ({
   },
 }));
 vi.mock("../../db/schema", () => ({
-  trips: { userId: {}, distanceKm: {}, co2SavedKg: {} },
+  trips: { userId: {}, distanceKm: {}, co2SavedKg: {}, moneySavedEur: {} },
   achievements: { userId: {}, badgeId: {} },
 }));
 vi.mock("../streaks", () => ({ computeStreak: vi.fn() }));
@@ -64,7 +64,9 @@ describe("evaluateAndUnlockBadges", () => {
   it("returns [] when no thresholds are met", async () => {
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 0, totalCo2SavedKg: 0, tripCount: 0 }]),
+        makeSelectChain([
+          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([]));
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
@@ -78,7 +80,9 @@ describe("evaluateAndUnlockBadges", () => {
     const insertChain = makeInsertChain();
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 10, totalCo2SavedKg: 1, tripCount: 1 }]),
+        makeSelectChain([
+          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([]));
     mockDb.insert.mockReturnValue(insertChain);
@@ -95,7 +99,9 @@ describe("evaluateAndUnlockBadges", () => {
   it("does not re-unlock already earned badges", async () => {
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 10, totalCo2SavedKg: 1, tripCount: 1 }]),
+        makeSelectChain([
+          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
@@ -109,7 +115,9 @@ describe("evaluateAndUnlockBadges", () => {
     const insertChain = makeInsertChain();
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 150, totalCo2SavedKg: 15, tripCount: 10 }]),
+        makeSelectChain([
+          { totalDistanceKm: 150, totalCo2SavedKg: 15, totalMoneySavedEur: 30, tripCount: 10 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([]));
     mockDb.insert.mockReturnValue(insertChain);
@@ -120,6 +128,22 @@ describe("evaluateAndUnlockBadges", () => {
     expect(result).toContain("trips_10");
     expect(result).toContain("km_100");
     expect(result).toContain("co2_10kg");
+  });
+
+  it("unlocks money_100 badge at 100 EUR saved", async () => {
+    const insertChain = makeInsertChain();
+    mockDb.select
+      .mockReturnValueOnce(
+        makeSelectChain([
+          { totalDistanceKm: 50, totalCo2SavedKg: 5, totalMoneySavedEur: 100, tripCount: 10 },
+        ]),
+      )
+      .mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(insertChain);
+    mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
+
+    const result = await evaluateAndUnlockBadges("user-1");
+    expect(result).toContain("money_100");
   });
 
   it("handles empty aggregate result gracefully (fallback to 0)", async () => {
@@ -139,7 +163,9 @@ describe("reevaluateBadges", () => {
   it("returns [] when all unlocked badges are still earned", async () => {
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 10, totalCo2SavedKg: 1, tripCount: 1 }]),
+        makeSelectChain([
+          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
@@ -153,7 +179,9 @@ describe("reevaluateBadges", () => {
     const deleteChain = makeDeleteChain();
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 5, totalCo2SavedKg: 0.5, tripCount: 5 }]),
+        makeSelectChain([
+          { totalDistanceKm: 5, totalCo2SavedKg: 0.5, totalMoneySavedEur: 2, tripCount: 5 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }, { badgeId: "trips_10" }]));
     mockDb.delete.mockReturnValue(deleteChain);
@@ -169,7 +197,9 @@ describe("reevaluateBadges", () => {
     const deleteChain = makeDeleteChain();
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 0, totalCo2SavedKg: 0, tripCount: 0 }]),
+        makeSelectChain([
+          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
+        ]),
       )
       .mockReturnValueOnce(
         makeSelectChain([
@@ -189,7 +219,9 @@ describe("reevaluateBadges", () => {
   it("returns [] when user has no badges", async () => {
     mockDb.select
       .mockReturnValueOnce(
-        makeSelectChain([{ totalDistanceKm: 0, totalCo2SavedKg: 0, tripCount: 0 }]),
+        makeSelectChain([
+          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
+        ]),
       )
       .mockReturnValueOnce(makeSelectChain([]));
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });

--- a/server/src/lib/__tests__/badges.test.ts
+++ b/server/src/lib/__tests__/badges.test.ts
@@ -11,6 +11,7 @@ function makeStats(overrides: Partial<UserStats> = {}): UserStats {
   return {
     totalDistanceKm: 0,
     totalCo2SavedKg: 0,
+    totalMoneySavedEur: 0,
     tripCount: 0,
     currentStreak: 0,
     ...overrides,
@@ -143,6 +144,20 @@ describe("BADGE_THRESHOLDS", () => {
 
     it("does not unlock at 29-day streak", () => {
       expect(BADGE_THRESHOLDS.streak_30(makeStats({ currentStreak: 29 }))).toBe(false);
+    });
+  });
+
+  describe("money_100", () => {
+    it("unlocks at exactly 100 EUR saved", () => {
+      expect(BADGE_THRESHOLDS.money_100(makeStats({ totalMoneySavedEur: 100 }))).toBe(true);
+    });
+
+    it("does not unlock at 99.99 EUR", () => {
+      expect(BADGE_THRESHOLDS.money_100(makeStats({ totalMoneySavedEur: 99.99 }))).toBe(false);
+    });
+
+    it("unlocks above threshold", () => {
+      expect(BADGE_THRESHOLDS.money_100(makeStats({ totalMoneySavedEur: 250 }))).toBe(true);
     });
   });
 

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -11,6 +11,7 @@ import type { BadgeId } from "@ecoride/shared/types";
 export interface UserStats {
   totalDistanceKm: number;
   totalCo2SavedKg: number;
+  totalMoneySavedEur: number;
   tripCount: number;
   currentStreak: number;
 }
@@ -28,6 +29,7 @@ export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
   co2_1t: (s) => s.totalCo2SavedKg >= 1000,
   streak_7: (s) => s.currentStreak >= 7,
   streak_30: (s) => s.currentStreak >= 30,
+  money_100: (s) => s.totalMoneySavedEur >= 100,
 };
 
 /**
@@ -42,6 +44,7 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
     .select({
       totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
       totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
       tripCount: count(),
     })
     .from(trips)
@@ -52,6 +55,7 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
   const userStats: UserStats = {
     totalDistanceKm: stats?.totalDistanceKm ?? 0,
     totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
+    totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
     tripCount: stats?.tripCount ?? 0,
     currentStreak: streaks.current,
   };
@@ -99,6 +103,7 @@ export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
     .select({
       totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
       totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
       tripCount: count(),
     })
     .from(trips)
@@ -109,6 +114,7 @@ export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
   const userStats: UserStats = {
     totalDistanceKm: stats?.totalDistanceKm ?? 0,
     totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
+    totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
     tripCount: stats?.tripCount ?? 0,
     currentStreak: streaks.current,
   };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -123,6 +123,7 @@ export const BADGES = {
   co2_1t: { id: "co2_1t", label: "1 tonne CO₂ économisée", icon: "🌲" },
   streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥" },
   streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡" },
+  money_100: { id: "money_100", label: "100 € économisés", icon: "💰" },
 } as const;
 
 export type BadgeId = keyof typeof BADGES;


### PR DESCRIPTION
## Summary

### Layout proportionnel (page Commu)
- Distribue l'espace vertical proportionnellement entre podium (22%), liste (33%) et section communauté (45%) via `flex-[n]` — élimine le vide béant sur grands écrans
- Scale les avatars podium avec `clamp()` basé sur `svh`
- `CommunityChart` remplit son conteneur (`height="100%"`) au lieu de `110px` fixe
- Titre "Commu" restauré (suppression de `titleHidden`)

### Fix tests (pré-existants sur main)
- `useSessionRecovery` appelait `localStorage.getItem` au mount dans les tests TripPage → mock `@/lib/stopped-session` dans les 2 fichiers concernés

### Badge 💰 100€ économisés (closes #264)
- Nouveau badge `money_100` déclenché quand l'utilisateur cumule ≥ 100 € économisés
- Serveur : `UserStats.totalMoneySavedEur` + `SUM(moneySavedEur)` dans les deux fonctions d'évaluation (unlock + revocation)
- Client : nouvelle catégorie `money` dans `BADGE_THRESHOLDS` + `CATEGORY_TO_STAT` + `UserStats`
- Affiché automatiquement dans la grille de badges (ProfilePage lit `BADGES` depuis shared/types)
- 6 nouveaux tests : 3 threshold (serveur), 2 evaluateBadges (client), 1 DB integration

## Test plan

- [ ] Page Commu : les 3 sections remplissent l'écran proportionnellement (iPhone SE et 15 Pro Max)
- [ ] Titre "Commu" visible
- [ ] Badge 💰 visible dans la grille profil (verrouillé < 100€, déverrouillé ≥ 100€)
- [ ] `bun test` : 250 client + 283 serveur

🤖 Generated with [Claude Code](https://claude.com/claude-code)