### PR TITLE
fix(admin): allow admins to fetch any trip via GET /trips/:id

### DIFF
--- a/server/src/routes/__tests__/trips-get.test.ts
+++ b/server/src/routes/__tests__/trips-get.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../../types/context";
+
+const mocks = vi.hoisted(() => {
+  const mockSelect = vi.fn();
+  return { mockSelect };
+});
+
+vi.mock("../../db", () => ({ db: { select: mocks.mockSelect } }));
+vi.mock("../../db/schema", () => ({
+  trips: { id: {}, userId: {}, idempotencyKey: {}, startedAt: {}, endedAt: {} },
+}));
+vi.mock("../../db/schema/auth", () => ({ user: { id: {}, consumptionL100: {}, fuelType: {} } }));
+vi.mock("../../lib/badges", () => ({
+  evaluateAndUnlockBadges: vi.fn(),
+  reevaluateBadges: vi.fn(),
+}));
+vi.mock("../../lib/push", () => ({ sendPushToUser: vi.fn() }));
+vi.mock("../../lib/leaderboard-notifications", () => ({ checkLeaderboardChanges: vi.fn() }));
+vi.mock("../../lib/fuel-price", () => ({ getFuelPrice: vi.fn() }));
+vi.mock("../../lib/calculations", () => ({ calculateSavings: vi.fn() }));
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+  },
+}));
+vi.mock("../../lib/rate-limit", () => ({
+  rateLimit: () => (_c: unknown, next: () => Promise<void>) => next(),
+}));
+vi.mock("../../lib/audit", () => ({ logAudit: vi.fn() }));
+
+import { tripsRouter } from "../trips.routes";
+
+const TRIP_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+const TRIP = {
+  id: TRIP_ID,
+  userId: "owner-1",
+  distanceKm: 10,
+  co2SavedKg: 1.5,
+  moneySavedEur: 2,
+  fuelSavedL: 0.7,
+  startedAt: new Date().toISOString(),
+  endedAt: new Date().toISOString(),
+  gpsPoints: null,
+};
+
+function buildSelectChain(result: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function buildApp(userId: string, isAdmin = false) {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", { id: userId, isAdmin } as AuthEnv["Variables"]["user"]);
+    await next();
+  });
+  app.route("/trips", tripsRouter);
+  return app;
+}
+
+describe("GET /trips/:id", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns the trip to its owner", async () => {
+    mocks.mockSelect.mockReturnValue(buildSelectChain([TRIP]));
+    const res = await buildApp("owner-1").request("/trips/a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.trip.id).toBe(TRIP_ID);
+  });
+
+  it("returns 403 when a non-admin requests another user's trip", async () => {
+    mocks.mockSelect.mockReturnValue(buildSelectChain([TRIP]));
+    const res = await buildApp("other-user").request("/trips/a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows an admin to fetch another user's trip", async () => {
+    mocks.mockSelect.mockReturnValue(buildSelectChain([TRIP]));
+    const res = await buildApp("admin-user", true).request(
+      "/trips/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.trip.id).toBe(TRIP_ID);
+  });
+});

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -181,7 +181,7 @@ tripsRouter.get("/", zValidator("query", tripsListQuery, validationHook), async 
   });
 });
 
-// GET /api/trips/:id — Single trip
+// GET /api/trips/:id — Single trip (admins can fetch any trip)
 tripsRouter.get("/:id", zValidator("param", uuidParam, validationHook), async (c) => {
   const { id } = c.req.valid("param");
   const currentUser = c.get("user");
@@ -189,7 +189,7 @@ tripsRouter.get("/:id", zValidator("param", uuidParam, validationHook), async (c
   const [trip] = await db.select().from(trips).where(eq(trips.id, id));
 
   if (!trip) throw notFound(`Trip ${id} not found`);
-  if (trip.userId !== currentUser.id) throw forbidden();
+  if (trip.userId !== currentUser.id && !currentUser.isAdmin) throw forbidden();
 
   return c.json({ ok: true, data: { trip } });
 });


### PR DESCRIPTION
## Summary

- `GET /trips/:id` was returning 403 when an admin tried to fetch another user's trip, leaving the admin trip detail bottom sheet empty
- Added an `isAdmin` bypass: admins can now read any trip regardless of ownership

## Root cause

The ownership check `trip.userId !== currentUser.id` had no admin exception, so the trip detail sheet opened but never loaded any content.

## Test plan

- [x] New vitest: `trips-get.test.ts` — covers owner access (200), non-owner non-admin (403), and admin bypass (200)

Closes #283 (follow-up — the UI was correct, the server blocked the data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)