### PR TITLE
fix(trip): distinguish interrupt save button

### DIFF
--- a/client/src/components/trip/InterruptMenu.tsx
+++ b/client/src/components/trip/InterruptMenu.tsx
@@ -52,7 +52,7 @@ export function InterruptMenu({
             onClick={onStop}
             disabled={!canStop}
             title={canStop ? undefined : t("trip.interrupt.tooShort")}
-            className="flex w-full items-center justify-center gap-3 rounded-2xl bg-surface-high py-4 text-base font-bold text-text active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-3 rounded-2xl border border-primary/40 bg-primary/10 py-4 text-base font-bold text-primary-light active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Square size={18} fill="currentColor" />
             {t("trip.interrupt.save")}

--- a/client/src/components/trip/__tests__/InterruptMenu.test.tsx
+++ b/client/src/components/trip/__tests__/InterruptMenu.test.tsx
@@ -28,4 +28,19 @@ describe("InterruptMenu", () => {
     const btn = screen.getByRole("button", { name: "Enregistrer" }) as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
   });
+
+  it("renders Enregistrer as a positive secondary action distinct from Reprendre", () => {
+    renderWithI18n(<InterruptMenu {...baseProps} canStop={true} />);
+
+    const resume = screen.getByRole("button", { name: "Reprendre" });
+    const save = screen.getByRole("button", { name: "Enregistrer" });
+
+    expect(resume.className).toContain("bg-primary");
+    expect(resume.className).toContain("text-bg");
+    expect(save.className).toContain("border-primary/40");
+    expect(save.className).toContain("bg-primary/10");
+    expect(save.className).toContain("text-primary-light");
+    expect(save.className).not.toContain("bg-primary ");
+    expect(save.className).not.toContain("bg-surface-high");
+  });
 });


### PR DESCRIPTION
## What

- Style the interrupted-trip “Enregistrer” action as a positive secondary button instead of a neutral grey surface.
- Keep “Reprendre” as the primary solid action so the two valid actions remain visually distinct.
- Add a regression test for the visual hierarchy.

Closes #303

## Verification

- `bunx vitest run src/components/trip/__tests__/InterruptMenu.test.tsx`
- `bunx prettier --check src/components/trip/InterruptMenu.tsx src/components/trip/__tests__/InterruptMenu.test.tsx`
- `bunx eslint src/components/trip/InterruptMenu.tsx src/components/trip/__tests__/InterruptMenu.test.tsx`
- `bun run typecheck`