### PR TITLE
fix: bump version to 2.47.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecoride",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "private": true,
   "workspaces": [
     "shared",


### PR DESCRIPTION
## Summary
- Manual bump to 2.47.1 — the auto-bump was bypassed on PRs #299 and #301 because they were merged with a merge commit instead of squash, causing the workflow to read "Merge pull request #..." instead of the conventional commit prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)