### PR TITLE
fix: localize fuel price to Annemasse

### DIFF
--- a/client/e2e/smoke.spec.ts
+++ b/client/e2e/smoke.spec.ts
@@ -80,9 +80,9 @@ for (const { path, name } of PAGES) {
           body: JSON.stringify({
             ok: true,
             data: {
-              priceEur: 1.75,
+              priceEur: 2.02,
               fuelType: "sp95",
-              stationName: "Prix moyen national",
+              stationName: "6 Route des Vallées, Annemasse",
               updatedAt: new Date().toISOString(),
             },
           }),

--- a/server/src/lib/__tests__/fuel-price.test.ts
+++ b/server/src/lib/__tests__/fuel-price.test.ts
@@ -54,15 +54,74 @@ describe("getFuelPrice", () => {
     expect(result.priceEur).toBe(FALLBACK_PRICES.e85);
   });
 
-  it("returns API price when API returns a valid result", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+  it("defaults coord-less lookups to Annemasse and returns the nearest station", async () => {
+    let capturedUrl: string | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      capturedUrl = decodeURIComponent(String(url));
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              adresse: "6 Route des Vallées",
+              ville: "Annemasse",
+              e10_prix: 2.024,
+              e10_maj: "2026-04-18T06:41:00Z",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const result = await getFuelPrice("sp95");
+
+    expect(capturedUrl).toContain("6.2376");
+    expect(capturedUrl).toContain("46.1944");
+    expect(capturedUrl).toContain("within_distance");
+    expect(result.priceEur).toBe(2.024);
+    expect(result.stationName).toBe("6 Route des Vallées, Annemasse");
+    expect(result.fuelType).toBe("sp95");
+  });
+
+  it("uses requested French coords and fuel-specific fields when lat/lng are provided", async () => {
+    let capturedUrl: string | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      capturedUrl = decodeURIComponent(String(url));
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              adresse: "Rue de Lyon",
+              ville: "Lyon",
+              sp98_prix: 1.91,
+              sp98_maj: "2026-04-19T10:00:00Z",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const result = await getFuelPrice("sp98", 45.75, 4.85);
+
+    expect(capturedUrl).toContain("4.85");
+    expect(capturedUrl).toContain("45.75");
+    expect(capturedUrl).toContain("within_distance");
+    expect(capturedUrl).toContain("sp98_prix");
+    expect(result.priceEur).toBe(1.91);
+    expect(result.stationName).toBe("Rue de Lyon, Lyon");
+  });
+
+  it("caches results to avoid repeated fetch calls", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
           results: [
             {
-              nom_ev: "Station Total",
-              prix_valeur: 1820, // stored as milli-euros: 1820 = 1.820 EUR
-              prix_maj: "2025-06-15T10:00:00Z",
+              adresse: "Station GPL",
+              ville: "Annemasse",
+              gplc_prix: 1.02,
+              gplc_maj: "2025-01-01",
             },
           ],
         }),
@@ -70,41 +129,9 @@ describe("getFuelPrice", () => {
       ),
     );
 
-    const result = await getFuelPrice("sp98");
-    expect(result.priceEur).toBe(1.82);
-    expect(result.stationName).toBe("Station Total");
-    expect(result.fuelType).toBe("sp98");
-  });
-
-  it("uses geo params when lat/lng are provided", async () => {
-    let capturedUrl: string | undefined;
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
-      capturedUrl = decodeURIComponent(String(url));
-      return new Response(JSON.stringify({ results: [] }), { status: 200 });
-    });
-
-    await getFuelPrice("sp95", 48.85, 2.35);
-    // URL params encode spaces as '+', so check for the parts individually
-    expect(capturedUrl).toContain("2.35");
-    expect(capturedUrl).toContain("48.85");
-    expect(capturedUrl).toContain("within_distance");
-    expect(capturedUrl).toContain("distance(geom");
-  });
-
-  it("caches results to avoid repeated fetch calls", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          results: [{ nom_ev: "Cached", prix_valeur: 1900, prix_maj: "2025-01-01" }],
-        }),
-        { status: 200 },
-      ),
-    );
-
-    // Two calls with same key
     await getFuelPrice("gpl");
     await getFuelPrice("gpl");
-    // Second call should be served from cache — fetch only called once
+
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -113,30 +140,27 @@ describe("getFuelPrice", () => {
   it("uses EU Oil Bulletin snapshot for Belgian coordinates and skips French API", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    // Brussels
     const result = await getFuelPrice("sp95", 50.85, 4.35);
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.fuelType).toBe("sp95");
-    expect(result.priceEur).toBe(1.72); // BE sp95 from EU_COUNTRY_PRICES
+    expect(result.priceEur).toBe(1.72);
     expect(result.stationName).toBe("EU Oil Bulletin (BE)");
   });
 
   it("uses EU snapshot for German diesel and still skips the French API", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    // Berlin
     const result = await getFuelPrice("diesel", 52.52, 13.4);
 
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(result.priceEur).toBe(1.65); // DE diesel
+    expect(result.priceEur).toBe(1.65);
     expect(result.stationName).toBe("EU Oil Bulletin (DE)");
   });
 
   it("falls back to French hardcoded average for coords outside any known country", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    // Middle of the Atlantic
     const result = await getFuelPrice("sp95", 0, -30);
 
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -147,7 +171,6 @@ describe("getFuelPrice", () => {
   it("falls back to French hardcoded average when EU country has no price for the fuel type", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    // Brussels + E85 (not published in EU Oil Bulletin for BE)
     const result = await getFuelPrice("e85", 50.85, 4.35);
 
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -155,39 +178,20 @@ describe("getFuelPrice", () => {
     expect(result.stationName).toBeUndefined();
   });
 
-  it("still uses the French API for coordinates inside France", async () => {
-    let capturedUrl: string | undefined;
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
-      capturedUrl = String(url);
-      return new Response(
-        JSON.stringify({
-          results: [{ nom_ev: "Station Lyon", prix_valeur: 1710, prix_maj: "2025-06-15" }],
-        }),
-        { status: 200 },
-      );
-    });
-
-    // Lyon
-    const result = await getFuelPrice("sp95", 45.75, 4.85);
-
-    expect(capturedUrl).toContain("data.economie.gouv.fr");
-    expect(result.priceEur).toBe(1.71);
-    expect(result.stationName).toBe("Station Lyon");
-  });
-
-  it("handles missing prix_valeur by falling back to hardcoded price", async () => {
+  it("handles missing fuel-specific price field by falling back to hardcoded price", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
-          results: [{ nom_ev: "NoPrix", prix_maj: "2025-01-01" }],
+          results: [{ adresse: "NoPrix", ville: "Annemasse", e10_maj: "2025-01-01" }],
         }),
         { status: 200 },
       ),
     );
 
-    const result = await getFuelPrice("sp95", 1.0, 2.0); // different key to bypass cache
-    // prix_valeur undefined => FALLBACK_PRICES[sp95] * 1000 / 1000 = 1.75
+    const result = await getFuelPrice("sp95", 45.0, 2.0);
+
     expect(result.priceEur).toBe(FALLBACK_PRICES.sp95);
+    expect(result.stationName).toBe("NoPrix, Annemasse");
   });
 });
 

--- a/server/src/lib/fuel-price.ts
+++ b/server/src/lib/fuel-price.ts
@@ -49,25 +49,38 @@ const FALLBACK_PRICES: Record<FuelType, number> = {
   gpl: 0.95,
 };
 
-// Map our fuel types to the API's fuel type codes
-const FUEL_TYPE_API_CODES: Record<FuelType, string> = {
-  sp95: "E10",
-  sp98: "SP98",
-  diesel: "Gazole",
-  e85: "E85",
-  gpl: "GPLc",
+const DEFAULT_FRANCE_LOOKUP = {
+  lat: 46.1944,
+  lng: 6.2376,
 };
+
+const FUEL_TYPE_API_FIELDS: Record<FuelType, { price: string; updatedAt: string }> = {
+  sp95: { price: "e10_prix", updatedAt: "e10_maj" },
+  sp98: { price: "sp98_prix", updatedAt: "sp98_maj" },
+  diesel: { price: "gazole_prix", updatedAt: "gazole_maj" },
+  e85: { price: "e85_prix", updatedAt: "e85_maj" },
+  gpl: { price: "gplc_prix", updatedAt: "gplc_maj" },
+};
+
+function formatStationName(address?: string, city?: string): string | undefined {
+  const parts = [address?.trim(), city?.trim()].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
 
 /**
  * Fetch fuel price from the French open data API.
- * Uses geolocation to find nearby stations. Falls back to national average.
+ * Uses caller coordinates when available, otherwise defaults to Annemasse so
+ * profile lookups stay local to ecoRide's operating area.
  */
 export async function getFuelPrice(
   fuelType: FuelType,
   lat?: number,
   lng?: number,
 ): Promise<CachedPrice> {
-  const cacheKey = `${fuelType}-${lat?.toFixed(2)}-${lng?.toFixed(2)}`;
+  const hasExplicitCoords = lat !== undefined && lng !== undefined;
+  const lookupLat = hasExplicitCoords ? lat : DEFAULT_FRANCE_LOOKUP.lat;
+  const lookupLng = hasExplicitCoords ? lng : DEFAULT_FRANCE_LOOKUP.lng;
+  const cacheKey = `${fuelType}-${lookupLat.toFixed(2)}-${lookupLng.toFixed(2)}`;
   const cached = cache.get(cacheKey);
   if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
     return cached;
@@ -75,11 +88,13 @@ export async function getFuelPrice(
 
   // Outside France: skip the French station API entirely and use the EU
   // Weekly Oil Bulletin snapshot for the detected country (issue #94).
-  // Check specific EU country bboxes before the France bbox, because the
-  // France bbox overlaps small neighbours like Belgium and Luxembourg.
-  if (lat !== undefined && lng !== undefined) {
-    const country = detectEuCountry(lat, lng);
-    const useEuPath = country !== undefined || !isInFrance(lat, lng);
+  // Coord-less requests intentionally stay on the French path because the
+  // profile card defaults to a local Annemasse station lookup.
+  if (hasExplicitCoords) {
+    // Check specific EU country bboxes before the France bbox, because the
+    // France bbox overlaps small neighbours like Belgium and Luxembourg.
+    const country = detectEuCountry(lookupLat, lookupLng);
+    const useEuPath = country !== undefined || !isInFrance(lookupLat, lookupLng);
     if (useEuPath) {
       const euPrice = country ? lookupEuPrice(country, fuelType) : undefined;
       if (country && euPrice !== undefined) {
@@ -109,21 +124,13 @@ export async function getFuelPrice(
   }
 
   try {
-    const apiCode = FUEL_TYPE_API_CODES[fuelType];
+    const apiFields = FUEL_TYPE_API_FIELDS[fuelType];
     const params = new URLSearchParams({
-      select: "nom_ev,prix_valeur,prix_maj",
-      where: `carburants_disponibles LIKE '%${apiCode}%' AND prix_nom='${apiCode}'`,
-      order_by: "prix_maj DESC",
+      select: `adresse,ville,${apiFields.price},${apiFields.updatedAt}`,
+      where: `${apiFields.price} is not null AND within_distance(geom, geom'POINT(${lookupLng} ${lookupLat})', 20km)`,
+      order_by: `distance(geom, geom'POINT(${lookupLng} ${lookupLat})')`,
       limit: "1",
     });
-
-    if (lat !== undefined && lng !== undefined) {
-      params.set(
-        "where",
-        `${params.get("where")} AND within_distance(geom, GEOM'POINT(${lng} ${lat})', 20km)`,
-      );
-      params.set("order_by", `distance(geom, GEOM'POINT(${lng} ${lat})')`);
-    }
 
     const url = `https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-des-carburants-en-france-flux-instantane-v2/records?${params}`;
     const response = await fetch(url, { signal: AbortSignal.timeout(1500) });
@@ -133,20 +140,19 @@ export async function getFuelPrice(
     }
 
     const data = (await response.json()) as {
-      results: Array<{
-        nom_ev?: string;
-        prix_valeur?: number;
-        prix_maj?: string;
-      }>;
+      results: Array<Record<string, unknown> & { adresse?: string; ville?: string }>;
     };
 
     if (data.results.length > 0) {
       const record = data.results[0]!;
+      const rawPrice = record[apiFields.price];
+      const rawUpdatedAt = record[apiFields.updatedAt];
+      const priceEur = typeof rawPrice === "number" ? rawPrice : FALLBACK_PRICES[fuelType];
       const result: CachedPrice = {
-        priceEur: (record.prix_valeur ?? FALLBACK_PRICES[fuelType] * 1000) / 1000,
+        priceEur,
         fuelType,
-        stationName: record.nom_ev,
-        updatedAt: record.prix_maj ?? new Date().toISOString(),
+        stationName: formatStationName(record.adresse, record.ville),
+        updatedAt: typeof rawUpdatedAt === "string" ? rawUpdatedAt : new Date().toISOString(),
         cachedAt: Date.now(),
       };
       evictIfNeeded();

--- a/server/src/routes/__tests__/trips-create.test.ts
+++ b/server/src/routes/__tests__/trips-create.test.ts
@@ -207,4 +207,25 @@ describe("POST /trips", () => {
       }),
     );
   });
+
+  it("prices trips from the Annemasse market instead of the trip GPS start point", async () => {
+    const app = buildApp();
+    const res = await app.request("/trips", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        distanceKm: 12,
+        durationSec: 900,
+        startedAt: "2026-04-07T10:00:00.000Z",
+        endedAt: "2026-04-07T10:15:00.000Z",
+        gpsPoints: [
+          { lat: 46.2044, lng: 6.1432, ts: 1712484000000 },
+          { lat: 46.205, lng: 6.145, ts: 1712484300000 },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mocks.mockGetFuelPrice).toHaveBeenCalledWith("sp95");
+  });
 });

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -77,11 +77,11 @@ tripsRouter.post(
     const consumptionL100 = profile?.consumptionL100 ?? 7; // Default 7L/100km
     const fuelType = (profile?.fuelType ?? "sp95") as "sp95" | "sp98" | "diesel" | "e85" | "gpl";
 
-    // Get current fuel price — non-blocking: use cache or fallback immediately
-    const startPoint = data.gpsPoints?.[0];
+    // Fuel savings are valued against the user's local refuelling market, not
+    // the trip start point — ecoRide currently uses the Annemasse lookup.
     let fuelPriceEur: number;
     try {
-      const fuelPriceData = await getFuelPrice(fuelType, startPoint?.lat, startPoint?.lng);
+      const fuelPriceData = await getFuelPrice(fuelType);
       fuelPriceEur = fuelPriceData.priceEur;
     } catch {
       // On any failure, use hardcoded fallback so trip creation is never blocked

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -143,8 +143,8 @@ export interface PushSubscribeRequest {
 }
 
 export interface FuelPriceQuery {
-  lat: number;
-  lng: number;
+  lat?: number;
+  lng?: number;
   type: FuelType;
 }
 


### PR DESCRIPTION
## Summary
- switch fuel-price lookups to the live data.economie.gouv.fr schema (`*_prix`, `*_maj`) instead of the obsolete `prix_valeur` path that was forcing fallback prices
- default coordinate-less fuel price lookups to Annemasse and use that same local market price for trip savings calculations
- add regression coverage for the Annemasse default lookup and for trip creation ignoring trip-start GPS when pricing fuel

## Testing
- bunx vitest run src/lib/__tests__/fuel-price.test.ts src/routes/__tests__/trips-create.test.ts
- bun run typecheck