### PR TITLE
perf(client): cut initial bundle cost

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -3,7 +3,7 @@ module.exports = {
     collect: {
       staticDistDir: "./client/dist",
       url: ["http://localhost/"],
-      numberOfRuns: 1,
+      numberOfRuns: 3,
     },
     upload: {
       target: "temporary-public-storage",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,8 +2,10 @@ import { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router";
 import { AppShell } from "@/components/layout/AppShell";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
-import { LoginPage } from "@/pages/LoginPage";
-import { DashboardPage } from "@/pages/DashboardPage";
+const LoginPage = lazy(() => import("@/pages/LoginPage").then((m) => ({ default: m.LoginPage })));
+const DashboardPage = lazy(() =>
+  import("@/pages/DashboardPage").then((m) => ({ default: m.DashboardPage })),
+);
 
 const TripPage = lazy(() => import("@/pages/TripPage").then((m) => ({ default: m.TripPage })));
 const StatsPage = lazy(() => import("@/pages/StatsPage").then((m) => ({ default: m.StatsPage })));

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "maplibre-gl/dist/maplibre-gl.css";
 
 @theme {
   /* Core palette — Luminous Carbon (charcoal + leaf green + white) */

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import * as Sentry from "@sentry/react";
+import { captureClientError } from "@/lib/sentry";
+import { runWhenNoBlockingTripData } from "@/lib/update-guard";
 import { Component } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import { Bike } from "lucide-react";
@@ -49,9 +50,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("ErrorBoundary caught:", error, info.componentStack);
-    Sentry.captureException(error, {
-      extra: { componentStack: info.componentStack },
-    });
+    captureClientError(error, { componentStack: info.componentStack });
 
     // Auto-reload on stale chunk errors (after deploy, old JS files are gone)
     const msg = error.message || "";
@@ -59,9 +58,12 @@ export class ErrorBoundary extends Component<Props, State> {
       msg.includes("not a valid JavaScript MIME type") ||
       msg.includes("Failed to fetch dynamically imported module") ||
       msg.includes("Loading chunk") ||
-      msg.includes("Loading CSS chunk")
+      msg.includes("Loading CSS chunk") ||
+      msg.includes("Unable to preload CSS")
     ) {
-      window.location.reload();
+      runWhenNoBlockingTripData(() => {
+        window.location.reload();
+      });
     }
   }
 

--- a/client/src/components/TripMiniMap.tsx
+++ b/client/src/components/TripMiniMap.tsx
@@ -1,3 +1,4 @@
+import "maplibre-gl/dist/maplibre-gl.css";
 import { useState, useMemo, useEffect, useRef } from "react";
 import Map, { Source, Layer, useMap } from "react-map-gl/maplibre";
 import type { LayerProps } from "react-map-gl/maplibre";

--- a/client/src/lib/__tests__/update-guard.test.ts
+++ b/client/src/lib/__tests__/update-guard.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/stopped-session", () => ({
   hasStoppedSession: () => hasStoppedSessionMock(),
 }));
 
-import { hasBlockingTripDataForUpdate } from "../update-guard";
+import { hasBlockingTripDataForUpdate, runWhenNoBlockingTripData } from "../update-guard";
 
 const localStore = new Map<string, string>();
 const sessionStore = new Map<string, string>();
@@ -67,5 +67,18 @@ describe("hasBlockingTripDataForUpdate", () => {
 
   it("returns false when no trip data needs protection", () => {
     expect(hasBlockingTripDataForUpdate()).toBe(false);
+  });
+
+  it("skips automatic actions when trip data must be protected", () => {
+    const action = vi.fn();
+    sessionStorage.setItem("ecoride-trip-session", "2026-04-09T10:00:00.000Z");
+    expect(runWhenNoBlockingTripData(action)).toBe(false);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("runs automatic actions when no trip data is at risk", () => {
+    const action = vi.fn();
+    expect(runWhenNoBlockingTripData(action)).toBe(true);
+    expect(action).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/lib/sentry.ts
+++ b/client/src/lib/sentry.ts
@@ -1,0 +1,77 @@
+import type * as SentryModule from "@sentry/react";
+
+type BreadcrumbEvent = {
+  breadcrumbs?: Array<{
+    data?: Record<string, unknown> | null;
+  }>;
+};
+
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN || "";
+const sentryEnabled = sentryDsn.length > 0;
+
+let sentryModulePromise: Promise<typeof SentryModule> | null = null;
+let sentryInitPromise: Promise<void> | null = null;
+
+async function loadSentry() {
+  if (!sentryEnabled) return null;
+  try {
+    sentryModulePromise ??= import("@sentry/react").catch((error) => {
+      sentryModulePromise = null;
+      throw error;
+    });
+    return await sentryModulePromise;
+  } catch {
+    return null;
+  }
+}
+
+export function redactBreadcrumbEmails<T extends BreadcrumbEvent>(event: T): T {
+  if (event.breadcrumbs) {
+    for (const breadcrumb of event.breadcrumbs) {
+      if (breadcrumb.data && "email" in breadcrumb.data) {
+        breadcrumb.data.email = "[redacted]";
+      }
+    }
+  }
+  return event;
+}
+
+export function initSentry() {
+  if (!sentryEnabled) return Promise.resolve();
+  if (sentryInitPromise) return sentryInitPromise;
+
+  sentryInitPromise = (async () => {
+    const Sentry = await loadSentry();
+    if (!Sentry) return;
+
+    Sentry.init({
+      dsn: sentryDsn,
+      environment: import.meta.env.MODE,
+      release: __APP_VERSION__,
+      enabled: true,
+      sendDefaultPii: true,
+      integrations: [Sentry.replayIntegration()],
+      tracesSampleRate: 0.1,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+      beforeSend: redactBreadcrumbEmails,
+    });
+  })().catch(() => {
+    sentryInitPromise = null;
+  });
+
+  return sentryInitPromise;
+}
+
+export function captureClientError(error: unknown, extra?: Record<string, unknown>) {
+  void loadSentry().then((Sentry) => {
+    if (!Sentry) return;
+    Sentry.captureException(error, extra ? { extra } : undefined);
+  });
+}
+
+export function bindUnhandledRejectionListener() {
+  window.addEventListener("unhandledrejection", (event) => {
+    captureClientError(event.reason);
+  });
+}

--- a/client/src/lib/update-guard.ts
+++ b/client/src/lib/update-guard.ts
@@ -12,3 +12,9 @@ export function hasBlockingTripDataForUpdate(): boolean {
     hasPendingTrips()
   );
 }
+
+export function runWhenNoBlockingTripData(action: () => void): boolean {
+  if (hasBlockingTripDataForUpdate()) return false;
+  action();
+  return true;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
@@ -8,39 +7,23 @@ import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persist
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { I18nProvider } from "./i18n/provider";
 import { App } from "./App";
-import { hasBlockingTripDataForUpdate } from "@/lib/update-guard";
+import { bindUnhandledRejectionListener, initSentry } from "@/lib/sentry";
+import { hasBlockingTripDataForUpdate, runWhenNoBlockingTripData } from "@/lib/update-guard";
 import { MAP_TILE_CACHE_NAME } from "@/lib/tile-cache";
 import "./app.css";
 
-// ---------------------------------------------------------------------------
-// Sentry — client-side error tracking
-// Disabled by default; set VITE_SENTRY_DSN to enable.
-// ---------------------------------------------------------------------------
-Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN || "",
-  environment: import.meta.env.MODE,
-  release: __APP_VERSION__,
-  enabled: !!import.meta.env.VITE_SENTRY_DSN,
-  sendDefaultPii: true,
-  integrations: [Sentry.replayIntegration()],
-  tracesSampleRate: 0.1,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  beforeSend(event: Sentry.ErrorEvent) {
-    if (event.breadcrumbs) {
-      for (const b of event.breadcrumbs) {
-        if (b.data && "email" in b.data) {
-          (b.data as Record<string, unknown>).email = "[redacted]";
-        }
-      }
-    }
-    return event;
-  },
-});
+// Sentry — client-side error tracking is loaded lazily when a DSN is configured.
+
+void initSentry();
 
 // Capture unhandled promise rejections
-window.addEventListener("unhandledrejection", (event) => {
-  Sentry.captureException(event.reason);
+bindUnhandledRejectionListener();
+
+window.addEventListener("vite:preloadError", (event) => {
+  event.preventDefault();
+  runWhenNoBlockingTripData(() => {
+    window.location.reload();
+  });
 });
 
 const CACHE_VERSION_KEY = "ecoride-version";

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -20,7 +20,7 @@ import { getPendingTrips, getRejectedTrips } from "@/lib/offline-queue";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useT } from "@/i18n/provider";
 import type { TranslationKey } from "@/i18n/locales/fr";
-import appLogo from "/pwa-192x192.png?url";
+const appLogo = "/favicon.svg";
 
 interface Milestone {
   value: number;

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { signIn, signUp } from "@/lib/auth";
 import { useT } from "@/i18n/provider";
-import appLogo from "/pwa-192x192.png?url";
+const appLogo = "/favicon.svg";
 
 export function LoginPage() {
   const t = useT();

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,8 +1,9 @@
+import "maplibre-gl/dist/maplibre-gl.css";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { Play, Keyboard, AlertTriangle, MapPin, X, LocateFixed } from "lucide-react";
 import Map, { Marker, Source, Layer } from "react-map-gl/maplibre";
 import type { MapRef, LayerProps } from "react-map-gl/maplibre";
-// maplibre-gl.css imported in app.css to avoid orphan CSS chunks
+// Imported here so MapLibre styles stay off the initial app shell bundle.
 import { useCreateTrip, useProfile, useTripPresets } from "@/hooks/queries";
 import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
 import { useAppGpsTracking } from "@/hooks/useGpsTracking";

--- a/client/src/sentry.test.ts
+++ b/client/src/sentry.test.ts
@@ -1,51 +1,24 @@
 import { describe, it, expect } from "vitest";
-import * as Sentry from "@sentry/react";
+import { captureClientError, initSentry, redactBreadcrumbEmails } from "@/lib/sentry";
 
 describe("Sentry integration", () => {
-  it("Sentry.init does not throw when DSN is empty", () => {
+  it("initSentry resolves when DSN is not configured", async () => {
+    await expect(initSentry()).resolves.toBeUndefined();
+  });
+
+  it("captureClientError does not throw when Sentry is disabled", () => {
     expect(() => {
-      Sentry.init({
-        dsn: "",
-        enabled: false,
-      });
+      captureClientError(new Error("test error"));
     }).not.toThrow();
   });
 
-  it("Sentry.init does not throw when DSN is undefined", () => {
-    expect(() => {
-      Sentry.init({
-        dsn: undefined,
-        enabled: false,
-      });
-    }).not.toThrow();
-  });
-
-  it("Sentry.captureException does not throw when disabled", () => {
-    Sentry.init({ dsn: "", enabled: false });
-    expect(() => {
-      Sentry.captureException(new Error("test error"));
-    }).not.toThrow();
-  });
-
-  it("beforeSend strips email PII from breadcrumbs", () => {
-    // Test the beforeSend logic that we use in main.tsx
-    const beforeSend = (event: Sentry.ErrorEvent) => {
-      if (event.breadcrumbs) {
-        event.breadcrumbs = event.breadcrumbs.map((b) => {
-          if (b.data?.email) b.data.email = "[redacted]";
-          return b;
-        });
-      }
-      return event;
-    };
-
-    const event = beforeSend({
-      type: undefined,
+  it("redactBreadcrumbEmails strips email PII from breadcrumbs", () => {
+    const event = redactBreadcrumbEmails({
       breadcrumbs: [
         { data: { email: "user@example.com", url: "/api/trips" } },
         { data: { url: "/api/health" } },
       ],
-    } as unknown as Sentry.ErrorEvent);
+    });
 
     expect(event.breadcrumbs?.[0]?.data?.email).toBe("[redacted]");
     expect(event.breadcrumbs?.[0]?.data?.url).toBe("/api/trips");


### PR DESCRIPTION
## What

- lazy-load `LoginPage` and `DashboardPage` so they stop inflating the initial route bundle
- move MapLibre CSS off the global stylesheet and load it only from map entrypoints (`TripPage` and `TripMiniMap`)
- replace the UI logo imports on login/dashboard with the SVG asset instead of the PWA PNG
- lazy-load Sentry behind `VITE_SENTRY_DSN` and guard failed telemetry chunk loads
- route preload/chunk reloads through the existing trip-data safety guard so an auto-reload cannot wipe an in-progress ride
- increase Lighthouse collection from 1 run to 3 runs to reduce CI score noise

## Verification

- `bunx vitest run src/pages/__tests__/DashboardPage.i18n.test.tsx src/pages/__tests__/DashboardPage.announcement.test.tsx src/pages/__tests__/LoginPage.i18n.test.tsx src/lib/__tests__/update-guard.test.ts src/sentry.test.ts`
- `bunx eslint --max-warnings 0 src/App.tsx src/main.tsx src/components/ErrorBoundary.tsx src/components/TripMiniMap.tsx src/lib/sentry.ts src/lib/update-guard.ts src/lib/__tests__/update-guard.test.ts src/pages/DashboardPage.tsx src/pages/LoginPage.tsx src/pages/TripPage.tsx`
- `bun run typecheck`
- `bun run build`
- `bunx playwright test e2e/navigation.spec.ts`
- `npx --yes @lhci/cli autorun`

## Measured impact

Local production build/lighthouse after the change:

- main CSS critical bundle: `114.84 kB raw / 18.31 kB gzip` → `44.99 kB raw / 8.27 kB gzip`
- initial app JS chunk: `646.75 kB raw / 202.70 kB gzip` → split into `406.65 kB raw / 126.00 kB gzip` + a lazy `458.20 kB raw / 151.11 kB gzip` chunk
- Lighthouse (3 runs, root config): stable `Performance 98 / Accessibility 100 / Best Practices 96 / SEO 91`
- Lighthouse unused JS estimate on the landing page: `118 KiB` → `54 KiB`

## Notes

- I did not add manual chunk rules in Vite for this pass because the route/CSS/Sentry splits already delivered a measurable improvement with less config risk.
- The build still reports large route/vendor chunks (`maplibre-gl`, `CartesianChart`), but they are no longer on the initial critical path for login/dashboard.