### PR TITLE
fix(navigation): instructions update synchronously with GPS point

### DIFF
--- a/client/src/hooks/__tests__/useNavigation.test.ts
+++ b/client/src/hooks/__tests__/useNavigation.test.ts
@@ -212,6 +212,29 @@ describe("useNavigation", () => {
     expect(result.current.isDeviated).toBe(true);
   });
 
+  it("instructions update in the same render as the GPS point — no extra act() needed (regression #271)", async () => {
+    // Bug: step advancement was in a useEffect, so instructions lagged one render
+    // behind the map position. Fix: useMemo computes step index synchronously during render.
+    const { result, rerender } = renderHook(
+      ({ point }: { point: { lat: number; lng: number; ts: number } }) =>
+        useNavigation({ currentPoint: point, lastAccuracy: 10 }),
+      { initialProps: { point: { lat: 48.8566, lng: 2.3522, ts: 0 } } },
+    );
+
+    await act(async () => {
+      result.current.setDestination(FIXTURE_DESTINATION, { lat: 48.8566, lng: 2.3522, ts: 0 });
+    });
+
+    expect(result.current.nextInstruction).toBe("Continuez tout droit");
+
+    // Move to the waypoint that ends step 0 — rerender only, no extra act()
+    rerender({ point: { lat: 48.84, lng: 2.3, ts: 1000 } });
+
+    // Instructions must be updated immediately, in the same render — not one cycle later
+    expect(result.current.nextInstruction).toBe("Tournez à gauche");
+    expect(result.current.currentStepType).toBe(1);
+  });
+
   it("remainingCoordinates shrinks as steps advance", async () => {
     // Start at the waypoint that ends step 0 (coord index 1) to trigger step advancement
     const { result, rerender } = renderHook(

--- a/client/src/hooks/useNavigation.ts
+++ b/client/src/hooks/useNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchRoute } from "@/lib/ors";
 import { haversineDistance } from "@/lib/haversine";
 import type { NavigationRoute, GpsPoint } from "@ecoride/shared/types";
@@ -112,11 +112,14 @@ export function useNavigation({
   const [isLoading, setIsLoading] = useState(false);
   const [isDeviated, setIsDeviated] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [isArrived, setIsArrived] = useState(false);
 
   const lastRecalculRef = useRef<number>(0);
   const destinationRef = useRef<Destination | null>(null);
+  // Tracks current step index without triggering a re-render — updated synchronously
+  // inside the useMemo below so instructions update in the same render as the GPS point.
+  const currentStepIndexRef = useRef(0);
+  const prevRouteRef = useRef<NavigationRoute | null>(null);
 
   // Keep ref in sync for use inside effects without stale closures
   destinationRef.current = destination;
@@ -127,7 +130,7 @@ export function useNavigation({
     try {
       const r = await fetchRoute(startLat, startLon, dest.lat, dest.lon);
       setRoute(r);
-      setCurrentStepIndex(0);
+      currentStepIndexRef.current = 0;
       setIsArrived(false);
       setIsDeviated(false);
       // Reset cooldown after every successful route load (initial + recalculs)
@@ -144,7 +147,7 @@ export function useNavigation({
     (dest: Destination | null, currentPointArg?: GpsPoint | null) => {
       setDestinationState(dest);
       setRoute(null);
-      setCurrentStepIndex(0);
+      currentStepIndexRef.current = 0;
       setIsArrived(false);
       setError(null);
       setIsDeviated(false);
@@ -160,14 +163,33 @@ export function useNavigation({
   const clearRoute = useCallback(() => {
     setDestinationState(null);
     setRoute(null);
-    setCurrentStepIndex(0);
+    currentStepIndexRef.current = 0;
     setIsArrived(false);
     setError(null);
     setIsDeviated(false);
     lastRecalculRef.current = 0;
   }, []);
 
-  // Deviation detection + step advancement
+  // Step advancement — synchronous during render so instructions update in the same
+  // render cycle as the GPS point (no extra render = no visible lag on the banner).
+  const currentStepIndex = useMemo(() => {
+    // Reset index when the route object changes (new route loaded or cleared)
+    if (route !== prevRouteRef.current) {
+      currentStepIndexRef.current = 0;
+      prevRouteRef.current = route;
+    }
+    if (!route || !currentPoint || isArrived) return currentStepIndexRef.current;
+    const newIdx = findCurrentStepIndex(
+      currentPoint.lat,
+      currentPoint.lng,
+      route,
+      currentStepIndexRef.current,
+    );
+    currentStepIndexRef.current = newIdx;
+    return newIdx;
+  }, [route, currentPoint, isArrived]);
+
+  // Side effects only: arrival detection + deviation/recalcul (async, not render-blocking)
   useEffect(() => {
     if (!route || !currentPoint || isArrived) return;
 
@@ -184,12 +206,6 @@ export function useNavigation({
       }
     }
 
-    // Advance step
-    const newStepIndex = findCurrentStepIndex(lat, lon, route, currentStepIndex);
-    if (newStepIndex !== currentStepIndex) {
-      setCurrentStepIndex(newStepIndex);
-    }
-
     // Deviation check — only when GPS is accurate enough
     if (lastAccuracy == null || lastAccuracy >= ACCURACY_THRESHOLD_M) return;
     if (Date.now() - lastRecalculRef.current < RECALCUL_COOLDOWN_MS) return;
@@ -200,7 +216,7 @@ export function useNavigation({
       lastRecalculRef.current = Date.now();
       void loadRoute(lat, lon, dest);
     }
-  }, [currentPoint, lastAccuracy, route, currentStepIndex, isArrived, loadRoute]);
+  }, [currentPoint, lastAccuracy, route, isArrived, loadRoute]);
 
   // Derived values
   const currentStep = route && !isArrived ? (route.steps[currentStepIndex] ?? null) : null;


### PR DESCRIPTION
Fixes #271

## Problème

Virginia Tournier signale que la carte GPS est fluide mais les indications de navigation (prochaine instruction, distance) ont un temps de retard.

**Cause** : l'avancement des étapes était calculé dans un `useEffect`. Quand un nouveau point GPS arrive :
1. Render 1 → la carte avance (lit directement `gpsPoints`)
2. `useEffect` se déclenche → `setCurrentStepIndex(newIdx)` → Render 2 → les instructions se mettent à jour

**Résultat** : un render de décalage systématique entre la carte et le bandeau d'instructions.

## Fix

Remplace `useState` + `useEffect` pour `currentStepIndex` par `useRef` + `useMemo` :
- Le step index est calculé **synchronement pendant le render** → instructions et carte s'affichent dans le même cycle
- La détection de déviation et d'arrivée reste dans un `useEffect` (effets asynchrones, pas bloquants)

## Test de régression

Nouveau test : `"instructions update in the same render as the GPS point — no extra act() needed (regression #271)"` — vérifie que `nextInstruction` est mis à jour immédiatement après `rerender`, sans `act()` supplémentaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)