### PR TITLE
fix(gps): count slow cycling distance

### DIFF
--- a/client/src/hooks/__tests__/useGpsTracking.test.ts
+++ b/client/src/hooks/__tests__/useGpsTracking.test.ts
@@ -222,20 +222,27 @@ describe("useGpsTracking — pause/resume (#166)", () => {
   });
 
   /** Inject a fake GPS fix at the given coordinates. */
-  async function injectGpsPoint(lat = 48.8566, lng = 2.3522) {
+  async function injectGpsPoint(
+    lat = 48.8566,
+    lng = 2.3522,
+    options: { speedMps?: number | null; timestamp?: number; accuracy?: number } = {},
+  ) {
     if (!watchPositionCallback) return;
+    const speed = Object.prototype.hasOwnProperty.call(options, "speedMps")
+      ? (options.speedMps ?? null)
+      : 5;
     await act(async () => {
       watchPositionCallback!({
         coords: {
           latitude: lat,
           longitude: lng,
-          accuracy: 10,
-          speed: 5,
+          accuracy: options.accuracy ?? 10,
+          speed,
           heading: 90,
           altitude: null,
           altitudeAccuracy: null,
         },
-        timestamp: Date.now(),
+        timestamp: options.timestamp ?? Date.now(),
       } as GeolocationPosition);
     });
   }
@@ -362,6 +369,75 @@ describe("useGpsTracking — pause/resume (#166)", () => {
     expect(result.current.state.distanceKm).toBe(distanceBefore);
   });
 
+  it("counts slow cycling segments below 5m when GPS speed confirms movement", async () => {
+    const { result } = renderHook(() => useGpsTracking());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await injectGpsPoint(48.8566, 2.3522, { speedMps: 2.2, timestamp: 1_000 });
+    await injectGpsPoint(48.856627, 2.3522, { speedMps: 2.2, timestamp: 2_500 });
+    await injectGpsPoint(48.856654, 2.3522, { speedMps: 2.2, timestamp: 4_000 });
+
+    expect(result.current.state.distanceKm).toBeGreaterThan(0.005);
+  });
+
+  it("accumulates slow cycling segments below 5m when GPS speed is unavailable", async () => {
+    const { result } = renderHook(() => useGpsTracking());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await injectGpsPoint(48.8566, 2.3522, { speedMps: null, timestamp: 1_000 });
+    await injectGpsPoint(48.856627, 2.3522, { speedMps: null, timestamp: 2_500 });
+    await injectGpsPoint(48.856654, 2.3522, { speedMps: null, timestamp: 4_000 });
+
+    expect(result.current.state.distanceKm).toBeGreaterThan(0.005);
+  });
+
+  it("does not count stationary GPS jitter when reported speed says stopped", async () => {
+    const { result } = renderHook(() => useGpsTracking());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await injectGpsPoint(48.8566, 2.3522, { speedMps: 0, timestamp: 1_000 });
+    await injectGpsPoint(48.85663, 2.3522, { speedMps: 0, timestamp: 2_000 });
+    await injectGpsPoint(48.85657, 2.3522, { speedMps: 0, timestamp: 3_000 });
+    await injectGpsPoint(48.85661, 2.3522, { speedMps: 0, timestamp: 4_000 });
+
+    expect(result.current.state.distanceKm).toBe(0);
+  });
+
+  it("counts plausible GPS reconnect segments after a temporary signal loss", async () => {
+    const { result } = renderHook(() => useGpsTracking());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await injectGpsPoint(48.8566, 2.3522, { speedMps: null, timestamp: 1_000 });
+    await injectGpsPoint(48.8611, 2.3522, { speedMps: null, timestamp: 181_000 });
+
+    expect(result.current.state.distanceKm).toBeGreaterThan(0.45);
+  });
+
+  it("rejects implausible short-window GPS jumps", async () => {
+    const { result } = renderHook(() => useGpsTracking());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    await injectGpsPoint(48.8566, 2.3522, { speedMps: null, timestamp: 1_000 });
+    await injectGpsPoint(48.8611, 2.3522, { speedMps: null, timestamp: 3_000 });
+
+    expect(result.current.state.distanceKm).toBe(0);
+  });
+
   it("stop() after pause/resume returns correct accumulated totals", async () => {
     const { result } = renderHook(() => useGpsTracking());
 
@@ -371,8 +447,8 @@ describe("useGpsTracking — pause/resume (#166)", () => {
     await act(async () => {
       vi.advanceTimersByTime(2000);
     });
-    await injectGpsPoint(48.8566, 2.3522);
-    await injectGpsPoint(48.86, 2.36); // some distance
+    await injectGpsPoint(48.8566, 2.3522, { timestamp: 2_000 });
+    await injectGpsPoint(48.86, 2.36, { timestamp: 32_000 }); // some distance
 
     await act(async () => {
       result.current.pause();

--- a/client/src/hooks/useGpsTracking.ts
+++ b/client/src/hooks/useGpsTracking.ts
@@ -13,7 +13,10 @@ import { useWakeLock } from "./useWakeLock";
 import type { GpsPoint } from "@ecoride/shared/types";
 
 const MAX_ACCURACY_M = 50;
-const MIN_DISTANCE_KM = 0.005; // 5m
+const STATIONARY_SPEED_MPS = 0.5; // 1.8 km/h: below this, treat fixes as stationary jitter
+const MAX_PLAUSIBLE_SPEED_MPS = 25; // 90 km/h: above this, treat as a GPS spike
+const GPS_RECONNECT_GAP_SEC = 30;
+const MIN_UNREPORTED_SPEED_DISTANCE_KM = 0.005; // 5m accumulated, not per-segment
 const BACKUP_KEY = "ecoride-tracking-backup";
 const SESSION_KEY = "ecoride-trip-session";
 const BACKUP_INTERVAL_MS = 30_000;
@@ -30,6 +33,7 @@ export interface TrackingState {
   lastAccuracy: number | null;
   speedKmh: number | null;
   heading: number | null;
+  distanceAnchor: GpsPoint | null;
 }
 
 export interface TrackingSession {
@@ -45,6 +49,7 @@ export interface TrackingBackup {
   distanceKm: number;
   durationSec: number;
   startedAt: string;
+  distanceAnchor?: GpsPoint | null;
 }
 
 export interface UseGpsTrackingResult {
@@ -83,7 +88,35 @@ const initial: TrackingState = {
   lastAccuracy: null,
   speedKmh: null,
   heading: null,
+  distanceAnchor: null,
 };
+
+function getSegmentDistanceKm(from: GpsPoint, to: GpsPoint): number {
+  return haversineDistance(from.lat, from.lng, to.lat, to.lng);
+}
+
+function shouldCountDistanceSegment(
+  distanceKm: number,
+  deltaSec: number,
+  reportedSpeedMps: number | null,
+): boolean {
+  if (deltaSec <= 0) return false;
+
+  const distanceM = distanceKm * 1000;
+  const impliedSpeedMps = distanceM / deltaSec;
+  if (!Number.isFinite(impliedSpeedMps)) return false;
+  if (impliedSpeedMps > MAX_PLAUSIBLE_SPEED_MPS) return false;
+
+  if (deltaSec >= GPS_RECONNECT_GAP_SEC) {
+    return impliedSpeedMps >= STATIONARY_SPEED_MPS;
+  }
+
+  if (reportedSpeedMps != null) {
+    return reportedSpeedMps >= STATIONARY_SPEED_MPS;
+  }
+
+  return impliedSpeedMps >= STATIONARY_SPEED_MPS && distanceKm >= MIN_UNREPORTED_SPEED_DISTANCE_KM;
+}
 
 function reducer(state: TrackingState, action: Action): TrackingState {
   switch (action.type) {
@@ -106,12 +139,19 @@ function reducer(state: TrackingState, action: Action): TrackingState {
       return { ...state, isPaused: false, error: null };
     case "GPS_POINT": {
       const points = [...state.gpsPoints, action.point];
+      const anchor = state.distanceAnchor ?? state.gpsPoints[state.gpsPoints.length - 1] ?? null;
       let added = 0;
-      if (state.gpsPoints.length > 0) {
-        const prev = state.gpsPoints[state.gpsPoints.length - 1]!;
-        const d = haversineDistance(prev.lat, prev.lng, action.point.lat, action.point.lng);
-        if (d >= MIN_DISTANCE_KM) added = d;
+      let distanceAnchor = state.distanceAnchor ?? action.point;
+
+      if (anchor) {
+        const d = getSegmentDistanceKm(anchor, action.point);
+        const deltaSec = (action.point.ts - anchor.ts) / 1000;
+        if (shouldCountDistanceSegment(d, deltaSec, action.speed)) {
+          added = d;
+          distanceAnchor = action.point;
+        }
       }
+
       const speedKmh = action.speed != null ? action.speed * 3.6 : state.speedKmh;
       const heading =
         action.heading != null && speedKmh != null && speedKmh > 1.8
@@ -121,6 +161,7 @@ function reducer(state: TrackingState, action: Action): TrackingState {
         ...state,
         gpsPoints: points,
         distanceKm: state.distanceKm + added,
+        distanceAnchor,
         error: null,
         lastAccuracy: action.accuracy,
         speedKmh,
@@ -144,6 +185,10 @@ function reducer(state: TrackingState, action: Action): TrackingState {
         lastAccuracy: null,
         speedKmh: null,
         heading: null,
+        distanceAnchor:
+          action.backup.distanceAnchor ??
+          action.backup.gpsPoints[action.backup.gpsPoints.length - 1] ??
+          null,
       };
   }
 }
@@ -228,6 +273,7 @@ export function useGpsTracking() {
         distanceKm: s.distanceKm,
         durationSec: s.durationSec,
         startedAt: startRef.current,
+        distanceAnchor: s.distanceAnchor,
       };
       localStorage.setItem(BACKUP_KEY, JSON.stringify(backup));
     } catch {


### PR DESCRIPTION
## Summary
- replace the per-segment 5m deadband with hybrid speed/time filtering
- count slow cycling micro-segments while filtering stationary jitter
- preserve plausible reconnect distance after temporary GPS loss

## Tests
- bunx vitest run src/hooks/__tests__/useGpsTracking.test.ts
- bun run client/typecheck

Closes #296