### PR TITLE
fix(map): preserve zoom and add recenter control during tracking

### DIFF
--- a/client/src/hooks/__tests__/useMapCamera.test.tsx
+++ b/client/src/hooks/__tests__/useMapCamera.test.tsx
@@ -47,7 +47,12 @@ describe("useMapCamera", () => {
     });
 
     expect(flyTo).toHaveBeenCalledTimes(1);
-    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3522, 48.8566] }));
+    expect(flyTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ center: [2.3522, 48.8566] }),
+    );
+    expect(flyTo).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ zoom: expect.anything() }),
+    );
   });
 
   it("replays the latest position after the throttle window instead of dropping it", () => {
@@ -61,7 +66,9 @@ describe("useMapCamera", () => {
     const { rerender } = render(<CameraHarness mapRef={mapRef} position={[48.8566, 2.3522]} />);
 
     expect(flyTo).toHaveBeenCalledTimes(1);
-    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3522, 48.8566] }));
+    expect(flyTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ center: [2.3522, 48.8566] }),
+    );
 
     rerender(<CameraHarness mapRef={mapRef} position={[48.8576, 2.3622]} />);
 
@@ -72,6 +79,11 @@ describe("useMapCamera", () => {
     });
 
     expect(flyTo).toHaveBeenCalledTimes(2);
-    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3622, 48.8576] }));
+    expect(flyTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ center: [2.3622, 48.8576] }),
+    );
+    expect(flyTo).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ zoom: expect.anything() }),
+    );
   });
 });

--- a/client/src/hooks/__tests__/useMapCamera.test.tsx
+++ b/client/src/hooks/__tests__/useMapCamera.test.tsx
@@ -47,9 +47,7 @@ describe("useMapCamera", () => {
     });
 
     expect(flyTo).toHaveBeenCalledTimes(1);
-    expect(flyTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({ center: [2.3522, 48.8566] }),
-    );
+    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3522, 48.8566] }));
     expect(flyTo).toHaveBeenLastCalledWith(
       expect.not.objectContaining({ zoom: expect.anything() }),
     );
@@ -66,9 +64,7 @@ describe("useMapCamera", () => {
     const { rerender } = render(<CameraHarness mapRef={mapRef} position={[48.8566, 2.3522]} />);
 
     expect(flyTo).toHaveBeenCalledTimes(1);
-    expect(flyTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({ center: [2.3522, 48.8566] }),
-    );
+    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3522, 48.8566] }));
 
     rerender(<CameraHarness mapRef={mapRef} position={[48.8576, 2.3622]} />);
 
@@ -79,9 +75,7 @@ describe("useMapCamera", () => {
     });
 
     expect(flyTo).toHaveBeenCalledTimes(2);
-    expect(flyTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({ center: [2.3622, 48.8576] }),
-    );
+    expect(flyTo).toHaveBeenLastCalledWith(expect.objectContaining({ center: [2.3622, 48.8576] }));
     expect(flyTo).toHaveBeenLastCalledWith(
       expect.not.objectContaining({ zoom: expect.anything() }),
     );

--- a/client/src/hooks/useMapCamera.ts
+++ b/client/src/hooks/useMapCamera.ts
@@ -60,7 +60,6 @@ export function useMapCamera(
         center: [position[1], position[0]],
         bearing: bearing ?? 0,
         pitch: bearing != null ? (pitch ?? 0) : 0,
-        zoom: 15,
         duration: 400,
         ...(padding ? { padding } : {}),
       });

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -90,6 +90,7 @@ export const en: Record<TranslationKey, string> = {
 
   "trip.map.orientationNorth": "Switch to north-up mode",
   "trip.map.orientationPov": "Switch to heading-up mode",
+  "trip.map.recenter": "Recenter",
 
   "vehicle.header.title": "My bike",
   "vehicle.header.back": "Back to profile",

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -92,6 +92,7 @@ export const en: Record<TranslationKey, string> = {
 
   "trip.map.orientationNorth": "Switch to north-up mode",
   "trip.map.orientationPov": "Switch to heading-up mode",
+  "trip.map.recenter": "Recenter",
 
   "vehicle.header.title": "My bike",
   "vehicle.header.back": "Back to profile",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -88,6 +88,7 @@ export const fr = {
 
   "trip.map.orientationNorth": "Passer en mode nord en haut",
   "trip.map.orientationPov": "Passer en mode suivi du cap",
+  "trip.map.recenter": "Recentrer",
 
   "vehicle.header.title": "Mon vélo",
   "vehicle.header.back": "Retour au profil",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -90,6 +90,7 @@ export const fr = {
 
   "trip.map.orientationNorth": "Passer en mode nord en haut",
   "trip.map.orientationPov": "Passer en mode suivi du cap",
+  "trip.map.recenter": "Recentrer",
 
   "vehicle.header.title": "Mon vélo",
   "vehicle.header.back": "Retour au profil",

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { Play, Keyboard, AlertTriangle, MapPin, X } from "lucide-react";
+import { Play, Keyboard, AlertTriangle, MapPin, X, LocateFixed } from "lucide-react";
 import Map, { Marker, Source, Layer } from "react-map-gl/maplibre";
 import type { MapRef, LayerProps } from "react-map-gl/maplibre";
 // maplibre-gl.css imported in app.css to avoid orphan CSS chunks
@@ -78,6 +78,7 @@ export function TripPage() {
     lastAccuracy: gps.state.lastAccuracy,
   });
   const [showDestinationSearch, setShowDestinationSearch] = useState(false);
+  const [isTrackingMapFollowing, setIsTrackingMapFollowing] = useState(true);
   const { orientation, toggle: toggleOrientation } = useMapOrientation();
   const isPov = orientation === "pov";
 
@@ -141,7 +142,7 @@ export function TripPage() {
     bearing: isPov ? gps.state.heading : 0,
     pitch: isPov ? 45 : 0,
     padding: TRACKING_CAMERA_PADDING,
-    enabled: uiState === "tracking",
+    enabled: uiState === "tracking" && isTrackingMapFollowing,
   });
   const idleCamera = useMapCamera(idleMapRef, currentPos, {
     enabled: uiState !== "tracking",
@@ -245,6 +246,7 @@ export function TripPage() {
 
   const startTracking = useCallback(() => {
     resetMapState();
+    setIsTrackingMapFollowing(true);
     recovery.setSessionPersistFailed(false);
     setInterruptMenuOpen(false);
     recovery.setPendingBackup(null);
@@ -267,6 +269,7 @@ export function TripPage() {
     const session = gps.stop();
     recovery.sessionRef.current = session;
     resetMapState();
+    setIsTrackingMapFollowing(true);
     setInterruptMenuOpen(false);
     recovery.setPendingBackup(null);
     recovery.setSessionPersistFailed(false);
@@ -281,6 +284,7 @@ export function TripPage() {
       recovery.setPendingBackup(null);
       clearStoppedSession();
       setInterruptMenuOpen(false);
+      setIsTrackingMapFollowing(true);
       setUiState("idle");
       recovery.sessionRef.current = null;
       gps.reset();
@@ -291,10 +295,24 @@ export function TripPage() {
   const handleRestore = useCallback(() => {
     recovery.handleRestore(() => {
       resetMapState();
+      setIsTrackingMapFollowing(true);
       setInterruptMenuOpen(false);
     });
     setUiState("tracking");
   }, [recovery, resetMapState]);
+
+  const handleTrackingMapInteraction = useCallback(
+    (evt?: { originalEvent?: unknown }) => {
+      if (uiState !== "tracking") return;
+      if (!evt?.originalEvent) return;
+      setIsTrackingMapFollowing(false);
+    },
+    [uiState],
+  );
+
+  const handleTrackingMapRecenter = useCallback(() => {
+    setIsTrackingMapFollowing(true);
+  }, []);
 
   return (
     <div
@@ -391,6 +409,7 @@ export function TripPage() {
                   onError={() => {
                     if (!mapStyleReadyRef.current) setMapLoadError(true);
                   }}
+                  onMoveStart={handleTrackingMapInteraction}
                 >
                   {remainingRouteGeoJSON && (
                     <Source id="nav-route-tracking" type="geojson" data={remainingRouteGeoJSON}>
@@ -463,8 +482,19 @@ export function TripPage() {
             ) : (
               <MapNoWebGL />
             )}
-            <div className="pointer-events-none absolute right-3 top-3 z-10">
-              <div className="pointer-events-auto">
+            <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-3">
+              {!isTrackingMapFollowing && (
+                <button
+                  type="button"
+                  onClick={handleTrackingMapRecenter}
+                  aria-label={t("trip.map.recenter")}
+                  className="pointer-events-auto flex h-12 min-w-12 items-center justify-center gap-2 self-end rounded-full border border-surface-highest bg-surface-container/90 px-4 text-sm font-bold text-text backdrop-blur active:scale-95"
+                >
+                  <LocateFixed size={18} className="shrink-0 text-primary" />
+                  <span>{t("trip.map.recenter")}</span>
+                </button>
+              )}
+              <div className="pointer-events-auto self-end">
                 <MapOrientationButton orientation={orientation} onToggle={toggleOrientation} />
               </div>
             </div>

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { Play, Keyboard, AlertTriangle, MapPin, X } from "lucide-react";
+import { Play, Keyboard, AlertTriangle, MapPin, X, LocateFixed } from "lucide-react";
 import Map, { Marker, Source, Layer } from "react-map-gl/maplibre";
 import type { MapRef, LayerProps } from "react-map-gl/maplibre";
 // maplibre-gl.css imported in app.css to avoid orphan CSS chunks
@@ -78,6 +78,7 @@ export function TripPage() {
     lastAccuracy: gps.state.lastAccuracy,
   });
   const [showDestinationSearch, setShowDestinationSearch] = useState(false);
+  const [isTrackingMapFollowing, setIsTrackingMapFollowing] = useState(true);
   const { orientation, toggle: toggleOrientation } = useMapOrientation();
   const isPov = orientation === "pov";
 
@@ -141,7 +142,7 @@ export function TripPage() {
     bearing: isPov ? gps.state.heading : 0,
     pitch: isPov ? 45 : 0,
     padding: TRACKING_CAMERA_PADDING,
-    enabled: uiState === "tracking",
+    enabled: uiState === "tracking" && isTrackingMapFollowing,
   });
   const idleCamera = useMapCamera(idleMapRef, currentPos, {
     enabled: uiState !== "tracking",
@@ -258,6 +259,7 @@ export function TripPage() {
 
   const startTracking = useCallback(() => {
     resetMapState();
+    setIsTrackingMapFollowing(true);
     recovery.setSessionPersistFailed(false);
     setInterruptMenuOpen(false);
     recovery.setPendingBackup(null);
@@ -280,6 +282,7 @@ export function TripPage() {
     const session = gps.stop();
     recovery.sessionRef.current = session;
     resetMapState();
+    setIsTrackingMapFollowing(true);
     setInterruptMenuOpen(false);
     recovery.setPendingBackup(null);
     recovery.setSessionPersistFailed(false);
@@ -294,6 +297,7 @@ export function TripPage() {
       recovery.setPendingBackup(null);
       clearStoppedSession();
       setInterruptMenuOpen(false);
+      setIsTrackingMapFollowing(true);
       setUiState("idle");
       recovery.sessionRef.current = null;
       gps.reset();
@@ -304,10 +308,24 @@ export function TripPage() {
   const handleRestore = useCallback(() => {
     recovery.handleRestore(() => {
       resetMapState();
+      setIsTrackingMapFollowing(true);
       setInterruptMenuOpen(false);
     });
     setUiState("tracking");
   }, [recovery, resetMapState]);
+
+  const handleTrackingMapInteraction = useCallback(
+    (evt?: { originalEvent?: unknown }) => {
+      if (uiState !== "tracking") return;
+      if (!evt?.originalEvent) return;
+      setIsTrackingMapFollowing(false);
+    },
+    [uiState],
+  );
+
+  const handleTrackingMapRecenter = useCallback(() => {
+    setIsTrackingMapFollowing(true);
+  }, []);
 
   return (
     <div
@@ -404,6 +422,7 @@ export function TripPage() {
                   onError={() => {
                     if (!mapStyleReadyRef.current) setMapLoadError(true);
                   }}
+                  onMoveStart={handleTrackingMapInteraction}
                 >
                   {remainingRouteGeoJSON && (
                     <Source id="nav-route-tracking" type="geojson" data={remainingRouteGeoJSON}>
@@ -476,8 +495,19 @@ export function TripPage() {
             ) : (
               <MapNoWebGL />
             )}
-            <div className="pointer-events-none absolute right-3 top-3 z-10">
-              <div className="pointer-events-auto">
+            <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-3">
+              {!isTrackingMapFollowing && (
+                <button
+                  type="button"
+                  onClick={handleTrackingMapRecenter}
+                  aria-label={t("trip.map.recenter")}
+                  className="pointer-events-auto flex h-12 min-w-12 items-center justify-center gap-2 self-end rounded-full border border-surface-highest bg-surface-container/90 px-4 text-sm font-bold text-text backdrop-blur active:scale-95"
+                >
+                  <LocateFixed size={18} className="shrink-0 text-primary" />
+                  <span>{t("trip.map.recenter")}</span>
+                </button>
+              )}
+              <div className="pointer-events-auto self-end">
                 <MapOrientationButton orientation={orientation} onToggle={toggleOrientation} />
               </div>
             </div>

--- a/client/src/pages/__tests__/TripPage.map-follow.test.tsx
+++ b/client/src/pages/__tests__/TripPage.map-follow.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { forwardRef } from "react";
+import { TripPage } from "../TripPage";
+import { I18nProvider } from "@/i18n/provider";
+
+const mocks = vi.hoisted(() => ({
+  startMock: vi.fn(),
+  mutateMock: vi.fn(),
+  resetMock: vi.fn(),
+  stopMock: vi.fn(),
+  restoreMock: vi.fn(),
+  pauseMock: vi.fn(),
+  resumeMock: vi.fn(),
+}));
+
+function renderTripPage() {
+  return render(
+    <I18nProvider>
+      <TripPage />
+    </I18nProvider>,
+  );
+}
+
+vi.mock("react-map-gl/maplibre", () => {
+  const MockMap = forwardRef<HTMLDivElement, Record<string, unknown>>(function MockMap(props, _ref) {
+    const { children, onMoveStart } = props as {
+      children?: React.ReactNode;
+      onMoveStart?: (evt: { originalEvent?: unknown }) => void;
+    };
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => onMoveStart?.({ originalEvent: { type: "pointerdown" } })}
+        >
+          simulate-map-interaction
+        </button>
+        {children}
+      </div>
+    );
+  });
+
+  return {
+    __esModule: true,
+    default: MockMap,
+    Marker: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Source: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Layer: () => null,
+  };
+});
+
+vi.mock("@/hooks/queries", () => ({
+  useCreateTrip: () => ({
+    mutate: mocks.mutateMock,
+    isPending: false,
+  }),
+  useProfile: () => ({
+    data: {
+      user: {
+        consumptionL100: 7,
+        super73Enabled: false,
+      },
+    },
+  }),
+  useTripPresets: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useGpsTracking", () => ({
+  useAppGpsTracking: () => ({
+    state: {
+      isTracking: false,
+      isPaused: false,
+      distanceKm: 0.4,
+      durationSec: 60,
+      gpsPoints: [{ lat: 48.8566, lng: 2.3522, ts: 1 }],
+      error: null,
+      lastAccuracy: 5,
+      speedKmh: 12,
+      heading: 90,
+    },
+    start: mocks.startMock,
+    stop: mocks.stopMock,
+    reset: mocks.resetMock,
+    restore: mocks.restoreMock,
+    pause: mocks.pauseMock,
+    resume: mocks.resumeMock,
+  }),
+  getTrackingBackup: () => null,
+  clearTrackingBackup: vi.fn(),
+  getTrackingSession: () => null,
+}));
+
+vi.mock("@/hooks/useSessionRecovery", () => ({
+  useSessionRecovery: () => ({
+    initialUiState: null,
+    pendingBackup: null,
+    sessionRef: { current: null },
+    setPendingBackup: vi.fn(),
+    setSessionPersistFailed: vi.fn(),
+    sessionPersistFailed: false,
+    handleRestore: (cb: () => void) => cb(),
+    handleDismissBackup: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useManualTrip", () => ({
+  useManualTrip: () => ({
+    manualKm: "",
+    setManualKm: vi.fn(),
+    manualMinutes: "",
+    setManualMinutes: vi.fn(),
+    manualPresetId: "custom",
+    setManualPresetId: vi.fn(),
+    handleManualPresetChange: vi.fn(),
+    resetManualForm: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useNavigation", () => ({
+  useNavigation: () => ({
+    destination: null,
+    route: null,
+    remainingCoordinates: [],
+    nextInstruction: null,
+    distanceToNextStep: null,
+    isLoading: false,
+    isArrived: false,
+    currentStepType: null,
+    clearRoute: vi.fn(),
+    setDestination: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useSuper73", () => ({
+  useSuper73: () => ({
+    bikeSpeedKmh: null,
+  }),
+}));
+
+vi.mock("@/lib/stopped-session", () => ({
+  getStoppedSession: () => null,
+  setStoppedSession: vi.fn(),
+  clearStoppedSession: vi.fn(),
+  hasStoppedSession: () => false,
+}));
+
+vi.mock("@/lib/offline-queue", () => ({ queueTrip: vi.fn() }));
+vi.mock("@/lib/webgl", () => ({ isWebGLSupported: () => true }));
+vi.mock("@/components/MapNoWebGL", () => ({ MapNoWebGL: () => <div>Map fallback</div> }));
+
+describe("TripPage map follow mode", () => {
+  beforeEach(() => {
+    vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+    vi.clearAllMocks();
+  });
+
+  it("shows a recenter button after manual map interaction and hides it after recentering", () => {
+    renderTripPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Démarrer" }));
+
+    expect(screen.queryByRole("button", { name: "Recentrer" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "simulate-map-interaction" }));
+
+    expect(screen.getByRole("button", { name: "Recentrer" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Recentrer" }));
+
+    expect(screen.queryByRole("button", { name: "Recentrer" })).toBeNull();
+  });
+});

--- a/client/src/pages/__tests__/TripPage.map-follow.test.tsx
+++ b/client/src/pages/__tests__/TripPage.map-follow.test.tsx
@@ -23,23 +23,25 @@ function renderTripPage() {
 }
 
 vi.mock("react-map-gl/maplibre", () => {
-  const MockMap = forwardRef<HTMLDivElement, Record<string, unknown>>(function MockMap(props, _ref) {
-    const { children, onMoveStart } = props as {
-      children?: React.ReactNode;
-      onMoveStart?: (evt: { originalEvent?: unknown }) => void;
-    };
-    return (
-      <div>
-        <button
-          type="button"
-          onClick={() => onMoveStart?.({ originalEvent: { type: "pointerdown" } })}
-        >
-          simulate-map-interaction
-        </button>
-        {children}
-      </div>
-    );
-  });
+  const MockMap = forwardRef<HTMLDivElement, Record<string, unknown>>(
+    function MockMap(props, _ref) {
+      const { children, onMoveStart } = props as {
+        children?: React.ReactNode;
+        onMoveStart?: (evt: { originalEvent?: unknown }) => void;
+      };
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => onMoveStart?.({ originalEvent: { type: "pointerdown" } })}
+          >
+            simulate-map-interaction
+          </button>
+          {children}
+        </div>
+      );
+    },
+  );
 
   return {
     __esModule: true,


### PR DESCRIPTION
## Summary
- preserve the rider's current zoom level while the active-trip map follows GPS updates instead of forcing `zoom: 15` on every recenter
- stop follow mode when the user manually interacts with the tracking map, then show a `Recentrer` control to explicitly resume follow mode
- keep the existing orientation toggle and add targeted coverage for the new follow/recenter behavior

## User-facing behavior
- zooming in or out during an active trip now persists while the map keeps recentering on the rider
- dragging/exploring the map no longer snaps immediately back to the rider
- a recenter button appears after manual map interaction, similar to Google Maps

## Testing
- added a focused regression test for `useMapCamera` to ensure follow updates no longer force a zoom value
- added a `TripPage` test covering manual map interaction and the `Recentrer` control
- local test execution was not completed in this Codex environment because the fresh clone does not have project dependencies installed and no `bun`/`npm` CLI was available on PATH