### PR TITLE
fix(stats): show metric unit on Y axis ticks

### DIFF
--- a/client/src/components/leaderboard/CommunityChart.tsx
+++ b/client/src/components/leaderboard/CommunityChart.tsx
@@ -1,4 +1,4 @@
-import { AreaChart, Area, XAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { useCommunityTimeline } from "@/hooks/queries";
 import { useT } from "@/i18n/provider";
 import type { StatsPeriod, LeaderboardCategory } from "@ecoride/shared/api-contracts";
@@ -89,7 +89,7 @@ export function CommunityChart({ period, category, unit, categoryLabel }: Props)
         <span className="text-primary-light">{categoryLabel}</span>
       </h2>
       <ResponsiveContainer width="100%" height={160}>
-        <AreaChart data={points} margin={{ top: 8, right: 4, left: 4, bottom: 0 }}>
+        <AreaChart data={points} margin={{ top: 8, right: 4, left: 0, bottom: 0 }}>
           <defs>
             <linearGradient id="communityChartGradient" x1="0" y1="0" x2="0" y2="1">
               <stop offset="0%" stopColor="#54e98a" stopOpacity={0.25} />
@@ -102,6 +102,14 @@ export function CommunityChart({ period, category, unit, categoryLabel }: Props)
             tickLine={false}
             axisLine={false}
             interval={tickInterval}
+          />
+          <YAxis
+            tick={{ fill: "#8a9ba8", fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            width={48}
+            unit={` ${unit}`}
+            tickFormatter={(v) => formatValue(v as number)}
           />
           <Tooltip
             content={<CustomTooltip unit={unit} formatValue={formatValue} />}

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -489,7 +489,14 @@ export function StatsPage() {
                       tick={{ fill: "#8a9ba8", fontSize: 10 }}
                       axisLine={false}
                       tickLine={false}
-                      width={35}
+                      width={48}
+                      unit={
+                        metric === "km"
+                          ? ` ${t("stats.chart.unit.km")}`
+                          : metric === "co2"
+                            ? ` ${t("stats.chart.unit.co2")}`
+                            : ` ${t("stats.chart.unit.eur")}`
+                      }
                       tickFormatter={(v) =>
                         metric === "eur" ? Number(v).toFixed(0) : Number(v).toFixed(1)
                       }


### PR DESCRIPTION
## Summary

- Y axis ticks now display their unit suffix: `1.5 km`, `2.3 kg`, `1.2 €`
- Width widened from 35 to 48px to avoid text truncation
- Follow-up to #281 (merged before this commit landed)

## Test plan

- [x] Typecheck passes
- [x] Existing regression test in `stats-chart-y-axis.spec.ts` still covers the YAxis presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)