### PR TITLE
chore(ble): disable EPAC poll pending notifier validation

### DIFF
--- a/client/src/hooks/__tests__/useSuper73.test.tsx
+++ b/client/src/hooks/__tests__/useSuper73.test.tsx
@@ -251,94 +251,13 @@ describe("useSuper73 provider", () => {
     });
   });
 
-  it("polls the bike and resets to EPAC when assist reaches the trigger level", async () => {
-    vi.useFakeTimers();
-
-    render(
-      <Super73Provider enabled>
-        <Consumer label="vehicle" />
-      </Super73Provider>,
-    );
-
-    fireEvent.click(screen.getByText("vehicle connect"));
-
-    // Flush async connection chain (readState + applyConnectionPreferences)
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    expect(screen.getByText("vehicle:connected")).toBeTruthy();
-
-    // Simulate bike state: rider set assist to 3 while in race mode
-    readStateMock.mockResolvedValue({ ...baseState, mode: "race", assist: 3 });
-    writeStateMock.mockClear();
-
-    // Advance past the poll interval and flush async poll callback
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-
-    expect(writeStateMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ mode: "eco", assist: 3 }),
-    );
-    expect(screen.getByText("vehicle-mode:eco")).toBeTruthy();
-  }, 15_000);
-
-  it("does not write when assist is at trigger level but mode is already eco", async () => {
-    vi.useFakeTimers();
-
-    render(
-      <Super73Provider enabled>
-        <Consumer label="noop" />
-      </Super73Provider>,
-    );
-
-    fireEvent.click(screen.getByText("noop connect"));
-
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    expect(screen.getByText("noop:connected")).toBeTruthy();
-
-    // assist=3 but already in eco → no write expected
-    readStateMock.mockResolvedValue({ ...baseState, mode: "eco", assist: 3 });
-    writeStateMock.mockClear();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-
-    expect(writeStateMock).not.toHaveBeenCalled();
-  }, 15_000);
-
-  it("sets epacPollFallbackWarning when poll catches the EPAC trigger (notifier unavailable)", async () => {
-    vi.useFakeTimers();
-
-    render(
-      <Super73Provider enabled>
-        <Consumer label="warn" />
-      </Super73Provider>,
-    );
-
-    fireEvent.click(screen.getByText("warn connect"));
-
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
-
-    expect(screen.getByText("warn:connected")).toBeTruthy();
-    expect(screen.getByText("warn-poll-warning:no")).toBeTruthy();
-
-    readStateMock.mockResolvedValue({ ...baseState, mode: "race", assist: 3 });
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-
-    expect(screen.getByText("warn-poll-warning:yes")).toBeTruthy();
-  }, 15_000);
+  // TODO: poll disabled — these three tests cover the fixed-interval EPAC poll which is
+  // currently commented out in useSuper73.ts pending observation. Re-enable if poll is
+  // reintroduced; delete if poll is removed permanently.
+  //
+  // it("polls the bike and resets to EPAC when assist reaches the trigger level", ...)
+  // it("does not write when assist is at trigger level but mode is already eco", ...)
+  // it("sets epacPollFallbackWarning when poll catches the EPAC trigger (notifier unavailable)", ...)
 
   it("switches automatically to off-road then back to eco when speed crosses thresholds", async () => {
     const { rerender } = render(

--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -35,7 +35,11 @@ export type BleStatus = "disconnected" | "connecting" | "connected" | "unsupport
 const STATE_KEY = "ecoride-super73-state";
 const RECONNECT_DELAY = 2_000;
 const MAX_RECONNECT_ATTEMPTS = 1;
-const EPAC_TRIGGER_POLL_INTERVAL_MS = 5_000;
+// TODO: EPAC poll disabled for observation — the BLE notifier appears reliable on all
+// tested firmware versions. If no regression is reported, remove poll entirely.
+// If a firmware where the notifier silently fails is found, re-enable and consider
+// a smarter trigger (one-shot after action rather than fixed interval).
+// const EPAC_TRIGGER_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_AUTO_MODE_LOW_SPEED_KMH = 10;
 const DEFAULT_AUTO_MODE_HIGH_SPEED_KMH = 17;
 
@@ -476,37 +480,35 @@ function useSuper73Controller(
     preferences.autoModeHighSpeedKmh,
   ]);
 
-  // Poll the bike state every EPAC_TRIGGER_POLL_INTERVAL_MS when connected.
-  // If the rider has set assist to ASSIST_EPAC_TRIGGER from the physical buttons,
-  // force the mode back to eco (EPAC). This is the "reset from the bike" gesture.
-  useEffect(() => {
-    if (status !== "connected") return;
-
-    const pollId = setInterval(async () => {
-      if (isPollActiveRef.current || !serverRef.current?.connected) return;
-      isPollActiveRef.current = true;
-      try {
-        const polledState = await readState(serverRef.current);
-        setBikeState(polledState);
-        cacheState(polledState);
-        if (shouldTriggerEpac(polledState)) {
-          // Notifier didn't catch it (otherwise mode would already be eco).
-          // Show a warning so the user knows the notifier isn't firing.
-          setEpacPollFallbackWarning(true);
-          const epacState: Super73State = { ...polledState, mode: "eco" };
-          await writeState(serverRef.current, epacState);
-          setBikeState(epacState);
-          cacheState(epacState);
-        }
-      } catch {
-        // Poll silently skipped — will retry on next interval.
-      } finally {
-        isPollActiveRef.current = false;
-      }
-    }, EPAC_TRIGGER_POLL_INTERVAL_MS);
-
-    return () => clearInterval(pollId);
-  }, [status]);
+  // TODO: poll disabled — see EPAC_TRIGGER_POLL_INTERVAL_MS comment above.
+  // useEffect(() => {
+  //   if (status !== "connected") return;
+  //
+  //   const pollId = setInterval(async () => {
+  //     if (isPollActiveRef.current || !serverRef.current?.connected) return;
+  //     isPollActiveRef.current = true;
+  //     try {
+  //       const polledState = await readState(serverRef.current);
+  //       setBikeState(polledState);
+  //       cacheState(polledState);
+  //       if (shouldTriggerEpac(polledState)) {
+  //         // Notifier didn't catch it (otherwise mode would already be eco).
+  //         // Show a warning so the user knows the notifier isn't firing.
+  //         setEpacPollFallbackWarning(true);
+  //         const epacState: Super73State = { ...polledState, mode: "eco" };
+  //         await writeState(serverRef.current, epacState);
+  //         setBikeState(epacState);
+  //         cacheState(epacState);
+  //       }
+  //     } catch {
+  //       // Poll silently skipped — will retry on next interval.
+  //     } finally {
+  //       isPollActiveRef.current = false;
+  //     }
+  //   }, EPAC_TRIGGER_POLL_INTERVAL_MS);
+  //
+  //   return () => clearInterval(pollId);
+  // }, [status]);
 
   const dismissEpacPollFallback = useCallback(() => setEpacPollFallbackWarning(false), []);
 


### PR DESCRIPTION
## Summary

- Commente le poll BLE à 5s sur le S73 (EPAC trigger fallback)
- Le notifier `startStateNotifications` est fiable sur tous les firmwares testés — le poll était du code défensif basé sur l'incertitude du reverse-engineering, pas un bug observé
- TODO inline : supprimer définitivement si pas de régression, ou réintégrer avec un trigger one-shot-après-action si un firmware cassé est trouvé

## Test plan

- [ ] Connecter le S73 via BLE
- [ ] Changer mode/assist/lumière depuis l'app → le notifier met à jour l'état correctement
- [ ] Changer assist depuis les boutons physiques → vérifier que le mode EPAC se déclenche bien via le notifier
- [ ] Vérifier que `epacPollFallbackWarning` ne s'affiche pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)