### PR TITLE
fix(ui): rename interrupt button from "Terminer" to "Enregistrer"

### DIFF
--- a/client/e2e/trip-interrupt-menu.spec.ts
+++ b/client/e2e/trip-interrupt-menu.spec.ts
@@ -22,7 +22,7 @@ test("interrupt button pauses the trip and opens the interrupt menu", async ({ p
   const menu = page.getByRole("dialog", { name: "Menu d'interruption du trajet" });
   await expect(menu).toBeVisible();
   await expect(page.getByRole("button", { name: "Reprendre" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Terminer" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Enregistrer" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Abandonner" })).toBeVisible();
   await expect(page.getByLabel("Trajet en pause")).toBeVisible();
 });

--- a/client/src/components/trip/InterruptMenu.tsx
+++ b/client/src/components/trip/InterruptMenu.tsx
@@ -55,7 +55,7 @@ export function InterruptMenu({
             className="flex w-full items-center justify-center gap-3 rounded-2xl bg-surface-high py-4 text-base font-bold text-text active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Square size={18} fill="currentColor" />
-            {t("trip.interrupt.finish")}
+            {t("trip.interrupt.save")}
           </button>
           <button
             onClick={onAbandon}

--- a/client/src/components/trip/__tests__/InterruptMenu.test.tsx
+++ b/client/src/components/trip/__tests__/InterruptMenu.test.tsx
@@ -17,15 +17,15 @@ describe("InterruptMenu", () => {
     onClose: vi.fn(),
   };
 
-  it("disables Terminer when canStop is false", () => {
+  it("disables Enregistrer when canStop is false", () => {
     renderWithI18n(<InterruptMenu {...baseProps} canStop={false} />);
-    const btn = screen.getByRole("button", { name: "Terminer" }) as HTMLButtonElement;
+    const btn = screen.getByRole("button", { name: "Enregistrer" }) as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
   });
 
-  it("enables Terminer when canStop is true", () => {
+  it("enables Enregistrer when canStop is true", () => {
     renderWithI18n(<InterruptMenu {...baseProps} canStop={true} />);
-    const btn = screen.getByRole("button", { name: "Terminer" }) as HTMLButtonElement;
+    const btn = screen.getByRole("button", { name: "Enregistrer" }) as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
   });
 });

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -49,10 +49,10 @@ export const en: Record<TranslationKey, string> = {
 
   "trip.interrupt.dialogAria": "Trip interrupt menu",
   "trip.interrupt.title": "Trip paused",
-  "trip.interrupt.subtitle": "Resume, finish or abandon this trip.",
+  "trip.interrupt.subtitle": "Resume, save or abandon this trip.",
   "trip.interrupt.closeAria": "Close the interrupt menu",
   "trip.interrupt.resume": "Resume",
-  "trip.interrupt.finish": "Finish",
+  "trip.interrupt.save": "Save",
   "trip.interrupt.abandon": "Abandon",
   "trip.interrupt.tooShort": "Distance too short to save",
 

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -47,10 +47,10 @@ export const fr = {
 
   "trip.interrupt.dialogAria": "Menu d'interruption du trajet",
   "trip.interrupt.title": "Trajet interrompu",
-  "trip.interrupt.subtitle": "Reprendre, terminer ou abandonner ce trajet.",
+  "trip.interrupt.subtitle": "Reprendre, enregistrer ou abandonner ce trajet.",
   "trip.interrupt.closeAria": "Fermer le menu d'interruption",
   "trip.interrupt.resume": "Reprendre",
-  "trip.interrupt.finish": "Terminer",
+  "trip.interrupt.save": "Enregistrer",
   "trip.interrupt.abandon": "Abandonner",
   "trip.interrupt.tooShort": "Distance trop courte pour enregistrer",
 

--- a/client/src/pages/__tests__/TripPage.interrupt.test.tsx
+++ b/client/src/pages/__tests__/TripPage.interrupt.test.tsx
@@ -114,7 +114,7 @@ describe("TripPage interrupt finish flow", () => {
       expect(screen.getByRole("dialog", { name: "Menu d'interruption du trajet" })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Terminer" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enregistrer" }));
 
     expect(stopMock).toHaveBeenCalledOnce();
     expect(mutateMock).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Le bouton de sauvegarde dans `InterruptMenu` affichait "Terminer" alors qu'il enregistre directement le trajet
- Renommé la clé i18n `trip.interrupt.finish` → `trip.interrupt.save` (fr: "Enregistrer", en: "Save")
- Sous-titre du dialog mis à jour pour cohérence
- Test mis à jour pour chercher le nouveau label

Closes #276

## Test plan

- [ ] Démarrer un trajet, cliquer "Interrompre" → le bouton du bas affiche bien "Enregistrer"
- [ ] Cliquer "Enregistrer" → le trajet est sauvegardé normalement
- [ ] `vitest run TripPage.interrupt` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)