### PR TITLE
chore(quality): fix baseline hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ dev-dist/
 server/drizzle/meta/
 docs/screenshots/.playwright-cli/
 .claude/scheduled_tasks.lock
+
+# Local workspace artifacts
+/entities.json
+/mempalace.yaml
+/quality-gate.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,9 @@ dist
 .claude
 design
 bun.lock
+
+# Local workspace artifacts
+client/test-results
+/entities.json
+/mempalace.yaml
+/quality-gate.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ export default tseslint.config(
       ".claude/",
       "design/",
       "**/*.js",
-      "!eslint.config.js",
+      "!eslint.config.mjs",
     ],
   },
 
@@ -51,7 +51,7 @@ export default tseslint.config(
 
   // Config files — allow require()
   {
-    files: ["*.config.{ts,js}", "client/vite.config.ts", "drizzle.config.ts"],
+    files: ["*.config.{ts,js,mjs}", "client/vite.config.ts", "drizzle.config.ts"],
     rules: {
       "@typescript-eslint/no-require-imports": "off",
     },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "typecheck": "bun run --filter '*' typecheck",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:strict": "eslint . --max-warnings 0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "quality:local": "bun run format:check && bun run lint && bun run typecheck",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
## What

- rename the root ESLint config to `eslint.config.mjs` to remove the Node module-type warning during lint runs
- ignore confirmed local workspace artifacts in Prettier and Git so local quality checks stop failing on non-product files
- add explicit `lint:strict` and `quality:local` scripts for future cleanup work

Closes #305

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`

## Notes

- `bun run lint` still reports the existing 39 code warnings tracked by the cleanup roadmap; this PR only fixes the baseline hygiene/infrastructure issues.