### PR TITLE
fix(map): make trip map interactive and fix trace visibility on zoom-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,15 @@ Merge to main → Auto-bump (feat: → minor, fix: → patch) → Deploy to Cool
 ### Branching — MANDATORY
 
 - **NEVER commit directly to `main`** — not even a single line, not even a typo fix.
-- Every task (feature, fix, chore) starts by creating a dedicated branch: `git checkout -b feat/... main`
+- Every task starts by pulling main first, then creating a dedicated branch:
+  ```
+  git checkout main
+  git pull
+  git checkout -b feat/...
+  ```
 - Push the branch and open a PR. CI must pass before merge.
 - This applies to ALL agents and ALL sessions, no exceptions.
+- **Why pull first**: auto-bump pushes a commit to main after every merge, so local main is almost always stale. Branching from stale main causes an immediate "out-of-date" PR.
 
 ### Bug Fixes
 

--- a/client/src/components/TripMiniMap.tsx
+++ b/client/src/components/TripMiniMap.tsx
@@ -20,9 +20,14 @@ function FitBoundsOnLoad({ bounds }: { bounds: [[number, number], [number, numbe
     // Delay fitBounds until after the bottom sheet slide-up animation (0.2s)
     // completes. Without this, MapLibre doesn't know the container's final
     // dimensions and calculates the wrong center/zoom (#103).
+    // requestAnimationFrame ensures MapLibre has processed the resize before
+    // computing the new viewport, which prevents the trace from appearing
+    // outside the viewport after zoom-out.
     const timer = setTimeout(() => {
       map.resize();
-      map.fitBounds(bounds, { padding: 20 });
+      requestAnimationFrame(() => {
+        map.fitBounds(bounds, { padding: 20 });
+      });
     }, 250);
     return () => clearTimeout(timer);
   }, [map, bounds]);
@@ -38,22 +43,27 @@ export function TripMiniMap({ gpsPoints }: { gpsPoints: GpsPoint[] }) {
   const hasSpeedData = traceGeoJSON.type === "FeatureCollection";
   // Single-pass bounds computation: avoids Math.min/max spread which throws
   // RangeError when trips exceed ~65k GPS points (JS call-stack limit).
-  let minLng = Infinity,
-    maxLng = -Infinity,
-    minLat = Infinity,
-    maxLat = -Infinity;
-  for (const p of gpsPoints) {
-    if (p.lng < minLng) minLng = p.lng;
-    if (p.lng > maxLng) maxLng = p.lng;
-    if (p.lat < minLat) minLat = p.lat;
-    if (p.lat > maxLat) maxLat = p.lat;
-  }
-  const bounds: [[number, number], [number, number]] = [
-    [minLng, minLat],
-    [maxLng, maxLat],
-  ];
-  const centerLng = (minLng + maxLng) / 2;
-  const centerLat = (minLat + maxLat) / 2;
+  // Memoized so FitBoundsOnLoad's effect only re-fires when gpsPoints change.
+  const { bounds, centerLng, centerLat } = useMemo(() => {
+    let minLng = Infinity,
+      maxLng = -Infinity,
+      minLat = Infinity,
+      maxLat = -Infinity;
+    for (const p of gpsPoints) {
+      if (p.lng < minLng) minLng = p.lng;
+      if (p.lng > maxLng) maxLng = p.lng;
+      if (p.lat < minLat) minLat = p.lat;
+      if (p.lat > maxLat) maxLat = p.lat;
+    }
+    return {
+      bounds: [
+        [minLng, minLat],
+        [maxLng, maxLat],
+      ] as [[number, number], [number, number]],
+      centerLng: (minLng + maxLng) / 2,
+      centerLat: (minLat + maxLat) / 2,
+    };
+  }, [gpsPoints]);
 
   return (
     <div className="relative mb-4 h-48 overflow-hidden rounded-xl">
@@ -67,10 +77,6 @@ export function TripMiniMap({ gpsPoints }: { gpsPoints: GpsPoint[] }) {
             }}
             mapStyle={MAP_STYLE}
             attributionControl={false}
-            dragPan={false}
-            scrollZoom={false}
-            doubleClickZoom={false}
-            touchZoomRotate={false}
             style={{ width: "100%", height: "100%" }}
             onLoad={(e) => {
               mapStyleReadyRef.current = true;

--- a/client/src/components/__tests__/TripMiniMap.test.tsx
+++ b/client/src/components/__tests__/TripMiniMap.test.tsx
@@ -1,0 +1,85 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TripMiniMap } from "../TripMiniMap";
+import type { GpsPoint } from "@ecoride/shared/types";
+
+// vi.hoisted ensures the stable ref is available inside the vi.mock factory (which is hoisted).
+const { fitBounds, resize, mockMapRef } = vi.hoisted(() => {
+  const fitBounds = vi.fn();
+  const resize = vi.fn();
+  const mockMapRef = { current: { fitBounds, resize } };
+  return { fitBounds, resize, mockMapRef };
+});
+
+vi.mock("react-map-gl/maplibre", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Source: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Layer: () => null,
+  useMap: () => mockMapRef,
+}));
+
+vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => true }));
+vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => null }));
+
+const GPS_POINTS: GpsPoint[] = [
+  { lat: 45.0, lng: 6.0, ts: 1000 },
+  { lat: 45.1, lng: 6.1, ts: 10_000 },
+];
+
+describe("TripMiniMap", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fitBounds.mockClear();
+    resize.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defers fitBounds to the next animation frame after resize (regression: fitBounds was called synchronously with resize, before container settled)", () => {
+    render(<TripMiniMap gpsPoints={GPS_POINTS} />);
+
+    // Before the 250ms delay, nothing should fire.
+    expect(resize).not.toHaveBeenCalled();
+    expect(fitBounds).not.toHaveBeenCalled();
+
+    // After the delay, resize fires but fitBounds must wait for rAF.
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(resize).toHaveBeenCalledTimes(1);
+    expect(fitBounds).not.toHaveBeenCalled();
+
+    // Flush the pending requestAnimationFrame — now fitBounds fires.
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect(fitBounds).toHaveBeenCalledWith(
+      [
+        [6.0, 45.0],
+        [6.1, 45.1],
+      ],
+      { padding: 20 },
+    );
+  });
+
+  it("does not re-call fitBounds when the parent re-renders with the same GPS points", () => {
+    const { rerender } = render(<TripMiniMap gpsPoints={GPS_POINTS} />);
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+      vi.runAllTimers();
+    });
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    // Re-render with the same GPS_POINTS reference — bounds are memoized, no re-fit.
+    rerender(<TripMiniMap gpsPoints={GPS_POINTS} />);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **Map verrouillé** : suppression des props `dragPan={false}`, `scrollZoom={false}`, `doubleClickZoom={false}`, `touchZoomRotate={false}` — la carte était totalement non-interactive.
- **Trace invisible après zoom-out** : `fitBounds` était appelé directement après `resize()`, avant que MapLibre ait fini de traiter le redimensionnement. Le report sur `requestAnimationFrame` laisse le temps au renderer de stabiliser les dimensions du conteneur.
- **Bounds non mémoisés** : l'objet `bounds` était recréé à chaque render, ce qui déclenchait le `useEffect` de `FitBoundsOnLoad` en boucle. Mémoisé dans `useMemo`.

## Test plan

- [ ] Ouvrir un trajet existant → la carte doit zoomer pour afficher la trace complète
- [ ] Vérifier que la trace est visible après le zoom-out automatique
- [ ] Pinch-to-zoom / scroll-to-zoom / drag-pan doivent fonctionner
- [ ] Tests unitaires : `TripMiniMap.test.tsx` — 2 cas (regression rAF + memoisation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)