### PR TITLE
feat: use Super73 speed in trip dashboard

### DIFF
--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -30,6 +30,7 @@ import { useT } from "@/i18n/provider";
 import { useNavigation } from "@/hooks/useNavigation";
 import { DestinationSearch } from "@/components/trip/DestinationSearch";
 import { NavigationBanner } from "@/components/trip/NavigationBanner";
+import { useSuper73 } from "@/hooks/useSuper73";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -53,6 +54,7 @@ export function TripPage() {
   const { data: profileData } = useProfile();
   const { data: tripPresetsData } = useTripPresets();
   const gps = useAppGpsTracking();
+  const ble = useSuper73();
   const currentGpsPoint = gps.state.gpsPoints.at(-1) ?? null;
   const navigation = useNavigation({
     currentPoint: currentGpsPoint,
@@ -63,6 +65,7 @@ export function TripPage() {
   const isPov = orientation === "pov";
 
   const tripPresets = tripPresetsData ?? [];
+  const effectiveSpeedKmh = ble.bikeSpeedKmh ?? gps.state.speedKmh;
 
   // --- Custom hooks ---
   const recovery = useSessionRecovery({ gps });
@@ -313,7 +316,7 @@ export function TripPage() {
         <>
           <TrackingDashboard
             isPaused={gps.state.isPaused}
-            speedKmh={gps.state.speedKmh}
+            speedKmh={effectiveSpeedKmh}
             distance={distance}
             co2Saved={co2Saved}
             elapsed={elapsed}

--- a/client/src/pages/__tests__/TripPage.super73-speed.test.tsx
+++ b/client/src/pages/__tests__/TripPage.super73-speed.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TripPage } from "../TripPage";
+import { I18nProvider } from "@/i18n/provider";
+
+const mocks = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  startMock: vi.fn(),
+  stopMock: vi.fn(),
+  resetMock: vi.fn(),
+  restoreMock: vi.fn(),
+  pauseMock: vi.fn(),
+  resumeMock: vi.fn(),
+  useSuper73Mock: vi.fn(),
+}));
+
+function renderTripPage() {
+  return render(
+    <I18nProvider>
+      <TripPage />
+    </I18nProvider>,
+  );
+}
+
+vi.mock("react-map-gl/maplibre", () => ({
+  __esModule: true,
+  default: () => null,
+  Marker: () => null,
+  Source: () => null,
+  Layer: () => null,
+}));
+
+vi.mock("@/hooks/queries", () => ({
+  useCreateTrip: () => ({
+    mutate: mocks.mutateMock,
+    isPending: false,
+  }),
+  useDeleteTripPreset: () => ({ mutate: vi.fn(), isPending: false }),
+  useProfile: () => ({
+    data: {
+      user: {
+        consumptionL100: 7,
+        super73Enabled: true,
+      },
+    },
+  }),
+  useTripPresets: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useGpsTracking", () => ({
+  useAppGpsTracking: () => ({
+    state: {
+      isTracking: true,
+      isPaused: false,
+      distanceKm: 1.23,
+      durationSec: 120,
+      gpsPoints: [{ lat: 48.8566, lng: 2.3522, ts: 1 }],
+      error: null,
+      lastAccuracy: 5,
+      speedKmh: 12,
+      heading: 90,
+    },
+    start: mocks.startMock,
+    stop: mocks.stopMock,
+    reset: mocks.resetMock,
+    restore: mocks.restoreMock,
+    pause: mocks.pauseMock,
+    resume: mocks.resumeMock,
+  }),
+  getTrackingBackup: () => null,
+  clearTrackingBackup: vi.fn(),
+  getTrackingSession: () => null,
+}));
+
+vi.mock("@/hooks/useSuper73", () => ({
+  useSuper73: () => mocks.useSuper73Mock(),
+}));
+
+vi.mock("@/lib/stopped-session", () => ({
+  getStoppedSession: () => null,
+  setStoppedSession: vi.fn(),
+  clearStoppedSession: vi.fn(),
+  hasStoppedSession: () => false,
+}));
+vi.mock("@/lib/offline-queue", () => ({ queueTrip: vi.fn() }));
+vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => false }));
+vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));
+vi.mock("@/components/Super73ModeButton", () => ({ Super73ModeButton: () => null }));
+
+function super73State(bikeSpeedKmh: number | null) {
+  return {
+    status: bikeSpeedKmh == null ? "disconnected" : "connected",
+    bikeState: null,
+    bikeSpeedKmh,
+    error: null,
+    tripModeSelection: "eco",
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    setMode: vi.fn(),
+    setAssist: vi.fn(),
+    setLight: vi.fn(),
+    toggleMode: vi.fn(),
+    cycleTripModeSelection: vi.fn(),
+    epacPollFallbackWarning: false,
+    dismissEpacPollFallback: vi.fn(),
+  };
+}
+
+describe("TripPage Super73 speed display", () => {
+  beforeEach(() => {
+    vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+    vi.clearAllMocks();
+    mocks.useSuper73Mock.mockReturnValue(super73State(null));
+  });
+
+  it("uses Super73 wheel speed for the live speed dashboard when available", () => {
+    mocks.useSuper73Mock.mockReturnValue(super73State(32.4));
+
+    renderTripPage();
+
+    expect(screen.getByText("32")).toBeTruthy();
+    expect(screen.queryByText("12")).toBeNull();
+  });
+
+  it("falls back to GPS speed when no Super73 wheel speed is available", () => {
+    mocks.useSuper73Mock.mockReturnValue(super73State(null));
+
+    renderTripPage();
+
+    expect(screen.getByText("12")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- display Super73 BLE wheel speed in the trip dashboard when available
- keep GPS speed as fallback when no Super73 speed is connected
- leave GPS distance, trace, and trip persistence unchanged

Closes #279

## Verification
- bunx vitest run src/pages/__tests__/TripPage.super73-speed.test.tsx src/pages/__tests__/TripPage.interrupt.test.tsx
- bun run typecheck