### PR TITLE
fix: remove unused imports and dead variable flagged by ESLint

### DIFF
--- a/server/src/lib/__tests__/streaks-compute.test.ts
+++ b/server/src/lib/__tests__/streaks-compute.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // DB mock — must be set up BEFORE importing modules that use it

--- a/server/src/lib/__tests__/streaks.test.ts
+++ b/server/src/lib/__tests__/streaks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // Mock db and schema to prevent real Postgres connection on module load
 vi.mock("../../db", () => ({ db: {} }));

--- a/server/src/routes/sentry-webhook.routes.ts
+++ b/server/src/routes/sentry-webhook.routes.ts
@@ -29,7 +29,6 @@ interface SentryIssueEvent {
 }
 
 function verifySentrySignature(body: string, signature: string, secret: string): boolean {
-  const crypto = globalThis.crypto;
   // Sentry uses HMAC-SHA256
   const encoder = new TextEncoder();
   // Use Bun's sync crypto for simplicity


### PR DESCRIPTION
## Summary
- Remove unused `beforeEach` import from `streaks-compute.test.ts`
- Remove unused `beforeAll` import from `streaks.test.ts`
- Remove dead `const crypto = globalThis.crypto` from `sentry-webhook.routes.ts` (superseded by `Bun.CryptoHasher`)

These were flagged as ESLint warnings in CI since PR #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)