### PR TITLE
feat(admin): open trip detail from recent trips list

### DIFF
--- a/client/src/components/TripMiniMap.tsx
+++ b/client/src/components/TripMiniMap.tsx
@@ -1,0 +1,117 @@
+import { useState, useMemo, useEffect, useRef } from "react";
+import Map, { Source, Layer, useMap } from "react-map-gl/maplibre";
+import type { LayerProps } from "react-map-gl/maplibre";
+import type { GpsPoint } from "@ecoride/shared/types";
+import { isWebGLSupported } from "@/lib/webgl";
+import {
+  buildTraceGeoJSON,
+  speedTraceLayer,
+  solidTraceLayer,
+  SPEED_LEGEND,
+} from "@/lib/speedGeoJSON";
+import { MapNoWebGL } from "@/components/MapNoWebGL";
+
+const MAP_STYLE = "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json";
+
+function FitBoundsOnLoad({ bounds }: { bounds: [[number, number], [number, number]] }) {
+  const { current: map } = useMap();
+  useEffect(() => {
+    if (!map) return;
+    // Delay fitBounds until after the bottom sheet slide-up animation (0.2s)
+    // completes. Without this, MapLibre doesn't know the container's final
+    // dimensions and calculates the wrong center/zoom (#103).
+    const timer = setTimeout(() => {
+      map.resize();
+      map.fitBounds(bounds, { padding: 20 });
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [map, bounds]);
+  return null;
+}
+
+export function TripMiniMap({ gpsPoints }: { gpsPoints: GpsPoint[] }) {
+  const webGLSupported = isWebGLSupported();
+  const [webglLost, setWebglLost] = useState(false);
+  const mapStyleReadyRef = useRef(false);
+  const [mapLoadError, setMapLoadError] = useState(false);
+  const traceGeoJSON = useMemo(() => buildTraceGeoJSON(gpsPoints), [gpsPoints]);
+  const hasSpeedData = traceGeoJSON.type === "FeatureCollection";
+  // Single-pass bounds computation: avoids Math.min/max spread which throws
+  // RangeError when trips exceed ~65k GPS points (JS call-stack limit).
+  let minLng = Infinity,
+    maxLng = -Infinity,
+    minLat = Infinity,
+    maxLat = -Infinity;
+  for (const p of gpsPoints) {
+    if (p.lng < minLng) minLng = p.lng;
+    if (p.lng > maxLng) maxLng = p.lng;
+    if (p.lat < minLat) minLat = p.lat;
+    if (p.lat > maxLat) maxLat = p.lat;
+  }
+  const bounds: [[number, number], [number, number]] = [
+    [minLng, minLat],
+    [maxLng, maxLat],
+  ];
+  const centerLng = (minLng + maxLng) / 2;
+  const centerLat = (minLat + maxLat) / 2;
+
+  return (
+    <div className="relative mb-4 h-48 overflow-hidden rounded-xl">
+      {webGLSupported ? (
+        <>
+          <Map
+            initialViewState={{
+              longitude: centerLng,
+              latitude: centerLat,
+              zoom: 13,
+            }}
+            mapStyle={MAP_STYLE}
+            attributionControl={false}
+            dragPan={false}
+            scrollZoom={false}
+            doubleClickZoom={false}
+            touchZoomRotate={false}
+            style={{ width: "100%", height: "100%" }}
+            onLoad={(e) => {
+              mapStyleReadyRef.current = true;
+              setMapLoadError(false);
+              setWebglLost(false);
+              const m = e.target;
+              m.on("webglcontextlost", () => setWebglLost(true));
+              m.on("webglcontextrestored", () => setWebglLost(false));
+            }}
+            onError={() => {
+              if (!mapStyleReadyRef.current) setMapLoadError(true);
+            }}
+          >
+            <Source id="trace-stats" type="geojson" data={traceGeoJSON}>
+              <Layer
+                {...((hasSpeedData ? speedTraceLayer : solidTraceLayer) as LayerProps)}
+                id="trace-stats"
+              />
+            </Source>
+            <FitBoundsOnLoad bounds={bounds} />
+          </Map>
+          {(webglLost || mapLoadError) && (
+            <div className="absolute inset-0">
+              <MapNoWebGL />
+            </div>
+          )}
+          {hasSpeedData && (
+            <div className="absolute bottom-2 right-2 flex items-center gap-0.5 rounded-md bg-bg/80 px-2 py-1 text-[10px] text-text-dim backdrop-blur-sm">
+              {SPEED_LEGEND.map((s) => (
+                <div key={s.label} className="flex flex-col items-center">
+                  <div className="h-1.5 w-4 rounded-full" style={{ backgroundColor: s.color }} />
+                  <span>{s.label}</span>
+                </div>
+              ))}
+              <span className="ml-1">km/h</span>
+            </div>
+          )}
+        </>
+      ) : (
+        <MapNoWebGL />
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -25,9 +25,13 @@ import {
   useGrantSuper73Access,
   useRevokeSuper73Access,
   useDeleteAdminUser,
+  useTrip,
+  type AdminStatsTrip,
 } from "@/hooks/queries";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
-import { formatUptime, formatDate, formatDuration } from "@/lib/format-utils";
+import { formatUptime, formatDate, formatDuration, formatLongDate } from "@/lib/format-utils";
+import { tripLabelKey } from "@/lib/trip-utils";
+import { TripMiniMap } from "@/components/TripMiniMap";
 import { AdminStatCard } from "@/components/admin/AdminStatCard";
 import { AuditLogSection } from "@/components/admin/AuditLogSection";
 import { AnnouncementSection } from "@/components/admin/AnnouncementSection";
@@ -59,6 +63,10 @@ export function AdminPage() {
   const deleteAdminUser = useDeleteAdminUser();
   const [deployStatus, setDeployStatus] = useState<"idle" | "success" | "error">("idle");
   const [selectedUser, setSelectedUser] = useState<AdminManagedUser | null>(null);
+  const [selectedAdminTrip, setSelectedAdminTrip] = useState<AdminStatsTrip | null>(null);
+  const { data: adminTripDetail, isPending: adminTripPending } = useTrip(
+    selectedAdminTrip?.id ?? null,
+  );
 
   const isAdmin = profileData?.user?.isAdmin === true;
 
@@ -359,9 +367,10 @@ export function AdminPage() {
           ) : stats?.recentTrips && stats.recentTrips.length > 0 ? (
             <div className="max-h-80 space-y-3 overflow-auto">
               {stats.recentTrips.map((trip) => (
-                <div
+                <button
                   key={trip.id}
-                  className="flex items-center gap-3 rounded-lg bg-surface-high p-3"
+                  onClick={() => setSelectedAdminTrip(trip)}
+                  className="flex w-full items-center gap-3 rounded-lg bg-surface-high p-3 text-left active:bg-surface-highest"
                 >
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10">
                     <Bike size={18} className="text-primary-light" />
@@ -383,7 +392,7 @@ export function AdminPage() {
                       </span>
                     </div>
                   </div>
-                </div>
+                </button>
               ))}
             </div>
           ) : (
@@ -531,6 +540,87 @@ export function AdminPage() {
                   </div>
                 </section>
               </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+      {selectedAdminTrip &&
+        createPortal(
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={selectedAdminTrip.userName}
+            className="fixed inset-0 z-[60] flex items-end justify-center"
+            onClick={() => setSelectedAdminTrip(null)}
+          >
+            <div className="absolute inset-0 bg-black/50" />
+            <div
+              className="relative w-full max-w-lg overflow-y-auto max-h-[85vh] rounded-t-2xl bg-surface-container p-6 pb-10 animate-[slideUp_0.2s_ease-out]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="mx-auto mb-4 h-1 w-10 rounded-full bg-surface-highest" />
+              <div className="mb-6 flex items-start justify-between">
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
+                    {selectedAdminTrip.userName}
+                  </p>
+                  <h3 className="text-lg font-bold">
+                    {t(tripLabelKey(selectedAdminTrip.startedAt))}
+                  </h3>
+                  <p className="text-sm text-text-muted">
+                    {formatLongDate(selectedAdminTrip.startedAt)}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setSelectedAdminTrip(null)}
+                  className="rounded-lg p-2 text-text-muted active:bg-surface-high"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+              {adminTripPending && (
+                <div className="flex justify-center py-8">
+                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                </div>
+              )}
+              {!adminTripPending && adminTripDetail && (
+                <>
+                  {Array.isArray(adminTripDetail.gpsPoints) &&
+                  adminTripDetail.gpsPoints.length > 1 ? (
+                    <TripMiniMap gpsPoints={adminTripDetail.gpsPoints} />
+                  ) : (
+                    <p className="mb-4 text-center text-xs text-text-dim">
+                      {t("stats.detail.manualEntry")}
+                    </p>
+                  )}
+                  <div className="grid grid-cols-3 gap-4 text-center">
+                    <div>
+                      <p className="text-xl font-bold text-primary-light">
+                        {Number(adminTripDetail.distanceKm).toFixed(1)}
+                      </p>
+                      <p className="text-xs font-bold uppercase text-text-muted">
+                        {t("stats.detail.km")}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xl font-bold text-primary-light">
+                        {adminTripDetail.co2SavedKg.toFixed(1)}
+                      </p>
+                      <p className="text-xs font-bold uppercase text-text-muted">
+                        {t("stats.detail.co2")}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xl font-bold text-primary-light">
+                        {adminTripDetail.moneySavedEur.toFixed(2)}
+                      </p>
+                      <p className="text-xs font-bold uppercase text-text-muted">
+                        {t("stats.detail.eur")}
+                      </p>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           </div>,
           document.body,

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Bike, BarChart3, Trash2, X, Save } from "lucide-react";
-import type { Trip, GpsPoint } from "@ecoride/shared/types";
+import type { Trip } from "@ecoride/shared/types";
 import {
   LineChart,
   Line,
@@ -11,9 +11,6 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import Map, { Source, Layer, useMap } from "react-map-gl/maplibre";
-import type { LayerProps } from "react-map-gl/maplibre";
-// maplibre-gl.css imported in app.css to avoid orphan CSS chunks
 import { BADGES } from "@ecoride/shared/types";
 import type { BadgeId } from "@ecoride/shared/types";
 import {
@@ -29,14 +26,7 @@ import {
 import { formatDayMonth, formatLongDate, formatMonthYear } from "@/lib/format-utils";
 import { tripLabel, tripLabelKey } from "@/lib/trip-utils";
 import { useT, type TranslateFn } from "@/i18n/provider";
-import { isWebGLSupported } from "@/lib/webgl";
-import {
-  buildTraceGeoJSON,
-  speedTraceLayer,
-  solidTraceLayer,
-  SPEED_LEGEND,
-} from "@/lib/speedGeoJSON";
-import { MapNoWebGL } from "@/components/MapNoWebGL";
+import { TripMiniMap } from "@/components/TripMiniMap";
 import { PageHeader } from "@/components/layout/PageHeader";
 
 type Period = "week" | "month" | "year";
@@ -80,112 +70,6 @@ const getMonthLabels = (t: TranslateFn): string[] => [
 ];
 
 const allBadgeIds = Object.keys(BADGES) as BadgeId[];
-
-const MAP_STYLE = "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json";
-
-function FitBoundsOnLoad({ bounds }: { bounds: [[number, number], [number, number]] }) {
-  const { current: map } = useMap();
-  useEffect(() => {
-    if (!map) return;
-    // Delay fitBounds until after the bottom sheet slide-up animation (0.2s)
-    // completes. Without this, MapLibre doesn't know the container's final
-    // dimensions and calculates the wrong center/zoom (#103).
-    const timer = setTimeout(() => {
-      map.resize();
-      map.fitBounds(bounds, { padding: 20 });
-    }, 250);
-    return () => clearTimeout(timer);
-  }, [map, bounds]);
-  return null;
-}
-
-function TripMiniMap({ gpsPoints }: { gpsPoints: GpsPoint[] }) {
-  const webGLSupported = isWebGLSupported();
-  const [webglLost, setWebglLost] = useState(false);
-  const mapStyleReadyRef = useRef(false);
-  const [mapLoadError, setMapLoadError] = useState(false);
-  const traceGeoJSON = useMemo(() => buildTraceGeoJSON(gpsPoints), [gpsPoints]);
-  const hasSpeedData = traceGeoJSON.type === "FeatureCollection";
-  // Single-pass bounds computation: avoids Math.min/max spread which throws
-  // RangeError when trips exceed ~65k GPS points (JS call-stack limit).
-  let minLng = Infinity,
-    maxLng = -Infinity,
-    minLat = Infinity,
-    maxLat = -Infinity;
-  for (const p of gpsPoints) {
-    if (p.lng < minLng) minLng = p.lng;
-    if (p.lng > maxLng) maxLng = p.lng;
-    if (p.lat < minLat) minLat = p.lat;
-    if (p.lat > maxLat) maxLat = p.lat;
-  }
-  const bounds: [[number, number], [number, number]] = [
-    [minLng, minLat],
-    [maxLng, maxLat],
-  ];
-  const centerLng = (minLng + maxLng) / 2;
-  const centerLat = (minLat + maxLat) / 2;
-
-  return (
-    <div className="relative mb-4 h-48 overflow-hidden rounded-xl">
-      {webGLSupported ? (
-        <>
-          <Map
-            initialViewState={{
-              longitude: centerLng,
-              latitude: centerLat,
-              zoom: 13,
-            }}
-            mapStyle={MAP_STYLE}
-            attributionControl={false}
-            dragPan={false}
-            scrollZoom={false}
-            doubleClickZoom={false}
-            touchZoomRotate={false}
-            style={{ width: "100%", height: "100%" }}
-            onLoad={(e) => {
-              mapStyleReadyRef.current = true;
-              setMapLoadError(false);
-              setWebglLost(false);
-              const m = e.target;
-              m.on("webglcontextlost", () => setWebglLost(true));
-              m.on("webglcontextrestored", () => setWebglLost(false));
-            }}
-            onError={() => {
-              if (!mapStyleReadyRef.current) setMapLoadError(true);
-            }}
-          >
-            <Source id="trace-stats" type="geojson" data={traceGeoJSON}>
-              <Layer
-                {...((hasSpeedData ? speedTraceLayer : solidTraceLayer) as LayerProps)}
-                id="trace-stats"
-              />
-            </Source>
-            <FitBoundsOnLoad bounds={bounds} />
-          </Map>
-          {(webglLost || mapLoadError) && (
-            <div className="absolute inset-0">
-              <MapNoWebGL />
-            </div>
-          )}
-          {/* Speed legend — only when speed data available */}
-          {hasSpeedData && (
-            <div className="absolute bottom-2 right-2 flex items-center gap-0.5 rounded-md bg-bg/80 px-2 py-1 text-[10px] text-text-dim backdrop-blur-sm">
-              {SPEED_LEGEND.map((s) => (
-                <div key={s.label} className="flex flex-col items-center">
-                  <div className="h-1.5 w-4 rounded-full" style={{ backgroundColor: s.color }} />
-                  <span>{s.label}</span>
-                </div>
-              ))}
-              <span className="ml-1">km/h</span>
-            </div>
-          )}
-        </>
-      ) : (
-        <MapNoWebGL />
-      )}
-    </div>
-  );
-}
 
 export function StatsPage() {
   const t = useT();


### PR DESCRIPTION
## Summary

- Recent trip cards in the admin panel are now tappable
- Tapping a trip opens a read-only bottom sheet showing: user name, trip label, date, GPS map (if available), and distance/CO₂/money stats
- `TripMiniMap` extracted from `StatsPage.tsx` into a shared `components/TripMiniMap.tsx` so both pages reuse the same map component
- `useTrip()` fetches the full trip detail (with gpsPoints) on demand when the sheet opens

Closes #283

## Test plan

- [x] Typecheck passes
- [x] Existing smoke tests cover AdminPage rendering without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)