### PR TITLE
feat: allow user-chosen date/time on manual trip entry

### DIFF
--- a/client/e2e/manual-trip-datetime.spec.ts
+++ b/client/e2e/manual-trip-datetime.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from "@playwright/test";
+
+test("manual entry sends user-chosen startedAt to the API", async ({ page }) => {
+  const now = new Date().toISOString();
+  const user = {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+    emailVerified: true,
+    image: null,
+    vehicleModel: null,
+    fuelType: "sp95",
+    consumptionL100: 7,
+    mileage: null,
+    timezone: null,
+    leaderboardOptOut: false,
+    reminderEnabled: false,
+    reminderTime: null,
+    reminderDays: null,
+    isAdmin: false,
+    super73Enabled: false,
+    super73AutoModeEnabled: false,
+    super73DefaultMode: null,
+    super73DefaultAssist: null,
+    super73DefaultLight: null,
+    super73AutoModeLowSpeedKmh: null,
+    super73AutoModeHighSpeedKmh: null,
+    createdAt: now,
+  };
+
+  let createdTripRequest: Record<string, unknown> | null = null;
+
+  await page.route(/\/api\//, async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    if (pathname.startsWith("/api/auth/")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session: {
+            id: "session-1",
+            token: "token",
+            userId: user.id,
+            expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+          },
+          user,
+        }),
+      });
+    }
+
+    if (pathname === "/api/trips" && method === "POST") {
+      createdTripRequest = (await route.request().postDataJSON()) as Record<string, unknown>;
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            trip: { id: "00000000-0000-4000-8000-000000000001", ...createdTripRequest },
+            newBadges: [],
+          },
+        }),
+      });
+    }
+
+    if (pathname === "/api/trip-presets" && method === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { tripPresets: [] } }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    });
+  });
+
+  await page.goto("/trip", { waitUntil: "networkidle" });
+
+  await page.getByRole("button", { name: "Saisie manuelle" }).click();
+
+  await page.getByLabel("Distance (km)").fill("12");
+  await page.getByLabel("Durée (minutes)").fill("30");
+  await page.getByLabel("Date et heure").fill("2026-05-04T08:30");
+
+  await Promise.all([
+    page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/trips" && response.request().method() === "POST";
+    }),
+    page.getByRole("button", { name: "Enregistrer" }).click(),
+  ]);
+
+  expect(createdTripRequest).not.toBeNull();
+  const body = createdTripRequest as unknown as Record<string, unknown>;
+  expect(body.distanceKm).toBe(12);
+  expect(body.durationSec).toBe(1800);
+
+  // The datetime-local input is interpreted as local time; the resulting ISO
+  // is the same wall-clock moment converted to UTC.
+  const expectedStart = new Date("2026-05-04T08:30").toISOString();
+  expect(body.startedAt).toBe(expectedStart);
+
+  // endedAt = startedAt + durationSec
+  const expectedEnd = new Date(new Date(expectedStart).getTime() + 1800 * 1000).toISOString();
+  expect(body.endedAt).toBe(expectedEnd);
+});
+
+test("manual entry without a date defaults to now", async ({ page }) => {
+  const now = new Date().toISOString();
+  const user = {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+    emailVerified: true,
+    image: null,
+    vehicleModel: null,
+    fuelType: "sp95",
+    consumptionL100: 7,
+    mileage: null,
+    timezone: null,
+    leaderboardOptOut: false,
+    reminderEnabled: false,
+    reminderTime: null,
+    reminderDays: null,
+    isAdmin: false,
+    super73Enabled: false,
+    super73AutoModeEnabled: false,
+    super73DefaultMode: null,
+    super73DefaultAssist: null,
+    super73DefaultLight: null,
+    super73AutoModeLowSpeedKmh: null,
+    super73AutoModeHighSpeedKmh: null,
+    createdAt: now,
+  };
+
+  let createdTripRequest: Record<string, unknown> | null = null;
+
+  await page.route(/\/api\//, async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    if (pathname.startsWith("/api/auth/")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session: {
+            id: "session-1",
+            token: "token",
+            userId: user.id,
+            expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+          },
+          user,
+        }),
+      });
+    }
+
+    if (pathname === "/api/trips" && method === "POST") {
+      createdTripRequest = (await route.request().postDataJSON()) as Record<string, unknown>;
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            trip: { id: "00000000-0000-4000-8000-000000000002", ...createdTripRequest },
+            newBadges: [],
+          },
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    });
+  });
+
+  const submitTime = Date.now();
+  await page.goto("/trip", { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Saisie manuelle" }).click();
+  await page.getByLabel("Distance (km)").fill("5");
+  await page.getByLabel("Durée (minutes)").fill("20");
+  // Leave the date field empty.
+  await Promise.all([
+    page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/trips" && response.request().method() === "POST";
+    }),
+    page.getByRole("button", { name: "Enregistrer" }).click(),
+  ]);
+
+  const body = createdTripRequest as unknown as Record<string, unknown>;
+  const endedAtMs = new Date(body.endedAt as string).getTime();
+  // endedAt should be very close to "now" — tolerate ~10s of test latency.
+  expect(Math.abs(endedAtMs - submitTime)).toBeLessThan(10_000);
+});

--- a/client/src/components/trip/ManualEntryForm.tsx
+++ b/client/src/components/trip/ManualEntryForm.tsx
@@ -9,12 +9,22 @@ export interface ManualEntryFormProps {
   setManualMinutes: (v: string) => void;
   manualPresetId: string;
   setManualPresetId: (v: string) => void;
+  manualStartedAt: string;
+  setManualStartedAt: (v: string) => void;
   onPresetChange: (value: string) => void;
   tripPresets: TripPreset[];
-  onSubmit: (km: number, durationSec: number) => void;
+  /** startedAtIso is null when the user left the date field empty (= "now"). */
+  onSubmit: (km: number, durationSec: number, startedAtIso: string | null) => void;
   onCancel: () => void;
   isSaving: boolean;
   saveError: string;
+}
+
+/** `YYYY-MM-DDTHH:MM` reflecting the user's local clock — for the `max` attribute on datetime-local. */
+function localNowForInput(): string {
+  const now = new Date();
+  const offsetMs = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 16);
 }
 
 export function ManualEntryForm({
@@ -24,6 +34,8 @@ export function ManualEntryForm({
   setManualMinutes,
   manualPresetId,
   setManualPresetId,
+  manualStartedAt,
+  setManualStartedAt,
   onPresetChange,
   tripPresets,
   onSubmit,
@@ -43,7 +55,9 @@ export function ManualEntryForm({
             const durationSec = manualMinutes
               ? parseInt(manualMinutes) * 60
               : Math.round((km / 15) * 3600); // Fallback: estimate ~15 km/h
-            onSubmit(km, durationSec);
+            // datetime-local is "YYYY-MM-DDTHH:MM" in the user's local TZ; new Date() reads it as local.
+            const startedAtIso = manualStartedAt ? new Date(manualStartedAt).toISOString() : null;
+            onSubmit(km, durationSec, startedAtIso);
           }
         }}
       >
@@ -102,6 +116,21 @@ export function ManualEntryForm({
           placeholder={t("trip.manual.durationPlaceholder")}
           className="mb-4 w-full rounded-lg bg-surface-high p-4 text-2xl font-bold text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
         />
+        <label
+          htmlFor="manual-datetime-input"
+          className="mb-2 block text-xs font-bold uppercase tracking-widest text-text-muted"
+        >
+          {t("trip.manual.dateTimeLabel")}
+        </label>
+        <input
+          id="manual-datetime-input"
+          type="datetime-local"
+          value={manualStartedAt}
+          max={localNowForInput()}
+          onChange={(e) => setManualStartedAt(e.target.value)}
+          className="mb-2 w-full rounded-lg bg-surface-high p-4 text-base font-bold text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+        <p className="mb-4 text-xs text-text-muted">{t("trip.manual.dateTimeHelper")}</p>
         <div className="flex gap-3">
           <button
             type="button"

--- a/client/src/components/trip/ManualEntryForm.tsx
+++ b/client/src/components/trip/ManualEntryForm.tsx
@@ -20,11 +20,36 @@ export interface ManualEntryFormProps {
   saveError: string;
 }
 
-/** `YYYY-MM-DDTHH:MM` reflecting the user's local clock — for the `max` attribute on datetime-local. */
-function localNowForInput(): string {
-  const now = new Date();
-  const offsetMs = now.getTimezoneOffset() * 60_000;
-  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 16);
+/** Mirrors the submit handler's durationSec calculation so render-time bounds stay in sync. */
+export function computeManualDurationSec(manualKm: string, manualMinutes: string): number {
+  if (manualMinutes) {
+    const m = parseInt(manualMinutes);
+    if (Number.isFinite(m) && m > 0) return m * 60;
+  }
+  const km = parseFloat(manualKm);
+  if (Number.isFinite(km) && km > 0) return Math.round((km / 15) * 3600);
+  return 0;
+}
+
+/** Latest valid local startedAt — endedAt = startedAt + durationSec must not exceed `now`. */
+export function maxStartedAtLocal(durationSec: number, now: Date = new Date()): string {
+  const maxStart = new Date(now.getTime() - durationSec * 1000);
+  const offsetMs = maxStart.getTimezoneOffset() * 60_000;
+  return new Date(maxStart.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+/**
+ * Convert the form's local datetime into an ISO startedAt, clamped so `endedAt = startedAt +
+ * durationSec` cannot land in the future (the server rejects any endedAt > now + 60s).
+ */
+export function clampManualStartedAtIso(
+  localValue: string,
+  durationSec: number,
+  now: Date = new Date(),
+): string {
+  const chosenMs = new Date(localValue).getTime();
+  const maxStartMs = now.getTime() - durationSec * 1000;
+  return new Date(Math.min(chosenMs, maxStartMs)).toISOString();
 }
 
 export function ManualEntryForm({
@@ -44,6 +69,7 @@ export function ManualEntryForm({
   saveError,
 }: ManualEntryFormProps) {
   const t = useT();
+  const durationSecPreview = computeManualDurationSec(manualKm, manualMinutes);
   return (
     <div className="min-h-0 overflow-y-auto px-6 pb-4">
       <form
@@ -55,8 +81,9 @@ export function ManualEntryForm({
             const durationSec = manualMinutes
               ? parseInt(manualMinutes) * 60
               : Math.round((km / 15) * 3600); // Fallback: estimate ~15 km/h
-            // datetime-local is "YYYY-MM-DDTHH:MM" in the user's local TZ; new Date() reads it as local.
-            const startedAtIso = manualStartedAt ? new Date(manualStartedAt).toISOString() : null;
+            const startedAtIso = manualStartedAt
+              ? clampManualStartedAtIso(manualStartedAt, durationSec)
+              : null;
             onSubmit(km, durationSec, startedAtIso);
           }
         }}
@@ -126,7 +153,7 @@ export function ManualEntryForm({
           id="manual-datetime-input"
           type="datetime-local"
           value={manualStartedAt}
-          max={localNowForInput()}
+          max={maxStartedAtLocal(durationSecPreview)}
           onChange={(e) => setManualStartedAt(e.target.value)}
           className="mb-2 w-full rounded-lg bg-surface-high p-4 text-base font-bold text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
         />

--- a/client/src/components/trip/__tests__/ManualEntryForm.test.tsx
+++ b/client/src/components/trip/__tests__/ManualEntryForm.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeManualDurationSec,
+  maxStartedAtLocal,
+  clampManualStartedAtIso,
+} from "../ManualEntryForm";
+
+describe("computeManualDurationSec", () => {
+  it("returns minutes * 60 when manualMinutes is provided", () => {
+    expect(computeManualDurationSec("10", "30")).toBe(1800);
+  });
+
+  it("falls back to km / 15 km/h when minutes empty", () => {
+    expect(computeManualDurationSec("15", "")).toBe(3600);
+  });
+
+  it("returns 0 when both fields empty or invalid", () => {
+    expect(computeManualDurationSec("", "")).toBe(0);
+    expect(computeManualDurationSec("abc", "")).toBe(0);
+  });
+
+  it("ignores non-positive minutes and falls back to km", () => {
+    expect(computeManualDurationSec("15", "0")).toBe(3600);
+    expect(computeManualDurationSec("15", "-5")).toBe(3600);
+  });
+});
+
+describe("clampManualStartedAtIso (regression for endedAt-in-future bug)", () => {
+  it("snaps a too-recent startedAt so endedAt does not exceed now", () => {
+    const now = new Date("2026-05-06T12:00:00Z");
+    // User picked 'now' but durationSec is 30min → naive endedAt would be 12:30 (future).
+    const local = "2026-05-06T12:00";
+    const clampedIso = clampManualStartedAtIso(local, 1800, now);
+    const endedAtMs = new Date(clampedIso).getTime() + 1800 * 1000;
+    expect(endedAtMs).toBeLessThanOrEqual(now.getTime());
+  });
+
+  it("preserves a clearly-past startedAt", () => {
+    const now = new Date("2026-05-06T12:00:00Z");
+    const local = "2026-05-04T08:30";
+    const expected = new Date(local).toISOString();
+    expect(clampManualStartedAtIso(local, 1800, now)).toBe(expected);
+  });
+
+  it("clamps when chosen + duration is already in the future", () => {
+    const now = new Date("2026-05-06T12:00:00Z");
+    // Picked 5 min ago, duration 30 min → endedAt would be in the future.
+    const local = new Date(now.getTime() - 5 * 60 * 1000).toISOString().slice(0, 16);
+    const clampedIso = clampManualStartedAtIso(local, 1800, now);
+    expect(new Date(clampedIso).getTime() + 1800 * 1000).toBeLessThanOrEqual(now.getTime());
+  });
+});
+
+describe("maxStartedAtLocal", () => {
+  it("subtracts durationSec from now in the user's local timezone", () => {
+    const now = new Date("2026-05-06T12:00:00Z");
+    const max = maxStartedAtLocal(1800, now);
+    // 30 minutes earlier (UTC), then converted to local "YYYY-MM-DDTHH:MM".
+    const expected = new Date(new Date(now.getTime() - 1800 * 1000).getTime());
+    const offsetMs = expected.getTimezoneOffset() * 60_000;
+    expect(max).toBe(new Date(expected.getTime() - offsetMs).toISOString().slice(0, 16));
+  });
+
+  it("returns now when durationSec is 0", () => {
+    const now = new Date("2026-05-06T12:00:00Z");
+    const max = maxStartedAtLocal(0, now);
+    const offsetMs = now.getTimezoneOffset() * 60_000;
+    expect(max).toBe(new Date(now.getTime() - offsetMs).toISOString().slice(0, 16));
+  });
+});

--- a/client/src/hooks/__tests__/useManualTrip.test.ts
+++ b/client/src/hooks/__tests__/useManualTrip.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useManualTrip } from "../useManualTrip";
+import type { TripPreset } from "@ecoride/shared/types";
+
+const presets: TripPreset[] = [
+  {
+    id: "p1",
+    userId: "u1",
+    label: "Aller bureau",
+    distanceKm: 7.5,
+    durationSec: 1500,
+    gpsPoints: null,
+    sourceTripId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+describe("useManualTrip", () => {
+  it("starts with empty manualStartedAt", () => {
+    const { result } = renderHook(() => useManualTrip(presets));
+    expect(result.current.manualStartedAt).toBe("");
+  });
+
+  it("setManualStartedAt updates state", () => {
+    const { result } = renderHook(() => useManualTrip(presets));
+    act(() => result.current.setManualStartedAt("2026-05-04T08:30"));
+    expect(result.current.manualStartedAt).toBe("2026-05-04T08:30");
+  });
+
+  it("resetManualForm clears manualStartedAt along with km/minutes/preset", () => {
+    const { result } = renderHook(() => useManualTrip(presets));
+    act(() => {
+      result.current.setManualKm("12");
+      result.current.setManualMinutes("45");
+      result.current.setManualStartedAt("2026-05-04T08:30");
+      result.current.setManualPresetId("p1");
+    });
+    act(() => result.current.resetManualForm());
+    expect(result.current.manualKm).toBe("");
+    expect(result.current.manualMinutes).toBe("");
+    expect(result.current.manualStartedAt).toBe("");
+    expect(result.current.manualPresetId).toBe("custom");
+  });
+
+  it("applying a preset does not touch manualStartedAt", () => {
+    const { result } = renderHook(() => useManualTrip(presets));
+    act(() => result.current.setManualStartedAt("2026-05-04T08:30"));
+    act(() => result.current.handleManualPresetChange("p1"));
+    expect(result.current.manualKm).toBe("7.5");
+    expect(result.current.manualStartedAt).toBe("2026-05-04T08:30");
+  });
+});

--- a/client/src/hooks/useManualTrip.ts
+++ b/client/src/hooks/useManualTrip.ts
@@ -8,6 +8,9 @@ export interface UseManualTripResult {
   setManualMinutes: (v: string) => void;
   manualPresetId: string;
   setManualPresetId: (v: string) => void;
+  /** Local datetime in `YYYY-MM-DDTHH:MM` format from <input type="datetime-local">. Empty = "now". */
+  manualStartedAt: string;
+  setManualStartedAt: (v: string) => void;
   applyManualPreset: (preset: Pick<TripPreset, "id" | "distanceKm" | "durationSec">) => void;
   handleManualPresetChange: (value: string) => void;
   resetManualForm: () => void;
@@ -20,6 +23,7 @@ export function useManualTrip(tripPresets: TripPreset[]): UseManualTripResult {
   const [manualKm, setManualKm] = useState("");
   const [manualMinutes, setManualMinutes] = useState("");
   const [manualPresetId, setManualPresetId] = useState<string>("custom");
+  const [manualStartedAt, setManualStartedAt] = useState("");
 
   const applyManualPreset = useCallback(
     (preset: Pick<TripPreset, "id" | "distanceKm" | "durationSec">) => {
@@ -52,6 +56,7 @@ export function useManualTrip(tripPresets: TripPreset[]): UseManualTripResult {
     setManualPresetId("custom");
     setManualKm("");
     setManualMinutes("");
+    setManualStartedAt("");
   }, []);
 
   return {
@@ -61,6 +66,8 @@ export function useManualTrip(tripPresets: TripPreset[]): UseManualTripResult {
     setManualMinutes,
     manualPresetId,
     setManualPresetId,
+    manualStartedAt,
+    setManualStartedAt,
     applyManualPreset,
     handleManualPresetChange,
     resetManualForm,

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -78,6 +78,8 @@ export const en: Record<TranslationKey, string> = {
   "trip.manual.distanceLabel": "Distance (km)",
   "trip.manual.durationLabel": "Duration (minutes)",
   "trip.manual.durationPlaceholder": "Optional",
+  "trip.manual.dateTimeLabel": "Date and time",
+  "trip.manual.dateTimeHelper": "Leave empty to use the current time.",
   "trip.manual.cancel": "Cancel",
   "trip.manual.save": "Save",
 

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -76,6 +76,8 @@ export const fr = {
   "trip.manual.distanceLabel": "Distance (km)",
   "trip.manual.durationLabel": "Durée (minutes)",
   "trip.manual.durationPlaceholder": "Optionnel",
+  "trip.manual.dateTimeLabel": "Date et heure",
+  "trip.manual.dateTimeHelper": "Laissez vide pour utiliser l'heure actuelle.",
   "trip.manual.cancel": "Annuler",
   "trip.manual.save": "Enregistrer",
 

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -196,12 +196,25 @@ export function TripPage() {
 
   // --- Performance: memoize key handlers ---
   const handleSaveTrip = useCallback(
-    (km: number, durationSec: number, session?: TrackingSession | null) => {
+    (
+      km: number,
+      durationSec: number,
+      session?: TrackingSession | null,
+      manualStartedAtIso?: string | null,
+    ) => {
       setSaveError("");
-      const endedAt = session?.endedAt ?? new Date().toISOString();
-      const startedAt =
-        session?.startedAt ??
-        new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
+      let startedAt: string;
+      let endedAt: string;
+      if (session) {
+        endedAt = session.endedAt;
+        startedAt = session.startedAt;
+      } else if (manualStartedAtIso) {
+        startedAt = manualStartedAtIso;
+        endedAt = new Date(new Date(startedAt).getTime() + durationSec * 1000).toISOString();
+      } else {
+        endedAt = new Date().toISOString();
+        startedAt = new Date(new Date(endedAt).getTime() - durationSec * 1000).toISOString();
+      }
       const tripData = {
         distanceKm: Math.round(km * 100) / 100,
         durationSec,
@@ -590,9 +603,13 @@ export function TripPage() {
           setManualMinutes={manual.setManualMinutes}
           manualPresetId={manual.manualPresetId}
           setManualPresetId={manual.setManualPresetId}
+          manualStartedAt={manual.manualStartedAt}
+          setManualStartedAt={manual.setManualStartedAt}
           onPresetChange={manual.handleManualPresetChange}
           tripPresets={tripPresets}
-          onSubmit={(km, durationSec) => handleSaveTrip(km, durationSec)}
+          onSubmit={(km, durationSec, startedAtIso) =>
+            handleSaveTrip(km, durationSec, null, startedAtIso)
+          }
           onCancel={() => {
             manual.resetManualForm();
             setUiState("idle");

--- a/server/src/routes/__tests__/trips-create.test.ts
+++ b/server/src/routes/__tests__/trips-create.test.ts
@@ -148,14 +148,17 @@ describe("POST /trips", () => {
 
   it("returns 201 and logs background failures instead of swallowing them silently", async () => {
     const app = buildApp();
+    // Live trip (just ended): triggers both badge push and leaderboard check.
+    const endedAt = new Date().toISOString();
+    const startedAt = new Date(Date.now() - 600 * 1000).toISOString();
     const res = await app.request("/trips", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         distanceKm: 10,
         durationSec: 600,
-        startedAt: "2026-04-07T10:00:00.000Z",
-        endedAt: "2026-04-07T10:10:00.000Z",
+        startedAt,
+        endedAt,
         gpsPoints: null,
       }),
     });
@@ -206,6 +209,29 @@ describe("POST /trips", () => {
         ],
       }),
     );
+  });
+
+  it("skips the leaderboard overtake check for backdated trips", async () => {
+    const app = buildApp();
+    // 2 days ago — historical entry, must not fire leaderboard notifications.
+    const endedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const startedAt = new Date(new Date(endedAt).getTime() - 600 * 1000).toISOString();
+    const res = await app.request("/trips", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        distanceKm: 10,
+        durationSec: 600,
+        startedAt,
+        endedAt,
+        gpsPoints: null,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.mockCheckLeaderboardChanges).not.toHaveBeenCalled();
   });
 
   it("prices trips from the Annemasse market instead of the trip GPS start point", async () => {

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -143,13 +143,18 @@ tripsRouter.post(
       );
     }
 
-    // Fire-and-forget: check leaderboard overtakes
-    reportBackgroundError(
-      checkLeaderboardChanges(currentUser.id, savings.co2SavedKg),
-      requestLogger,
-      "leaderboard_check_failed",
-      { tripId: trip.id },
-    );
+    // Fire-and-forget: check leaderboard overtakes — only for live trips,
+    // not historical entries (backdated trip = no real-time overtake).
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    const isLiveTrip = Date.now() - new Date(data.endedAt).getTime() < ONE_HOUR_MS;
+    if (isLiveTrip) {
+      reportBackgroundError(
+        checkLeaderboardChanges(currentUser.id, savings.co2SavedKg),
+        requestLogger,
+        "leaderboard_check_failed",
+        { tripId: trip.id },
+      );
+    }
 
     return c.json({ ok: true, data: { trip, newBadges } }, 201);
   },

--- a/server/src/validators/__tests__/trips.test.ts
+++ b/server/src/validators/__tests__/trips.test.ts
@@ -131,6 +131,32 @@ describe("createTripSchema", () => {
       const result = createTripSchema.safeParse(validTrip({ startedAt: "not-a-date" }));
       expect(result.success).toBe(false);
     });
+
+    it("accepts a backdated trip (yesterday)", () => {
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const startedAt = yesterday.toISOString();
+      const endedAt = new Date(yesterday.getTime() + 30 * 60 * 1000).toISOString();
+      const result = createTripSchema.safeParse(validTrip({ startedAt, endedAt }));
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a trip ending in the future", () => {
+      const startedAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const endedAt = new Date(Date.now() + 90 * 60 * 1000).toISOString();
+      const result = createTripSchema.safeParse(validTrip({ startedAt, endedAt }));
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.map((i) => i.path.join("."));
+        expect(paths).toContain("endedAt");
+      }
+    });
+
+    it("tolerates a trip ending up to 60s in the future (clock drift)", () => {
+      const future30s = new Date(Date.now() + 30 * 1000).toISOString();
+      const startedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const result = createTripSchema.safeParse(validTrip({ startedAt, endedAt: future30s }));
+      expect(result.success).toBe(true);
+    });
   });
 
   describe("gpsPoints validation", () => {

--- a/server/src/validators/trips.ts
+++ b/server/src/validators/trips.ts
@@ -17,6 +17,9 @@ const gpsPointSchema = z.object({
   ts: z.preprocess(normalizeLegacyTimestamp, z.number().min(0)),
 });
 
+// Tolerance for clock drift between client and server.
+const FUTURE_TIMESTAMP_TOLERANCE_MS = 60_000;
+
 export const createTripSchema = z
   .object({
     distanceKm: z.number().positive().max(500),
@@ -29,7 +32,14 @@ export const createTripSchema = z
   .refine((data) => new Date(data.startedAt) < new Date(data.endedAt), {
     message: "startedAt must be before endedAt",
     path: ["startedAt"],
-  });
+  })
+  .refine(
+    (data) => new Date(data.endedAt).getTime() <= Date.now() + FUTURE_TIMESTAMP_TOLERANCE_MS,
+    {
+      message: "endedAt cannot be in the future",
+      path: ["endedAt"],
+    },
+  );
 
 export type CreateTripInput = z.infer<typeof createTripSchema>;
 


### PR DESCRIPTION
## Summary

- Adds an optional **datetime-local** field to the manual trip form. When set, it becomes `startedAt`; `endedAt` is derived as `startedAt + durationSec`. Empty = current behaviour ("now").
- Server rejects `endedAt` more than 60s in the future (clock-drift tolerance).
- The leaderboard overtake check is **skipped for backdated trips** (>1h old) so historical entries don't fire misleading "you overtook X" notifications.

Closes #292.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun --cwd server run test` — 290/290 (added: backdated accepts, future rejects, 60s drift tolerance, leaderboard skip)
- [x] `bun --cwd client run test` — 275/275 (added: `useManualTrip` covers `manualStartedAt` state + reset)
- [x] `bun run lint` / `bun run format:check` — clean
- [ ] Playwright e2e (`client/e2e/manual-trip-datetime.spec.ts`) — runs in CI; local browsers not installed
- [ ] Manual sanity check on staging: pick a past datetime, save, trip appears at the chosen date in history

## Notes

- Streak / leaderboard period filters already use `trips.startedAt`, so retroactive entries fall in the right buckets.
- No DB schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)