### PR TITLE
fix: preserve manual trip sync idempotency

### DIFF
--- a/client/src/lib/__tests__/offline-queue.test.ts
+++ b/client/src/lib/__tests__/offline-queue.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPendingTrips, queueTrip } from "../offline-queue";
+
+const store = new Map<string, string>();
+
+const localStorageMock = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    store.set(key, value);
+  },
+  removeItem: (key: string) => {
+    store.delete(key);
+  },
+  clear: () => {
+    store.clear();
+  },
+};
+
+describe("offline trip queue", () => {
+  beforeEach(() => {
+    store.clear();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+    });
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+      "99999999-9999-4999-9999-999999999999",
+    );
+  });
+
+  it("preserves the idempotency key from a failed live save", () => {
+    queueTrip({
+      distanceKm: 3.2,
+      durationSec: 720,
+      startedAt: "2026-04-23T09:00:00.000Z",
+      endedAt: "2026-04-23T09:12:00.000Z",
+      gpsPoints: null,
+      idempotencyKey: "11111111-1111-4111-8111-111111111111",
+    });
+
+    expect(getPendingTrips()).toEqual([
+      expect.objectContaining({
+        distanceKm: 3.2,
+        gpsPoints: null,
+        idempotencyKey: "11111111-1111-4111-8111-111111111111",
+      }),
+    ]);
+    expect(globalThis.crypto.randomUUID).not.toHaveBeenCalled();
+  });
+
+  it("generates an idempotency key for legacy callers", () => {
+    queueTrip({
+      distanceKm: 4.2,
+      durationSec: 900,
+      startedAt: "2026-04-23T10:00:00.000Z",
+      endedAt: "2026-04-23T10:15:00.000Z",
+      gpsPoints: null,
+    });
+
+    expect(getPendingTrips()).toEqual([
+      expect.objectContaining({
+        distanceKm: 4.2,
+        idempotencyKey: "99999999-9999-4999-9999-999999999999",
+      }),
+    ]);
+  });
+});

--- a/client/src/lib/offline-queue.ts
+++ b/client/src/lib/offline-queue.ts
@@ -48,7 +48,7 @@ function sameTripIdentity(a: CreateTripRequest, b: CreateTripRequest): boolean {
 
 export function queueTrip(data: CreateTripRequest): void {
   const pending = getPendingTrips();
-  const key = crypto.randomUUID();
+  const key = data.idempotencyKey ?? crypto.randomUUID();
   pending.push({ ...data, idempotencyKey: key });
   writeQueue(STORAGE_KEY, pending);
   notifyQueueChanged();

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -188,6 +188,7 @@ export function TripPage() {
         startedAt,
         endedAt,
         gpsPoints: session?.gpsPoints?.length ? session.gpsPoints : null,
+        idempotencyKey: crypto.randomUUID(),
       };
       createTrip.mutate(tripData, {
         onSuccess: () => {

--- a/client/src/pages/__tests__/TripPage.preset.test.tsx
+++ b/client/src/pages/__tests__/TripPage.preset.test.tsx
@@ -10,10 +10,13 @@ const renderTripPage = () =>
     </I18nProvider>,
   );
 
-const mutateMock = vi.fn();
-const startMock = vi.fn();
-const resetMock = vi.fn();
-
+const mocks = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  queueTripMock: vi.fn(),
+  startMock: vi.fn(),
+  resetMock: vi.fn(),
+}));
+const { mutateMock, queueTripMock, startMock, resetMock } = mocks;
 vi.mock("react-map-gl/maplibre", () => ({
   __esModule: true,
   default: () => null,
@@ -24,7 +27,7 @@ vi.mock("react-map-gl/maplibre", () => ({
 
 vi.mock("@/hooks/queries", () => ({
   useCreateTrip: () => ({
-    mutate: mutateMock,
+    mutate: mocks.mutateMock,
     isPending: false,
   }),
   useProfile: () => ({
@@ -65,9 +68,9 @@ vi.mock("@/hooks/useGpsTracking", () => ({
       speedKmh: null,
       heading: null,
     },
-    start: startMock,
+    start: mocks.startMock,
     stop: vi.fn(),
-    reset: resetMock,
+    reset: mocks.resetMock,
     restore: vi.fn(),
     pause: vi.fn(),
     resume: vi.fn(),
@@ -83,7 +86,7 @@ vi.mock("@/lib/stopped-session", () => ({
   clearStoppedSession: vi.fn(),
   hasStoppedSession: () => false,
 }));
-vi.mock("@/lib/offline-queue", () => ({ queueTrip: vi.fn() }));
+vi.mock("@/lib/offline-queue", () => ({ queueTrip: mocks.queueTripMock }));
 vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => false }));
 vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));
 vi.mock("@/components/Super73ModeButton", () => ({ Super73ModeButton: () => null }));
@@ -94,6 +97,7 @@ describe("TripPage trip preset selection", () => {
     mutateMock.mockReset();
     startMock.mockReset();
     resetMock.mockReset();
+    queueTripMock.mockReset();
   });
 
   it("creates a manual trip from the manual dropdown preset selection", () => {
@@ -116,6 +120,40 @@ describe("TripPage trip preset selection", () => {
         durationSec: 1500,
       }),
       expect.any(Object),
+    );
+  });
+
+  it("queues a failed manual trip with the same idempotency key used for the live save", () => {
+    renderTripPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Saisie manuelle" }));
+    fireEvent.change(screen.getByLabelText("Distance (km)"), { target: { value: "3.2" } });
+    fireEvent.change(screen.getByLabelText("Durée (minutes)"), { target: { value: "12" } });
+    fireEvent.click(screen.getByRole("button", { name: "Enregistrer" }));
+
+    expect(mutateMock).toHaveBeenCalledOnce();
+    const [tripData, options] = mutateMock.mock.calls[0] as [
+      { idempotencyKey?: string },
+      { onError: () => void },
+    ];
+    expect(tripData).toEqual(
+      expect.objectContaining({
+        distanceKm: 3.2,
+        durationSec: 720,
+        gpsPoints: null,
+        idempotencyKey: expect.any(String),
+      }),
+    );
+
+    options.onError();
+
+    expect(queueTripMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distanceKm: 3.2,
+        durationSec: 720,
+        gpsPoints: null,
+        idempotencyKey: tripData.idempotencyKey,
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary
- generate an idempotency key before the live manual/GPS trip save
- preserve that key when falling back to the offline queue
- add regression coverage for failed manual trip sync and queue key preservation

Fixes #287

## Verification
- bunx vitest run src/pages/__tests__/TripPage.preset.test.tsx src/lib/__tests__/offline-queue.test.ts
- bun run typecheck