### PR TITLE
fix: don't queue live trip validation errors

### DIFF
--- a/client/e2e/trip-preset-flow.spec.ts
+++ b/client/e2e/trip-preset-flow.spec.ts
@@ -248,7 +248,13 @@ test("preset flow works from Stats creation to Profile listing to Trip manual us
   await expect(page.getByLabel("Distance (km)")).toHaveValue("8.4");
   await expect(page.getByLabel("Durée (minutes)")).toHaveValue("25");
 
-  await page.getByRole("button", { name: "Enregistrer" }).click();
+  await Promise.all([
+    page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/trips" && response.request().method() === "POST";
+    }),
+    page.getByRole("button", { name: "Enregistrer" }).click(),
+  ]);
 
   expect(createdTripRequest).toMatchObject({
     distanceKm: 8.4,

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -33,6 +33,7 @@ export const en: Record<TranslationKey, string> = {
   "trip.confirm.save": "Save this trip?",
   "trip.confirm.abandon": "Abandon this trip? The data will be lost.",
   "trip.offline.savedLocally": "Trip saved offline. It will be sent automatically.",
+  "trip.errors.saveRejected": "Trip rejected by the server. Check the times and try again.",
 
   "trip.dashboard.pausedAria": "Trip paused",
   "trip.dashboard.pausedLabel": "PAUSED",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -31,6 +31,7 @@ export const fr = {
   "trip.confirm.save": "Enregistrer ce trajet ?",
   "trip.confirm.abandon": "Abandonner ce trajet ? Les données seront perdues.",
   "trip.offline.savedLocally": "Trajet sauvegardé hors-ligne. Il sera envoyé automatiquement.",
+  "trip.errors.saveRejected": "Trajet refusé par le serveur. Vérifiez les horaires et réessayez.",
 
   "trip.dashboard.pausedAria": "Trajet en pause",
   "trip.dashboard.pausedLabel": "PAUSÉ",

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -8,6 +8,7 @@ import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
 import { useAppGpsTracking } from "@/hooks/useGpsTracking";
 import type { TrackingSession } from "@/hooks/useGpsTracking";
 import { queueTrip } from "@/lib/offline-queue";
+import { ApiError } from "@/lib/api";
 import { clearStoppedSession } from "@/lib/stopped-session";
 import { isWebGLSupported } from "@/lib/webgl";
 import { MapNoWebGL } from "@/components/MapNoWebGL";
@@ -37,6 +38,22 @@ type TripState = "idle" | "tracking" | "stopped" | "manual";
 const DEFAULT_CENTER: [number, number] = [48.8566, 2.3522]; // Paris
 const MAP_STYLE = "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json";
 const TRACKING_CAMERA_PADDING = { top: 200, bottom: 0, left: 0, right: 0 };
+
+function extractApiErrorMessage(error: ApiError): string | null {
+  const body = error.body.trim();
+  if (!body) return null;
+
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown };
+      message?: unknown;
+    };
+    const message = parsed.error?.message ?? parsed.message;
+    return typeof message === "string" && message.trim() ? message : null;
+  } catch {
+    return body.startsWith("{") ? null : body;
+  }
+}
 
 export function TripPage() {
   const t = useT();
@@ -203,7 +220,12 @@ export function TripPage() {
           recovery.sessionRef.current = null;
           gps.reset();
         },
-        onError: () => {
+        onError: (error) => {
+          if (error instanceof ApiError) {
+            setSaveError(extractApiErrorMessage(error) ?? t("trip.errors.saveRejected"));
+            return;
+          }
+
           queueTrip(tripData);
           setSaveError(t("trip.offline.savedLocally"));
           setTimeout(() => {

--- a/client/src/pages/__tests__/TripPage.preset.test.tsx
+++ b/client/src/pages/__tests__/TripPage.preset.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { TripPage } from "../TripPage";
 import { I18nProvider } from "@/i18n/provider";
+import { ApiError } from "@/lib/api";
 
 const renderTripPage = () =>
   render(
@@ -155,6 +156,41 @@ describe("TripPage trip preset selection", () => {
         idempotencyKey: tripData.idempotencyKey,
       }),
     );
+  });
+
+  it("shows live validation errors instead of queuing them as offline trips", () => {
+    renderTripPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Saisie manuelle" }));
+    fireEvent.change(screen.getByLabelText("Distance (km)"), { target: { value: "3.2" } });
+    fireEvent.change(screen.getByLabelText("Durée (minutes)"), { target: { value: "12" } });
+    fireEvent.click(screen.getByRole("button", { name: "Enregistrer" }));
+
+    const [, options] = mutateMock.mock.calls[0] as [
+      unknown,
+      { onError: (error: unknown) => void },
+    ];
+
+    act(() => {
+      options.onError(
+        new ApiError(
+          409,
+          JSON.stringify({
+            ok: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Ce trajet chevauche un trajet existant.",
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(queueTripMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Ce trajet chevauche un trajet existant.")).toBeTruthy();
+    expect(
+      screen.queryByText("Trajet sauvegardé hors-ligne. Il sera envoyé automatiquement."),
+    ).toBeNull();
   });
 
   it("resets the fields when switching back to custom mode", () => {


### PR DESCRIPTION
## Summary
- distinguish live server validation errors from offline/network failures during trip save
- show the server validation message inline instead of queuing the trip as offline
- keep offline queue fallback for real network failures

Fixes #290

## Verification
- bunx vitest run src/pages/__tests__/TripPage.preset.test.tsx src/hooks/__tests__/useOfflineSync.test.tsx src/pages/__tests__/DashboardPage.announcement.test.tsx
- bun run typecheck