### PR TITLE
refactor(client): split trip and profile hotspots

### DIFF
--- a/client/src/components/profile/ProfileActionsSection.tsx
+++ b/client/src/components/profile/ProfileActionsSection.tsx
@@ -1,0 +1,87 @@
+import { Download, LogOut, Shield, Trash2, Upload, ChevronRight } from "lucide-react";
+import { Link } from "react-router";
+import { useT } from "@/i18n/provider";
+
+interface ProfileActionsSectionProps {
+  isAdmin: boolean;
+  onLogout: () => void;
+  onExport: () => void;
+  onImportClick: () => void;
+  onDeleteAccount: () => void;
+  exportPending: boolean;
+  importPending: boolean;
+  deletePending: boolean;
+}
+
+export function ProfileActionsSection({
+  isAdmin,
+  onLogout,
+  onExport,
+  onImportClick,
+  onDeleteAccount,
+  exportPending,
+  importPending,
+  deletePending,
+}: ProfileActionsSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      {isAdmin && (
+        <Link
+          to="/admin"
+          className="flex w-full items-center justify-between rounded-lg bg-surface-high p-4 transition-colors hover:bg-surface-low"
+        >
+          <div className="flex items-center gap-4">
+            <Shield size={20} className="text-primary-light" />
+            <span className="text-sm font-medium">{t("profile.admin")}</span>
+          </div>
+          <ChevronRight size={18} className="text-text-dim" />
+        </Link>
+      )}
+
+      <button
+        onClick={onLogout}
+        className="w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-danger active:scale-95"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <LogOut size={16} />
+          {t("profile.logout")}
+        </div>
+      </button>
+
+      <button
+        onClick={onExport}
+        disabled={exportPending}
+        className="w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <Download size={16} />
+          {exportPending ? t("profile.export.exporting") : t("profile.export.label")}
+        </div>
+      </button>
+
+      <button
+        onClick={onImportClick}
+        disabled={importPending}
+        className="w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <Upload size={16} />
+          {importPending ? t("profile.import.importing") : t("profile.import.label")}
+        </div>
+      </button>
+
+      <button
+        onClick={onDeleteAccount}
+        disabled={deletePending}
+        className="w-full rounded-lg border border-red-500/30 bg-red-500/10 py-4 text-xs font-bold uppercase tracking-widest text-red-400 active:scale-95 disabled:opacity-50"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <Trash2 size={16} />
+          {deletePending ? t("profile.delete.deleting") : t("profile.delete.label")}
+        </div>
+      </button>
+    </section>
+  );
+}

--- a/client/src/components/profile/ProfileBadgesSection.tsx
+++ b/client/src/components/profile/ProfileBadgesSection.tsx
@@ -1,0 +1,45 @@
+import { BADGES } from "@ecoride/shared/types";
+import type { Achievement, BadgeId } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+const allBadgeIds = Object.keys(BADGES) as BadgeId[];
+
+interface ProfileBadgesSectionProps {
+  achievements: Achievement[];
+}
+
+export function ProfileBadgesSection({ achievements }: ProfileBadgesSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-end justify-between">
+        <h2 className="text-lg font-bold tracking-tight">{t("profile.badges.title")}</h2>
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {allBadgeIds.map((id) => {
+          const badge = BADGES[id];
+          const unlocked = achievements.some((achievement) => achievement.badgeId === id);
+
+          return (
+            <div
+              key={id}
+              className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
+            >
+              <div
+                className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
+                  unlocked ? "bg-primary/10 text-primary-light" : "bg-surface-high text-text-dim"
+                }`}
+              >
+                <span className="text-2xl">{badge.icon}</span>
+              </div>
+              <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
+                {badge.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/profile/ProfileFeedbackCard.tsx
+++ b/client/src/components/profile/ProfileFeedbackCard.tsx
@@ -1,0 +1,114 @@
+import { Check, ChevronDown, ChevronRight, MessageSquarePlus } from "lucide-react";
+import { useT } from "@/i18n/provider";
+
+interface ProfileFeedbackCardProps {
+  open: boolean;
+  feedbackType: "bug" | "feature";
+  feedbackTitle: string;
+  feedbackDescription: string;
+  feedbackSent: boolean;
+  pending: boolean;
+  isError: boolean;
+  onToggle: () => void;
+  onFeedbackTypeChange: (value: "bug" | "feature") => void;
+  onFeedbackTitleChange: (value: string) => void;
+  onFeedbackDescriptionChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+}
+
+export function ProfileFeedbackCard({
+  open,
+  feedbackType,
+  feedbackTitle,
+  feedbackDescription,
+  feedbackSent,
+  pending,
+  isError,
+  onToggle,
+  onFeedbackTypeChange,
+  onFeedbackTitleChange,
+  onFeedbackDescriptionChange,
+  onSubmit,
+}: ProfileFeedbackCardProps) {
+  const t = useT();
+
+  return (
+    <div className="overflow-hidden rounded-lg bg-surface-low">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
+      >
+        <div className="flex items-center gap-4">
+          <MessageSquarePlus size={20} className="text-text-muted" />
+          <span className="text-sm font-medium">{t("profile.feedback.title")}</span>
+        </div>
+        {open ? (
+          <ChevronDown size={18} className="text-text-dim" />
+        ) : (
+          <ChevronRight size={18} className="text-text-dim" />
+        )}
+      </button>
+      {open && (
+        <div className="space-y-3 px-4 pb-4">
+          {feedbackSent ? (
+            <div className="flex items-center gap-3 rounded-lg bg-primary/10 p-4">
+              <Check size={18} className="text-primary-light" />
+              <span className="text-sm font-medium text-primary-light">
+                {t("profile.feedback.thanks")}
+              </span>
+            </div>
+          ) : (
+            <form onSubmit={onSubmit} className="space-y-3">
+              <div className="flex gap-2">
+                {(["bug", "feature"] as const).map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => onFeedbackTypeChange(type)}
+                    className={`flex-1 rounded-lg py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
+                      feedbackType === type
+                        ? "bg-primary/20 text-primary-light"
+                        : "bg-surface-high text-text-muted"
+                    }`}
+                  >
+                    {type === "bug" ? t("profile.feedback.bug") : t("profile.feedback.feature")}
+                  </button>
+                ))}
+              </div>
+              <input
+                type="text"
+                value={feedbackTitle}
+                onChange={(event) => onFeedbackTitleChange(event.target.value)}
+                placeholder={t("profile.feedback.titlePlaceholder")}
+                required
+                minLength={3}
+                maxLength={200}
+                className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+              />
+              <textarea
+                value={feedbackDescription}
+                onChange={(event) => onFeedbackDescriptionChange(event.target.value)}
+                placeholder={t("profile.feedback.descPlaceholder")}
+                required
+                minLength={10}
+                maxLength={2000}
+                rows={4}
+                className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
+              />
+              <button
+                type="submit"
+                disabled={pending}
+                className="w-full rounded-lg bg-primary py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
+              >
+                {pending ? t("profile.feedback.sending") : t("profile.feedback.send")}
+              </button>
+              {isError && (
+                <p className="text-center text-xs text-danger">{t("profile.feedback.error")}</p>
+              )}
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/profile/ProfileSettingsCard.tsx
+++ b/client/src/components/profile/ProfileSettingsCard.tsx
@@ -1,0 +1,225 @@
+import {
+  Bell,
+  BellOff,
+  Bike,
+  Bluetooth,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  User,
+} from "lucide-react";
+import { MapCacheRow } from "@/components/MapCacheRow";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { useT } from "@/i18n/provider";
+
+interface ProfileSettingsCardProps {
+  user: {
+    name: string;
+    email: string;
+    createdAt: string;
+    timezone: string | null;
+    super73Enabled: boolean;
+  };
+  showPersonalInfo: boolean;
+  push: {
+    status: "loading" | "subscribed" | "unsubscribed" | "unsupported" | "denied";
+    busy: boolean;
+    toggle: () => void | Promise<void>;
+  };
+  bleSupported: boolean;
+  profileUpdatePending: boolean;
+  onTogglePersonalInfo: () => void;
+  onVehicleClick: () => void;
+  onSuper73RowClick: () => void;
+  onSuper73ToggleClick: () => Promise<void>;
+  formatMemberSince: (createdAt: string, timezone: string | null) => string;
+}
+
+export function ProfileSettingsCard({
+  user,
+  showPersonalInfo,
+  push,
+  bleSupported,
+  profileUpdatePending,
+  onTogglePersonalInfo,
+  onVehicleClick,
+  onSuper73RowClick,
+  onSuper73ToggleClick,
+  formatMemberSince,
+}: ProfileSettingsCardProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-2">
+      <h2 className="mb-4 text-lg font-bold tracking-tight">{t("profile.settings.title")}</h2>
+      <div className="overflow-hidden rounded-lg bg-surface-low">
+        <button
+          onClick={onTogglePersonalInfo}
+          className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
+        >
+          <div className="flex items-center gap-4">
+            <User size={20} className="text-text-muted" />
+            <span className="text-sm font-medium">{t("profile.settings.personalInfo")}</span>
+          </div>
+          {showPersonalInfo ? (
+            <ChevronDown size={18} className="text-text-dim" />
+          ) : (
+            <ChevronRight size={18} className="text-text-dim" />
+          )}
+        </button>
+        {showPersonalInfo && (
+          <div className="space-y-3 px-4 pb-4">
+            <div>
+              <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+                {t("profile.settings.name")}
+              </label>
+              <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
+                {user.name}
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+                {t("profile.settings.email")}
+              </label>
+              <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
+                {user.email}
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+                {t("profile.settings.memberSince")}
+              </label>
+              <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
+                {formatMemberSince(user.createdAt, user.timezone)}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="mx-4 h-px bg-white/5" />
+
+        <button
+          onClick={onVehicleClick}
+          className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
+        >
+          <div className="flex items-center gap-4">
+            <Bike size={20} className="text-text-muted" />
+            <span className="text-sm font-medium">{t("profile.settings.myVehicle")}</span>
+          </div>
+          <ChevronRight size={18} className="text-text-dim" />
+        </button>
+
+        <div className="mx-4 h-px bg-white/5" />
+
+        <div className="flex w-full items-center justify-between p-4">
+          <div className="flex items-center gap-4">
+            {push.status === "subscribed" ? (
+              <Bell size={20} className="text-primary-light" />
+            ) : (
+              <BellOff size={20} className="text-text-muted" />
+            )}
+            <div className="flex flex-col items-start">
+              <span className="text-sm font-medium">{t("profile.settings.notifications")}</span>
+              {push.status === "unsupported" && (
+                <span className="text-xs text-text-dim">
+                  {t("profile.settings.notificationsUnsupported")}
+                </span>
+              )}
+              {push.status === "denied" && (
+                <span className="text-xs text-text-dim">
+                  {t("profile.settings.notificationsDenied")}
+                </span>
+              )}
+              {push.status === "subscribed" && (
+                <span className="text-xs text-primary/70">
+                  {t("profile.settings.notificationsEnabled")}
+                </span>
+              )}
+            </div>
+          </div>
+          {(push.status === "subscribed" || push.status === "unsubscribed") && (
+            <button
+              onClick={push.toggle}
+              disabled={push.busy}
+              aria-label={
+                push.status === "subscribed"
+                  ? t("profile.settings.notificationsDisableAria")
+                  : t("profile.settings.notificationsEnableAria")
+              }
+              className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
+                push.status === "subscribed" ? "bg-primary" : "bg-surface-high"
+              }`}
+            >
+              {push.busy ? (
+                <Loader2 size={14} className="mx-auto animate-spin text-text-dim" />
+              ) : (
+                <span
+                  className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
+                    push.status === "subscribed" ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              )}
+            </button>
+          )}
+        </div>
+
+        <div className="mx-4 h-px bg-white/5" />
+
+        {user.super73Enabled && (
+          <div className="flex w-full items-center justify-between p-4">
+            <button
+              type="button"
+              onClick={onSuper73RowClick}
+              disabled={!user.super73Enabled}
+              className="flex min-w-0 items-center gap-4 text-left"
+            >
+              <Bluetooth
+                size={20}
+                className={user.super73Enabled ? "text-primary-light" : "text-text-muted"}
+              />
+              <div className="flex flex-col items-start">
+                <span className="text-sm font-medium">
+                  {t("profile.settings.super73Connected")}
+                </span>
+                {!bleSupported && (
+                  <span className="text-xs text-text-dim">
+                    {t("profile.settings.super73Unsupported")}
+                  </span>
+                )}
+                <span className="text-xs text-primary/70">
+                  {t("profile.settings.super73Enabled")}
+                </span>
+              </div>
+              <ChevronRight size={18} className="shrink-0 text-text-dim" />
+            </button>
+            <button
+              onClick={() => {
+                void onSuper73ToggleClick();
+              }}
+              disabled={profileUpdatePending}
+              aria-label={
+                user.super73Enabled
+                  ? t("profile.settings.super73DisableAria")
+                  : t("profile.settings.super73EnableAria")
+              }
+              className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
+                user.super73Enabled ? "bg-primary" : "bg-surface-high"
+              }`}
+            >
+              <span
+                className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
+                  user.super73Enabled ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+        )}
+
+        <div className="mx-4 h-px bg-white/5" />
+        <MapCacheRow />
+        <div className="mx-4 h-px bg-white/5" />
+        <LanguageSwitcher />
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/profile/ProfileSummarySection.tsx
+++ b/client/src/components/profile/ProfileSummarySection.tsx
@@ -1,0 +1,145 @@
+import { Droplets } from "lucide-react";
+import { useT } from "@/i18n/provider";
+
+interface ProfileSummarySectionProps {
+  user: {
+    name: string;
+    image: string | null;
+  };
+  stats: {
+    totalCo2SavedKg: number;
+    totalDistanceKm: number;
+    tripCount: number;
+    totalFuelSavedL: number;
+    totalMoneySavedEur: number;
+  };
+  fuelPrice:
+    | {
+        priceEur: number;
+        fuelType: string;
+        stationName?: string | null;
+      }
+    | null
+    | undefined;
+  fuelPriceLoading: boolean;
+}
+
+export function ProfileSummarySection({
+  user,
+  stats,
+  fuelPrice,
+  fuelPriceLoading,
+}: ProfileSummarySectionProps) {
+  const t = useT();
+
+  return (
+    <>
+      <section className="flex flex-col items-center space-y-4 text-center">
+        <div className="relative">
+          <div className="rounded-full bg-gradient-to-tr from-primary to-primary-dark p-1">
+            <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border-2 border-surface bg-surface">
+              {user.image ? (
+                <img src={user.image} alt={user.name} className="h-full w-full object-cover" />
+              ) : (
+                <span className="text-4xl font-bold text-primary-light">{user.name.charAt(0)}</span>
+              )}
+            </div>
+          </div>
+        </div>
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight text-text">{user.name}</h2>
+          <div className="mt-1 inline-flex items-center rounded-full bg-primary/15 px-3 py-1 text-xs font-bold uppercase tracking-widest text-primary-light">
+            {t("profile.ecoRiderBadge")}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-2 gap-4">
+        <div className="group relative col-span-2 overflow-hidden rounded-lg bg-surface-low p-6">
+          <p className="text-xs font-bold uppercase tracking-widest text-primary/70">
+            {t("profile.stats.totalCo2")}
+          </p>
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="text-5xl font-extrabold tracking-tighter text-text">
+              {stats.totalCo2SavedKg.toFixed(1)}
+            </span>
+            <span className="text-xl font-bold uppercase text-text-dim">
+              {t("profile.stats.kgUnit")}
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg bg-surface-low p-5">
+          <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
+            {t("profile.stats.distance")}
+          </p>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold text-text">
+              {Math.round(stats.totalDistanceKm)}
+            </span>
+            <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
+              {t("profile.stats.kmUnit")}
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg bg-surface-low p-5">
+          <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
+            {t("profile.stats.trips")}
+          </p>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold text-text">{stats.tripCount}</span>
+          </div>
+        </div>
+        <div className="rounded-lg bg-surface-low p-5">
+          <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
+            {t("profile.stats.fuel")}
+          </p>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold text-text">{stats.totalFuelSavedL.toFixed(1)}</span>
+            <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
+              {t("profile.stats.litersUnit")}
+            </span>
+          </div>
+        </div>
+        <div className="rounded-lg bg-surface-low p-5">
+          <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
+            {t("profile.stats.saved")}
+          </p>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold text-text">
+              {stats.totalMoneySavedEur.toFixed(2)}
+            </span>
+            <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
+              {t("profile.stats.eurUnit")}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex items-center gap-4 rounded-lg bg-surface-low px-5 py-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+          <Droplets size={20} className="text-primary-light" />
+        </div>
+        {fuelPriceLoading ? (
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-24 animate-pulse rounded bg-surface-high" />
+            <div className="h-3 w-32 animate-pulse rounded bg-surface-high" />
+          </div>
+        ) : fuelPrice ? (
+          <div className="flex-1">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-lg font-bold text-text">
+                {fuelPrice.priceEur.toFixed(2)} &euro;/L
+              </span>
+              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
+                {fuelPrice.fuelType.toUpperCase()}
+              </span>
+            </div>
+            <p className="text-xs text-text-muted">
+              {fuelPrice.stationName ? fuelPrice.stationName : t("profile.fuel.nationalAverage")}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/client/src/components/profile/ProfileTripPresetsSection.tsx
+++ b/client/src/components/profile/ProfileTripPresetsSection.tsx
@@ -1,0 +1,58 @@
+import type { TripPreset } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+interface ProfileTripPresetsSectionProps {
+  tripPresets: TripPreset[];
+  deletePending: boolean;
+  onDelete: (tripPresetId: string, label: string) => void;
+}
+
+export function ProfileTripPresetsSection({
+  tripPresets,
+  deletePending,
+  onDelete,
+}: ProfileTripPresetsSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-end justify-between">
+        <div>
+          <h2 className="text-lg font-bold tracking-tight">{t("profile.presets.title")}</h2>
+          <p className="mt-1 text-sm text-text-muted">{t("profile.presets.subtitle")}</p>
+        </div>
+      </div>
+      <div className="space-y-3">
+        {tripPresets.length === 0 ? (
+          <div className="rounded-lg bg-surface-low p-5 text-sm text-text-muted">
+            {t("profile.presets.empty")}
+          </div>
+        ) : (
+          tripPresets.map((tripPreset) => (
+            <div
+              key={tripPreset.id}
+              className="flex items-center justify-between gap-4 rounded-lg bg-surface-low p-5"
+            >
+              <div>
+                <p className="text-sm font-bold text-text">{tripPreset.label}</p>
+                <p className="mt-1 text-xs text-text-muted">
+                  {tripPreset.distanceKm.toFixed(1)} {t("profile.stats.kmUnit")}
+                  {tripPreset.durationSec != null
+                    ? ` · ${Math.round(tripPreset.durationSec / 60)} min`
+                    : ` · ${t("profile.presets.customDuration")}`}
+                </p>
+              </div>
+              <button
+                onClick={() => onDelete(tripPreset.id, tripPreset.label)}
+                disabled={deletePending}
+                className="rounded-lg bg-danger/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-danger active:scale-95 disabled:opacity-50"
+              >
+                {t("profile.presets.delete")}
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/profile/ProfileVehicleEditorCard.tsx
+++ b/client/src/components/profile/ProfileVehicleEditorCard.tsx
@@ -1,0 +1,97 @@
+import type { FuelType } from "@ecoride/shared/types";
+import { Check } from "lucide-react";
+import { FUEL_TYPES } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+interface ProfileVehicleEditorCardProps {
+  open: boolean;
+  vehicleModel: string;
+  fuelType: FuelType;
+  consumption: string;
+  saveSuccess: boolean;
+  saving: boolean;
+  onVehicleModelChange: (value: string) => void;
+  onFuelTypeChange: (value: FuelType) => void;
+  onConsumptionChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function ProfileVehicleEditorCard({
+  open,
+  vehicleModel,
+  fuelType,
+  consumption,
+  saveSuccess,
+  saving,
+  onVehicleModelChange,
+  onFuelTypeChange,
+  onConsumptionChange,
+  onSave,
+}: ProfileVehicleEditorCardProps) {
+  const t = useT();
+
+  if (!open) return null;
+
+  return (
+    <section className="space-y-4 rounded-xl bg-surface-low p-6">
+      <h2 className="text-lg font-bold tracking-tight">{t("profile.vehicle.title")}</h2>
+      <div className="space-y-3">
+        <div>
+          <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+            {t("profile.vehicle.model")}
+          </label>
+          <input
+            type="text"
+            value={vehicleModel}
+            onChange={(event) => onVehicleModelChange(event.target.value)}
+            className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+            {t("profile.vehicle.fuel")}
+          </label>
+          <select
+            value={fuelType}
+            onChange={(event) => onFuelTypeChange(event.target.value as FuelType)}
+            className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+          >
+            {FUEL_TYPES.map((fuel) => (
+              <option key={fuel} value={fuel}>
+                {fuel.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
+            {t("profile.vehicle.consumption")}
+          </label>
+          <input
+            type="number"
+            value={consumption}
+            onChange={(event) => onConsumptionChange(event.target.value)}
+            className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+      </div>
+      <button
+        onClick={onSave}
+        disabled={saving || saveSuccess}
+        className={`w-full rounded-xl py-3 text-sm font-black uppercase tracking-widest active:scale-95 disabled:opacity-50 ${
+          saveSuccess ? "bg-green-600 text-white" : "bg-primary text-bg"
+        }`}
+      >
+        {saveSuccess ? (
+          <span className="flex items-center justify-center gap-2">
+            <Check size={16} /> {t("profile.vehicle.saved")}
+          </span>
+        ) : saving ? (
+          t("profile.vehicle.saving")
+        ) : (
+          t("profile.vehicle.save")
+        )}
+      </button>
+    </section>
+  );
+}

--- a/client/src/components/trip/TripIdleActions.tsx
+++ b/client/src/components/trip/TripIdleActions.tsx
@@ -1,0 +1,77 @@
+import { Keyboard, MapPin, Play, X } from "lucide-react";
+import { useT } from "@/i18n/provider";
+
+interface TripIdleActionsProps {
+  isSaving: boolean;
+  destination: { label: string } | null;
+  destinationLoading: boolean;
+  onStart: () => void;
+  onOpenDestinationSearch: () => void;
+  onClearDestination: () => void;
+  onOpenManual: () => void;
+}
+
+export function TripIdleActions({
+  isSaving,
+  destination,
+  destinationLoading,
+  onStart,
+  onOpenDestinationSearch,
+  onClearDestination,
+  onOpenManual,
+}: TripIdleActionsProps) {
+  const t = useT();
+
+  return (
+    <div className="space-y-3 px-6 py-6">
+      <button
+        onClick={onStart}
+        disabled={isSaving}
+        className="flex w-full items-center justify-center gap-4 rounded-xl bg-primary py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95 disabled:opacity-50"
+      >
+        <Play size={28} className="text-bg" fill="currentColor" />
+        <span className="text-xl font-black uppercase tracking-widest text-bg">
+          {isSaving ? t("trip.start.saving") : t("trip.start.label")}
+        </span>
+      </button>
+      {destination ? (
+        <div className="flex items-center gap-2 rounded-xl bg-blue-50 px-4 py-3">
+          <MapPin size={16} className="shrink-0 text-blue-500" />
+          <span className="flex-1 truncate text-sm font-medium text-blue-700">
+            {destination.label}
+          </span>
+          {destinationLoading && (
+            <span className="text-xs text-blue-500">{t("trip.navigation.search.loading")}</span>
+          )}
+          <button
+            type="button"
+            onClick={onClearDestination}
+            aria-label={t("stats.detail.closeAria")}
+            className="shrink-0 text-blue-400 active:text-blue-600"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onOpenDestinationSearch}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-text-muted py-3 active:scale-95"
+        >
+          <MapPin size={16} className="text-text-muted" />
+          <span className="text-sm font-medium text-text-muted">
+            {t("trip.navigation.addDestination")}
+          </span>
+        </button>
+      )}
+
+      <button
+        onClick={onOpenManual}
+        className="flex w-full items-center justify-center gap-3 rounded-xl bg-surface-container py-4 active:scale-95"
+      >
+        <Keyboard size={18} className="text-text-muted" />
+        <span className="text-sm font-bold text-text-muted">{t("trip.manualButton")}</span>
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/trip/TripMapCanvas.tsx
+++ b/client/src/components/trip/TripMapCanvas.tsx
@@ -1,0 +1,154 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import Map, { Layer, Marker, Source } from "react-map-gl/maplibre";
+import type { LayerProps, MapRef } from "react-map-gl/maplibre";
+import { MapPin } from "lucide-react";
+import { MapNoWebGL } from "@/components/MapNoWebGL";
+import { solidTraceLayer, speedTraceLayer, type TraceGeoJSON } from "@/lib/speedGeoJSON";
+
+type RouteFeature = {
+  type: "Feature";
+  geometry: { type: "LineString"; coordinates: number[][] };
+  properties: Record<string, unknown>;
+};
+
+interface DestinationMarker {
+  lat: number;
+  lon: number;
+}
+
+interface TripMapCanvasProps {
+  mapRef: React.RefObject<MapRef | null>;
+  initialViewState: {
+    longitude: number;
+    latitude: number;
+    zoom: number;
+    bearing?: number;
+    pitch?: number;
+  };
+  mapStyle: string;
+  webGLSupported: boolean;
+  webglLost: boolean;
+  mapLoadError: boolean;
+  currentPos: [number, number];
+  currentHeading: number | null;
+  showHeadingMarker: boolean;
+  rotateHeadingMarker: boolean;
+  routeGeoJSON: RouteFeature | null;
+  routeSourceId: string;
+  routeLayerId: string;
+  traceGeoJSON: TraceGeoJSON;
+  hasSpeedData: boolean;
+  showTrace: boolean;
+  traceSourceId: string;
+  destination: DestinationMarker | null;
+  onLoad: (event: { target: maplibregl.Map }) => void;
+  onError: () => void;
+  onMoveStart?: (evt?: { originalEvent?: unknown }) => void;
+}
+
+export function TripMapCanvas({
+  mapRef,
+  initialViewState,
+  mapStyle,
+  webGLSupported,
+  webglLost,
+  mapLoadError,
+  currentPos,
+  currentHeading,
+  showHeadingMarker,
+  rotateHeadingMarker,
+  routeGeoJSON,
+  routeSourceId,
+  routeLayerId,
+  traceGeoJSON,
+  hasSpeedData,
+  showTrace,
+  traceSourceId,
+  destination,
+  onLoad,
+  onError,
+  onMoveStart,
+}: TripMapCanvasProps) {
+  if (!webGLSupported) return <MapNoWebGL />;
+
+  return (
+    <>
+      <Map
+        ref={mapRef}
+        initialViewState={initialViewState}
+        mapStyle={mapStyle}
+        attributionControl={false}
+        fadeDuration={0}
+        style={{ width: "100%", height: "100%" }}
+        onLoad={onLoad}
+        onError={onError}
+        onMoveStart={onMoveStart}
+      >
+        {routeGeoJSON && (
+          <Source id={routeSourceId} type="geojson" data={routeGeoJSON}>
+            <Layer
+              id={routeLayerId}
+              type="line"
+              paint={{ "line-color": "#3b82f6", "line-width": 5, "line-opacity": 0.85 }}
+              layout={{ "line-cap": "round", "line-join": "round" }}
+            />
+          </Source>
+        )}
+        {showTrace && (
+          <Source id={traceSourceId} type="geojson" data={traceGeoJSON}>
+            <Layer
+              {...((hasSpeedData ? speedTraceLayer : solidTraceLayer) as LayerProps)}
+              id={traceSourceId}
+            />
+          </Source>
+        )}
+        {destination && (
+          <Marker longitude={destination.lon} latitude={destination.lat}>
+            <div style={{ color: "#3b82f6" }}>
+              <MapPin size={28} fill="currentColor" strokeWidth={1.5} />
+            </div>
+          </Marker>
+        )}
+        <Marker longitude={currentPos[1]} latitude={currentPos[0]}>
+          {showHeadingMarker && currentHeading != null ? (
+            <div
+              style={{
+                width: 24,
+                height: 24,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transform: rotateHeadingMarker ? `rotate(${currentHeading}deg)` : undefined,
+                transition: "transform 300ms linear",
+              }}
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24">
+                <path
+                  d="M12 2 L18 20 L12 16 L6 20 Z"
+                  fill="#2ecc71"
+                  stroke="#fff"
+                  strokeWidth="1.5"
+                />
+              </svg>
+            </div>
+          ) : (
+            <div
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: "50%",
+                background: "#2ecc71",
+                border: "2px solid #ffffff",
+              }}
+            />
+          )}
+        </Marker>
+      </Map>
+      {(webglLost || mapLoadError) && (
+        <div className="absolute inset-0">
+          <MapNoWebGL />
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/components/trip/__tests__/TripIdleActions.test.tsx
+++ b/client/src/components/trip/__tests__/TripIdleActions.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TripIdleActions } from "../TripIdleActions";
+import { I18nProvider } from "@/i18n/provider";
+
+function renderActions(props?: Partial<React.ComponentProps<typeof TripIdleActions>>) {
+  const defaultProps: React.ComponentProps<typeof TripIdleActions> = {
+    isSaving: false,
+    destination: null,
+    destinationLoading: false,
+    onStart: vi.fn(),
+    onOpenDestinationSearch: vi.fn(),
+    onClearDestination: vi.fn(),
+    onOpenManual: vi.fn(),
+  };
+
+  return {
+    ...render(
+      <I18nProvider>
+        <TripIdleActions {...defaultProps} {...props} />
+      </I18nProvider>,
+    ),
+    props: { ...defaultProps, ...props },
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+});
+
+describe("TripIdleActions", () => {
+  it("opens destination search and manual entry from the idle state", () => {
+    const { props } = renderActions();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ajouter une destination" }));
+    fireEvent.click(screen.getByRole("button", { name: "Saisie manuelle" }));
+
+    expect(props.onOpenDestinationSearch).toHaveBeenCalledOnce();
+    expect(props.onOpenManual).toHaveBeenCalledOnce();
+  });
+
+  it("shows the selected destination row and clears it on request", () => {
+    const { props } = renderActions({
+      destination: { label: "Maison" },
+      destinationLoading: true,
+    });
+
+    expect(screen.getByText("Maison")).toBeTruthy();
+    expect(screen.getByText("Recherche…")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fermer" }));
+
+    expect(props.onClearDestination).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,56 +1,39 @@
-import { useState, useRef } from "react";
-import { useNavigate, Link } from "react-router";
-import {
-  User as UserIcon,
-  Bike,
-  Bell,
-  BellOff,
-  ChevronRight,
-  ChevronDown,
-  LogOut,
-  Loader2,
-  Check,
-  Droplets,
-  Download,
-  Upload,
-  Trash2,
-  Shield,
-  MessageSquarePlus,
-  Bluetooth,
-} from "lucide-react";
+import { useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import type { FuelType } from "@ecoride/shared/types";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { BADGES, FUEL_TYPES } from "@ecoride/shared/types";
-import type { FuelType, BadgeId } from "@ecoride/shared/types";
+import { ProfileActionsSection } from "@/components/profile/ProfileActionsSection";
+import { ProfileBadgesSection } from "@/components/profile/ProfileBadgesSection";
+import { ProfileFeedbackCard } from "@/components/profile/ProfileFeedbackCard";
+import { ProfileSettingsCard } from "@/components/profile/ProfileSettingsCard";
+import { ProfileSummarySection } from "@/components/profile/ProfileSummarySection";
+import { ProfileTripPresetsSection } from "@/components/profile/ProfileTripPresetsSection";
+import { ProfileVehicleEditorCard } from "@/components/profile/ProfileVehicleEditorCard";
 import {
-  useProfile,
   useAchievements,
-  useTripPresets,
-  useUpdateProfile,
-  useFuelPrice,
   useDeleteAccount,
   useDeleteTripPreset,
   useExportData,
+  useFuelPrice,
   useImportData,
+  useProfile,
   useSubmitFeedback,
+  useTripPresets,
+  useUpdateProfile,
 } from "@/hooks/queries";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { useT } from "@/i18n/provider";
 import { signOut } from "@/lib/auth";
 import { formatFullDate } from "@/lib/format-utils";
 import { isBleSupported, scanAndConnect } from "@/lib/super73-ble";
-import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import { MapCacheRow } from "@/components/MapCacheRow";
-import { useT } from "@/i18n/provider";
-
-const allBadgeIds = Object.keys(BADGES) as BadgeId[];
 
 export function ProfilePage() {
   const t = useT();
   const navigate = useNavigate();
   const { data: profileData, isPending: profileLoading } = useProfile();
-  const { data: achievements, isPending: achievementsLoading } = useAchievements();
+  const { data: achievements = [], isPending: achievementsLoading } = useAchievements();
   const { data: tripPresetsData } = useTripPresets();
   const updateProfile = useUpdateProfile();
-
   const push = usePushNotifications();
   const deleteAccount = useDeleteAccount();
   const deleteTripPreset = useDeleteTripPreset();
@@ -76,7 +59,6 @@ export function ProfilePage() {
 
   const user = profileData?.user;
   const stats = profileData?.stats;
-
   const tripPresets = tripPresetsData ?? [];
 
   const handleVehicleToggle = () => {
@@ -150,16 +132,17 @@ export function ProfilePage() {
     if (!file) return;
     const confirmed = window.confirm(t("profile.import.confirm"));
     if (!confirmed) return;
+
     importData.mutate(file, {
       onSuccess: (data) => {
         window.alert(
           t("profile.import.success", { imported: data.imported, skipped: data.skipped }),
         );
       },
-      onError: (err) => {
+      onError: (error) => {
         window.alert(
           t("profile.import.error", {
-            message: err instanceof Error ? err.message : String(err),
+            message: error instanceof Error ? error.message : String(error),
           }),
         );
       },
@@ -172,632 +155,128 @@ export function ProfilePage() {
     deleteTripPreset.mutate(tripPresetId);
   };
 
+  const handleFeedbackToggle = () => {
+    setShowFeedback((current) => !current);
+    setFeedbackSent(false);
+  };
+
+  const handleFeedbackSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submitFeedback.mutate(
+      {
+        type: feedbackType,
+        title: feedbackTitle,
+        description: feedbackDesc,
+      },
+      {
+        onSuccess: () => {
+          setFeedbackSent(true);
+          setFeedbackTitle("");
+          setFeedbackDesc("");
+        },
+      },
+    );
+  };
+
+  const handleSuper73RowClick = () => {
+    if (user.super73Enabled) navigate("/vehicle");
+  };
+
+  const handleSuper73ToggleClick = async () => {
+    if (user.super73Enabled) {
+      updateProfile.mutate({ super73Enabled: false });
+      return;
+    }
+    if (!isBleSupported()) return;
+
+    try {
+      await scanAndConnect();
+      updateProfile.mutate({ super73Enabled: true });
+      navigate("/vehicle");
+    } catch {
+      // User cancelled pairing — leave access disabled.
+    }
+  };
+
   return (
     <>
       <PageHeader title={t("profile.header.title")} />
 
       <div className="space-y-8 px-6 pb-6">
-        {/* User Identity Hero */}
-        <section className="flex flex-col items-center space-y-4 text-center">
-          <div className="relative">
-            <div className="rounded-full bg-gradient-to-tr from-primary to-primary-dark p-1">
-              <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border-2 border-surface bg-surface">
-                {user.image ? (
-                  <img src={user.image} alt={user.name} className="h-full w-full object-cover" />
-                ) : (
-                  <span className="text-4xl font-bold text-primary-light">
-                    {user.name.charAt(0)}
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-          <div>
-            <h2 className="text-3xl font-bold tracking-tight text-text">{user.name}</h2>
-            <div className="mt-1 inline-flex items-center rounded-full bg-primary/15 px-3 py-1 text-xs font-bold uppercase tracking-widest text-primary-light">
-              {t("profile.ecoRiderBadge")}
-            </div>
-          </div>
-        </section>
+        <ProfileSummarySection
+          user={user}
+          stats={stats}
+          fuelPrice={fuelPrice}
+          fuelPriceLoading={fuelPriceLoading}
+        />
 
-        {/* Stats Bento Grid */}
-        <section className="grid grid-cols-2 gap-4">
-          <div className="group relative col-span-2 overflow-hidden rounded-lg bg-surface-low p-6">
-            <p className="text-xs font-bold uppercase tracking-widest text-primary/70">
-              {t("profile.stats.totalCo2")}
-            </p>
-            <div className="mt-2 flex items-baseline gap-2">
-              <span className="text-5xl font-extrabold tracking-tighter text-text">
-                {stats.totalCo2SavedKg.toFixed(1)}
-              </span>
-              <span className="text-xl font-bold uppercase text-text-dim">
-                {t("profile.stats.kgUnit")}
-              </span>
-            </div>
-          </div>
-          <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              {t("profile.stats.distance")}
-            </p>
-            <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-3xl font-bold text-text">
-                {Math.round(stats.totalDistanceKm)}
-              </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                {t("profile.stats.kmUnit")}
-              </span>
-            </div>
-          </div>
-          <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              {t("profile.stats.trips")}
-            </p>
-            <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-3xl font-bold text-text">{stats.tripCount}</span>
-            </div>
-          </div>
-          <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              {t("profile.stats.fuel")}
-            </p>
-            <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-3xl font-bold text-text">
-                {stats.totalFuelSavedL.toFixed(1)}
-              </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                {t("profile.stats.litersUnit")}
-              </span>
-            </div>
-          </div>
-          <div className="rounded-lg bg-surface-low p-5">
-            <p className="text-xs font-bold uppercase tracking-widest text-text-dim">
-              {t("profile.stats.saved")}
-            </p>
-            <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-3xl font-bold text-text">
-                {stats.totalMoneySavedEur.toFixed(2)}
-              </span>
-              <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                {t("profile.stats.eurUnit")}
-              </span>
-            </div>
-          </div>
-        </section>
+        <ProfileBadgesSection achievements={achievements} />
 
-        {/* Fuel Price */}
-        <div className="flex items-center gap-4 rounded-lg bg-surface-low px-5 py-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10">
-            <Droplets size={20} className="text-primary-light" />
-          </div>
-          {fuelPriceLoading ? (
-            <div className="flex-1 space-y-2">
-              <div className="h-4 w-24 animate-pulse rounded bg-surface-high" />
-              <div className="h-3 w-32 animate-pulse rounded bg-surface-high" />
-            </div>
-          ) : fuelPrice ? (
-            <div className="flex-1">
-              <div className="flex items-baseline gap-1.5">
-                <span className="text-lg font-bold text-text">
-                  {fuelPrice.priceEur.toFixed(2)} &euro;/L
-                </span>
-                <span className="text-xs font-bold uppercase tracking-widest text-text-dim">
-                  {fuelPrice.fuelType.toUpperCase()}
-                </span>
-              </div>
-              <p className="text-xs text-text-muted">
-                {fuelPrice.stationName ? fuelPrice.stationName : t("profile.fuel.nationalAverage")}
-              </p>
-            </div>
-          ) : null}
-        </div>
+        <ProfileTripPresetsSection
+          tripPresets={tripPresets}
+          deletePending={deleteTripPreset.isPending}
+          onDelete={handleDeleteTripPreset}
+        />
 
-        {/* Badges */}
-        <section className="space-y-4">
-          <div className="flex items-end justify-between">
-            <h2 className="text-lg font-bold tracking-tight">{t("profile.badges.title")}</h2>
-          </div>
-          <div className="grid grid-cols-4 gap-4">
-            {allBadgeIds.map((id) => {
-              const badge = BADGES[id];
-              const unlocked = (achievements ?? []).some((a) => a.badgeId === id);
-              return (
-                <div
-                  key={id}
-                  className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
-                >
-                  <div
-                    className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
-                      unlocked
-                        ? "bg-primary/10 text-primary-light"
-                        : "bg-surface-high text-text-dim"
-                    }`}
-                  >
-                    <span className="text-2xl">{badge.icon}</span>
-                  </div>
-                  <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
-                    {badge.label}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </section>
+        <ProfileVehicleEditorCard
+          open={showVehicle}
+          vehicleModel={vehicleModel}
+          fuelType={fuelType}
+          consumption={consumption}
+          saveSuccess={saveSuccess}
+          saving={updateProfile.isPending}
+          onVehicleModelChange={setVehicleModel}
+          onFuelTypeChange={setFuelType}
+          onConsumptionChange={setConsumption}
+          onSave={handleSaveVehicle}
+        />
 
-        <section className="space-y-4">
-          <div className="flex items-end justify-between">
-            <div>
-              <h2 className="text-lg font-bold tracking-tight">{t("profile.presets.title")}</h2>
-              <p className="mt-1 text-sm text-text-muted">{t("profile.presets.subtitle")}</p>
-            </div>
-          </div>
-          <div className="space-y-3">
-            {tripPresets.length === 0 ? (
-              <div className="rounded-lg bg-surface-low p-5 text-sm text-text-muted">
-                {t("profile.presets.empty")}
-              </div>
-            ) : (
-              tripPresets.map((tripPreset) => (
-                <div
-                  key={tripPreset.id}
-                  className="flex items-center justify-between gap-4 rounded-lg bg-surface-low p-5"
-                >
-                  <div>
-                    <p className="text-sm font-bold text-text">{tripPreset.label}</p>
-                    <p className="mt-1 text-xs text-text-muted">
-                      {tripPreset.distanceKm.toFixed(1)} {t("profile.stats.kmUnit")}
-                      {tripPreset.durationSec != null
-                        ? ` · ${Math.round(tripPreset.durationSec / 60)} min`
-                        : ` · ${t("profile.presets.customDuration")}`}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => handleDeleteTripPreset(tripPreset.id, tripPreset.label)}
-                    disabled={deleteTripPreset.isPending}
-                    className="rounded-lg bg-danger/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-danger active:scale-95 disabled:opacity-50"
-                  >
-                    {t("profile.presets.delete")}
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
+        <ProfileSettingsCard
+          user={user}
+          showPersonalInfo={showPersonalInfo}
+          push={push}
+          bleSupported={isBleSupported()}
+          profileUpdatePending={updateProfile.isPending}
+          onTogglePersonalInfo={() => setShowPersonalInfo((current) => !current)}
+          onVehicleClick={handleVehicleToggle}
+          onSuper73RowClick={handleSuper73RowClick}
+          onSuper73ToggleClick={handleSuper73ToggleClick}
+          formatMemberSince={formatFullDate}
+        />
 
-        {/* Vehicle Form (collapsible) */}
-        {showVehicle && (
-          <section className="space-y-4 rounded-xl bg-surface-low p-6">
-            <h2 className="text-lg font-bold tracking-tight">{t("profile.vehicle.title")}</h2>
-            <div className="space-y-3">
-              <div>
-                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                  {t("profile.vehicle.model")}
-                </label>
-                <input
-                  type="text"
-                  value={vehicleModel}
-                  onChange={(e) => setVehicleModel(e.target.value)}
-                  className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                  {t("profile.vehicle.fuel")}
-                </label>
-                <select
-                  value={fuelType}
-                  onChange={(e) => setFuelType(e.target.value as FuelType)}
-                  className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-                >
-                  {FUEL_TYPES.map((f) => (
-                    <option key={f} value={f}>
-                      {f.toUpperCase()}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                  {t("profile.vehicle.consumption")}
-                </label>
-                <input
-                  type="number"
-                  value={consumption}
-                  onChange={(e) => setConsumption(e.target.value)}
-                  className="w-full rounded-lg bg-surface-high p-3 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </div>
-            </div>
-            <button
-              onClick={handleSaveVehicle}
-              disabled={updateProfile.isPending || saveSuccess}
-              className={`w-full rounded-xl py-3 text-sm font-black uppercase tracking-widest active:scale-95 disabled:opacity-50 ${
-                saveSuccess ? "bg-green-600 text-white" : "bg-primary text-bg"
-              }`}
-            >
-              {saveSuccess ? (
-                <span className="flex items-center justify-center gap-2">
-                  <Check size={16} /> {t("profile.vehicle.saved")}
-                </span>
-              ) : updateProfile.isPending ? (
-                t("profile.vehicle.saving")
-              ) : (
-                t("profile.vehicle.save")
-              )}
-            </button>
-          </section>
-        )}
+        <ProfileFeedbackCard
+          open={showFeedback}
+          feedbackType={feedbackType}
+          feedbackTitle={feedbackTitle}
+          feedbackDescription={feedbackDesc}
+          feedbackSent={feedbackSent}
+          pending={submitFeedback.isPending}
+          isError={submitFeedback.isError}
+          onToggle={handleFeedbackToggle}
+          onFeedbackTypeChange={setFeedbackType}
+          onFeedbackTitleChange={setFeedbackTitle}
+          onFeedbackDescriptionChange={setFeedbackDesc}
+          onSubmit={handleFeedbackSubmit}
+        />
 
-        {/* Settings List */}
-        <section className="space-y-2">
-          <h2 className="mb-4 text-lg font-bold tracking-tight">{t("profile.settings.title")}</h2>
-          <div className="overflow-hidden rounded-lg bg-surface-low">
-            {/* Informations personnelles */}
-            <button
-              onClick={() => setShowPersonalInfo(!showPersonalInfo)}
-              className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
-            >
-              <div className="flex items-center gap-4">
-                <UserIcon size={20} className="text-text-muted" />
-                <span className="text-sm font-medium">{t("profile.settings.personalInfo")}</span>
-              </div>
-              {showPersonalInfo ? (
-                <ChevronDown size={18} className="text-text-dim" />
-              ) : (
-                <ChevronRight size={18} className="text-text-dim" />
-              )}
-            </button>
-            {showPersonalInfo && (
-              <div className="space-y-3 px-4 pb-4">
-                <div>
-                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                    {t("profile.settings.name")}
-                  </label>
-                  <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
-                    {user.name}
-                  </div>
-                </div>
-                <div>
-                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                    {t("profile.settings.email")}
-                  </label>
-                  <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
-                    {user.email}
-                  </div>
-                </div>
-                <div>
-                  <label className="mb-1 block text-xs font-bold uppercase tracking-widest text-text-muted">
-                    {t("profile.settings.memberSince")}
-                  </label>
-                  <div className="w-full rounded-lg bg-surface-high p-3 text-sm text-text-dim">
-                    {formatFullDate(user.createdAt, user.timezone)}
-                  </div>
-                </div>
-              </div>
-            )}
+        <input
+          ref={importFileRef}
+          type="file"
+          accept="application/json,.json"
+          onChange={handleImportFile}
+          className="hidden"
+        />
 
-            <div className="mx-4 h-px bg-white/5" />
-
-            {/* Mon véhicule */}
-            <button
-              onClick={handleVehicleToggle}
-              className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
-            >
-              <div className="flex items-center gap-4">
-                <Bike size={20} className="text-text-muted" />
-                <span className="text-sm font-medium">{t("profile.settings.myVehicle")}</span>
-              </div>
-              <ChevronRight size={18} className="text-text-dim" />
-            </button>
-
-            <div className="mx-4 h-px bg-white/5" />
-
-            {/* Notifications — toggle */}
-            <div className="flex w-full items-center justify-between p-4">
-              <div className="flex items-center gap-4">
-                {push.status === "subscribed" ? (
-                  <Bell size={20} className="text-primary-light" />
-                ) : (
-                  <BellOff size={20} className="text-text-muted" />
-                )}
-                <div className="flex flex-col items-start">
-                  <span className="text-sm font-medium">{t("profile.settings.notifications")}</span>
-                  {push.status === "unsupported" && (
-                    <span className="text-xs text-text-dim">
-                      {t("profile.settings.notificationsUnsupported")}
-                    </span>
-                  )}
-                  {push.status === "denied" && (
-                    <span className="text-xs text-text-dim">
-                      {t("profile.settings.notificationsDenied")}
-                    </span>
-                  )}
-                  {push.status === "subscribed" && (
-                    <span className="text-xs text-primary/70">
-                      {t("profile.settings.notificationsEnabled")}
-                    </span>
-                  )}
-                </div>
-              </div>
-              {(push.status === "subscribed" || push.status === "unsubscribed") && (
-                <button
-                  onClick={push.toggle}
-                  disabled={push.busy}
-                  aria-label={
-                    push.status === "subscribed"
-                      ? t("profile.settings.notificationsDisableAria")
-                      : t("profile.settings.notificationsEnableAria")
-                  }
-                  className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
-                    push.status === "subscribed" ? "bg-primary" : "bg-surface-high"
-                  }`}
-                >
-                  {push.busy ? (
-                    <Loader2 size={14} className="mx-auto animate-spin text-text-dim" />
-                  ) : (
-                    <span
-                      className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
-                        push.status === "subscribed" ? "translate-x-6" : "translate-x-1"
-                      }`}
-                    />
-                  )}
-                </button>
-              )}
-            </div>
-
-            <div className="mx-4 h-px bg-white/5" />
-
-            {user?.super73Enabled && (
-              <>
-                {/* Super73 BLE — toggle + navigate to /vehicle */}
-                <div className="flex w-full items-center justify-between p-4">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (user?.super73Enabled) navigate("/vehicle");
-                    }}
-                    disabled={!user?.super73Enabled}
-                    className="flex min-w-0 items-center gap-4 text-left"
-                  >
-                    <Bluetooth
-                      size={20}
-                      className={user?.super73Enabled ? "text-primary-light" : "text-text-muted"}
-                    />
-                    <div className="flex flex-col items-start">
-                      <span className="text-sm font-medium">
-                        {t("profile.settings.super73Connected")}
-                      </span>
-                      {!isBleSupported() && (
-                        <span className="text-xs text-text-dim">
-                          {t("profile.settings.super73Unsupported")}
-                        </span>
-                      )}
-                      {user?.super73Enabled && (
-                        <span className="text-xs text-primary/70">
-                          {t("profile.settings.super73Enabled")}
-                        </span>
-                      )}
-                    </div>
-                    {user?.super73Enabled && (
-                      <ChevronRight size={18} className="shrink-0 text-text-dim" />
-                    )}
-                  </button>
-                  <button
-                    onClick={async () => {
-                      if (user?.super73Enabled) {
-                        // Disable — just toggle off
-                        updateProfile.mutate({ super73Enabled: false });
-                        return;
-                      }
-                      // Enable — launch pairing immediately
-                      if (!isBleSupported()) return;
-                      try {
-                        await scanAndConnect(); // opens picker, user selects bike
-                        updateProfile.mutate({ super73Enabled: true });
-                        navigate("/vehicle");
-                      } catch {
-                        // User cancelled picker — don't enable
-                      }
-                    }}
-                    disabled={updateProfile.isPending}
-                    aria-label={
-                      user?.super73Enabled
-                        ? t("profile.settings.super73DisableAria")
-                        : t("profile.settings.super73EnableAria")
-                    }
-                    className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 ${
-                      user?.super73Enabled ? "bg-primary" : "bg-surface-high"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-5 w-5 rounded-full bg-white shadow-md transition-transform ${
-                        user?.super73Enabled ? "translate-x-6" : "translate-x-1"
-                      }`}
-                    />
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
-
-          {/* Feedback form */}
-          <div className="overflow-hidden rounded-lg bg-surface-low">
-            <button
-              onClick={() => {
-                setShowFeedback(!showFeedback);
-                setFeedbackSent(false);
-              }}
-              className="flex w-full items-center justify-between p-4 transition-colors hover:bg-surface-high"
-            >
-              <div className="flex items-center gap-4">
-                <MessageSquarePlus size={20} className="text-text-muted" />
-                <span className="text-sm font-medium">{t("profile.feedback.title")}</span>
-              </div>
-              {showFeedback ? (
-                <ChevronDown size={18} className="text-text-dim" />
-              ) : (
-                <ChevronRight size={18} className="text-text-dim" />
-              )}
-            </button>
-            {showFeedback && (
-              <div className="space-y-3 px-4 pb-4">
-                {feedbackSent ? (
-                  <div className="flex items-center gap-3 rounded-lg bg-primary/10 p-4">
-                    <Check size={18} className="text-primary-light" />
-                    <span className="text-sm font-medium text-primary-light">
-                      {t("profile.feedback.thanks")}
-                    </span>
-                  </div>
-                ) : (
-                  <form
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      submitFeedback.mutate(
-                        {
-                          type: feedbackType,
-                          title: feedbackTitle,
-                          description: feedbackDesc,
-                        },
-                        {
-                          onSuccess: () => {
-                            setFeedbackSent(true);
-                            setFeedbackTitle("");
-                            setFeedbackDesc("");
-                          },
-                        },
-                      );
-                    }}
-                    className="space-y-3"
-                  >
-                    <div className="flex gap-2">
-                      {(["bug", "feature"] as const).map((type) => (
-                        <button
-                          key={type}
-                          type="button"
-                          onClick={() => setFeedbackType(type)}
-                          className={`flex-1 rounded-lg py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
-                            feedbackType === type
-                              ? "bg-primary/20 text-primary-light"
-                              : "bg-surface-high text-text-muted"
-                          }`}
-                        >
-                          {type === "bug"
-                            ? t("profile.feedback.bug")
-                            : t("profile.feedback.feature")}
-                        </button>
-                      ))}
-                    </div>
-                    <input
-                      type="text"
-                      value={feedbackTitle}
-                      onChange={(e) => setFeedbackTitle(e.target.value)}
-                      placeholder={t("profile.feedback.titlePlaceholder")}
-                      required
-                      minLength={3}
-                      maxLength={200}
-                      className="w-full rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
-                    />
-                    <textarea
-                      value={feedbackDesc}
-                      onChange={(e) => setFeedbackDesc(e.target.value)}
-                      placeholder={t("profile.feedback.descPlaceholder")}
-                      required
-                      minLength={10}
-                      maxLength={2000}
-                      rows={4}
-                      className="w-full resize-none rounded-lg bg-surface-high p-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/30"
-                    />
-                    <button
-                      type="submit"
-                      disabled={submitFeedback.isPending}
-                      className="w-full rounded-lg bg-primary py-3 text-sm font-bold text-bg active:scale-95 disabled:opacity-50"
-                    >
-                      {submitFeedback.isPending
-                        ? t("profile.feedback.sending")
-                        : t("profile.feedback.send")}
-                    </button>
-                    {submitFeedback.isError && (
-                      <p className="text-center text-xs text-danger">
-                        {t("profile.feedback.error")}
-                      </p>
-                    )}
-                  </form>
-                )}
-              </div>
-            )}
-
-            <div className="mx-4 h-px bg-white/5" />
-
-            <MapCacheRow />
-
-            <div className="mx-4 h-px bg-white/5" />
-
-            <LanguageSwitcher />
-          </div>
-
-          {/* Admin link (only visible for admins) */}
-          {user.isAdmin && (
-            <Link
-              to="/admin"
-              className="mt-4 flex w-full items-center justify-between rounded-lg bg-surface-high p-4 transition-colors hover:bg-surface-low"
-            >
-              <div className="flex items-center gap-4">
-                <Shield size={20} className="text-primary-light" />
-                <span className="text-sm font-medium">{t("profile.admin")}</span>
-              </div>
-              <ChevronRight size={18} className="text-text-dim" />
-            </Link>
-          )}
-
-          <button
-            onClick={handleLogout}
-            className="mt-6 w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-danger active:scale-95"
-          >
-            <div className="flex items-center justify-center gap-2">
-              <LogOut size={16} />
-              {t("profile.logout")}
-            </div>
-          </button>
-
-          <button
-            onClick={handleExportData}
-            disabled={exportData.isPending}
-            className="mt-4 w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
-          >
-            <div className="flex items-center justify-center gap-2">
-              <Download size={16} />
-              {exportData.isPending ? t("profile.export.exporting") : t("profile.export.label")}
-            </div>
-          </button>
-
-          <input
-            ref={importFileRef}
-            type="file"
-            accept="application/json,.json"
-            onChange={handleImportFile}
-            className="hidden"
-          />
-          <button
-            onClick={handleImportClick}
-            disabled={importData.isPending}
-            className="mt-4 w-full rounded-lg bg-surface-high py-4 text-xs font-bold uppercase tracking-widest text-text-muted active:scale-95 disabled:opacity-50"
-          >
-            <div className="flex items-center justify-center gap-2">
-              <Upload size={16} />
-              {importData.isPending ? t("profile.import.importing") : t("profile.import.label")}
-            </div>
-          </button>
-
-          <button
-            onClick={handleDeleteAccount}
-            disabled={deleteAccount.isPending}
-            className="mt-4 w-full rounded-lg border border-red-500/30 bg-red-500/10 py-4 text-xs font-bold uppercase tracking-widest text-red-400 active:scale-95 disabled:opacity-50"
-          >
-            <div className="flex items-center justify-center gap-2">
-              <Trash2 size={16} />
-              {deleteAccount.isPending ? t("profile.delete.deleting") : t("profile.delete.label")}
-            </div>
-          </button>
-        </section>
+        <ProfileActionsSection
+          isAdmin={user.isAdmin}
+          onLogout={handleLogout}
+          onExport={handleExportData}
+          onImportClick={handleImportClick}
+          onDeleteAccount={handleDeleteAccount}
+          exportPending={exportData.isPending}
+          importPending={importData.isPending}
+          deletePending={deleteAccount.isPending}
+        />
       </div>
     </>
   );

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -1,9 +1,6 @@
-import "maplibre-gl/dist/maplibre-gl.css";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { Play, Keyboard, AlertTriangle, MapPin, X, LocateFixed } from "lucide-react";
-import Map, { Marker, Source, Layer } from "react-map-gl/maplibre";
-import type { MapRef, LayerProps } from "react-map-gl/maplibre";
-// Imported here so MapLibre styles stay off the initial app shell bundle.
+import { AlertTriangle, LocateFixed } from "lucide-react";
+import type { MapRef } from "react-map-gl/maplibre";
 import { useCreateTrip, useProfile, useTripPresets } from "@/hooks/queries";
 import { CO2_KG_PER_LITER } from "@ecoride/shared/types";
 import { useAppGpsTracking } from "@/hooks/useGpsTracking";
@@ -12,9 +9,8 @@ import { queueTrip } from "@/lib/offline-queue";
 import { ApiError } from "@/lib/api";
 import { clearStoppedSession } from "@/lib/stopped-session";
 import { isWebGLSupported } from "@/lib/webgl";
-import { MapNoWebGL } from "@/components/MapNoWebGL";
 import { formatTime } from "@/lib/format-utils";
-import { buildTraceGeoJSON, speedTraceLayer, solidTraceLayer } from "@/lib/speedGeoJSON";
+import { buildTraceGeoJSON } from "@/lib/speedGeoJSON";
 import { GpsStatusBadge } from "@/components/trip/GpsStatusBadge";
 import { TripRecoveryBanner } from "@/components/trip/TripRecoveryBanner";
 import { TrackingDashboard } from "@/components/trip/TrackingDashboard";
@@ -22,6 +18,8 @@ import { StoppedSummary } from "@/components/trip/StoppedSummary";
 import { ManualEntryForm } from "@/components/trip/ManualEntryForm";
 import { InterruptMenu } from "@/components/trip/InterruptMenu";
 import { TrackingControls } from "@/components/trip/TrackingControls";
+import { TripIdleActions } from "@/components/trip/TripIdleActions";
+import { TripMapCanvas } from "@/components/trip/TripMapCanvas";
 import { useSessionRecovery } from "@/hooks/useSessionRecovery";
 import { useManualTrip } from "@/hooks/useManualTrip";
 import { useMapCamera } from "@/hooks/useMapCamera";
@@ -181,6 +179,36 @@ export function TripPage() {
     mapStyleReadyRef.current = false;
     setWebglLost(false);
     setMapLoadError(false);
+  }, []);
+
+  const handleTrackingMapLoad = useCallback(
+    (event: { target: { on: (name: string, listener: () => void) => void } }) => {
+      mapStyleReadyRef.current = true;
+      setMapLoadError(false);
+      trackingCamera.setMapLoadSeq((seq) => seq + 1);
+      setWebglLost(false);
+      const map = event.target;
+      map.on("webglcontextlost", () => setWebglLost(true));
+      map.on("webglcontextrestored", () => setWebglLost(false));
+    },
+    [trackingCamera],
+  );
+
+  const handleIdleMapLoad = useCallback(
+    (event: { target: { on: (name: string, listener: () => void) => void } }) => {
+      mapStyleReadyRef.current = true;
+      setMapLoadError(false);
+      idleCamera.setMapLoadSeq((seq) => seq + 1);
+      setWebglLost(false);
+      const map = event.target;
+      map.on("webglcontextlost", () => setWebglLost(true));
+      map.on("webglcontextrestored", () => setWebglLost(false));
+    },
+    [idleCamera],
+  );
+
+  const handleMapLoadError = useCallback(() => {
+    if (!mapStyleReadyRef.current) setMapLoadError(true);
   }, []);
 
   // --- Performance: memoize key handlers ---
@@ -374,7 +402,6 @@ export function TripPage() {
             />
           )}
 
-          {/* Mini map */}
           <div
             className="relative min-h-0 flex-1 overflow-hidden"
             data-testid="tracking-map"
@@ -383,106 +410,35 @@ export function TripPage() {
             data-camera-padding-top={TRACKING_CAMERA_PADDING.top}
             data-camera-padding-bottom={TRACKING_CAMERA_PADDING.bottom}
           >
-            {webGLSupported ? (
-              <>
-                <Map
-                  ref={trackingMapRef}
-                  initialViewState={{
-                    longitude: currentPos[1],
-                    latitude: currentPos[0],
-                    zoom: 15,
-                    bearing: isPov ? (gps.state.heading ?? 0) : 0,
-                    pitch: isPov && gps.state.heading != null ? 45 : 0,
-                  }}
-                  mapStyle={MAP_STYLE}
-                  attributionControl={false}
-                  fadeDuration={0}
-                  style={{ width: "100%", height: "100%" }}
-                  onLoad={(e) => {
-                    mapStyleReadyRef.current = true;
-                    setMapLoadError(false);
-                    trackingCamera.setMapLoadSeq((s) => s + 1);
-                    setWebglLost(false);
-                    const m = e.target;
-                    m.on("webglcontextlost", () => setWebglLost(true));
-                    m.on("webglcontextrestored", () => setWebglLost(false));
-                  }}
-                  onError={() => {
-                    if (!mapStyleReadyRef.current) setMapLoadError(true);
-                  }}
-                  onMoveStart={handleTrackingMapInteraction}
-                >
-                  {remainingRouteGeoJSON && (
-                    <Source id="nav-route-tracking" type="geojson" data={remainingRouteGeoJSON}>
-                      <Layer
-                        id="nav-route-tracking-line"
-                        type="line"
-                        paint={{ "line-color": "#3b82f6", "line-width": 5, "line-opacity": 0.85 }}
-                        layout={{ "line-cap": "round", "line-join": "round" }}
-                      />
-                    </Source>
-                  )}
-                  {positions.length > 1 && (
-                    <Source id="trace-tracking" type="geojson" data={traceGeoJSON}>
-                      <Layer
-                        {...((hasSpeedData ? speedTraceLayer : solidTraceLayer) as LayerProps)}
-                      />
-                    </Source>
-                  )}
-                  {navigation.destination && (
-                    <Marker
-                      longitude={navigation.destination.lon}
-                      latitude={navigation.destination.lat}
-                    >
-                      <div style={{ color: "#3b82f6" }}>
-                        <MapPin size={28} fill="currentColor" strokeWidth={1.5} />
-                      </div>
-                    </Marker>
-                  )}
-                  <Marker longitude={currentPos[1]} latitude={currentPos[0]}>
-                    {gps.state.heading != null ? (
-                      <div
-                        style={{
-                          width: 24,
-                          height: 24,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          transform: isPov ? undefined : `rotate(${gps.state.heading}deg)`,
-                          transition: "transform 300ms linear",
-                        }}
-                      >
-                        <svg width="24" height="24" viewBox="0 0 24 24">
-                          <path
-                            d="M12 2 L18 20 L12 16 L6 20 Z"
-                            fill="#2ecc71"
-                            stroke="#fff"
-                            strokeWidth="1.5"
-                          />
-                        </svg>
-                      </div>
-                    ) : (
-                      <div
-                        style={{
-                          width: 16,
-                          height: 16,
-                          borderRadius: "50%",
-                          background: "#2ecc71",
-                          border: "2px solid #ffffff",
-                        }}
-                      />
-                    )}
-                  </Marker>
-                </Map>
-                {(webglLost || mapLoadError) && (
-                  <div className="absolute inset-0">
-                    <MapNoWebGL />
-                  </div>
-                )}
-              </>
-            ) : (
-              <MapNoWebGL />
-            )}
+            <TripMapCanvas
+              mapRef={trackingMapRef}
+              initialViewState={{
+                longitude: currentPos[1],
+                latitude: currentPos[0],
+                zoom: 15,
+                bearing: isPov ? (gps.state.heading ?? 0) : 0,
+                pitch: isPov && gps.state.heading != null ? 45 : 0,
+              }}
+              mapStyle={MAP_STYLE}
+              webGLSupported={webGLSupported}
+              webglLost={webglLost}
+              mapLoadError={mapLoadError}
+              currentPos={currentPos}
+              currentHeading={gps.state.heading ?? null}
+              showHeadingMarker={gps.state.heading != null}
+              rotateHeadingMarker={!isPov}
+              routeGeoJSON={remainingRouteGeoJSON}
+              routeSourceId="nav-route-tracking"
+              routeLayerId="nav-route-tracking-line"
+              traceGeoJSON={traceGeoJSON}
+              hasSpeedData={hasSpeedData}
+              showTrace={positions.length > 1}
+              traceSourceId="trace-tracking"
+              destination={navigation.destination}
+              onLoad={handleTrackingMapLoad}
+              onError={handleMapLoadError}
+              onMoveStart={handleTrackingMapInteraction}
+            />
             <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-3">
               {!isTrackingMapFollowing && (
                 <button
@@ -506,82 +462,34 @@ export function TripPage() {
       {/* === IDLE / STOPPED / MANUAL: full map === */}
       {uiState !== "tracking" && (
         <div className="relative min-h-0 flex-1" data-testid="idle-map">
-          {webGLSupported ? (
-            <>
-              <Map
-                ref={idleMapRef}
-                initialViewState={{
-                  longitude: currentPos[1],
-                  latitude: currentPos[0],
-                  zoom: 15,
-                  bearing: 0,
-                  pitch: 0,
-                }}
-                mapStyle={MAP_STYLE}
-                attributionControl={false}
-                style={{ width: "100%", height: "100%" }}
-                onLoad={(e) => {
-                  mapStyleReadyRef.current = true;
-                  setMapLoadError(false);
-                  idleCamera.setMapLoadSeq((s) => s + 1);
-                  setWebglLost(false);
-                  const m = e.target;
-                  m.on("webglcontextlost", () => setWebglLost(true));
-                  m.on("webglcontextrestored", () => setWebglLost(false));
-                }}
-                onError={() => {
-                  if (!mapStyleReadyRef.current) setMapLoadError(true);
-                }}
-              >
-                {fullRouteGeoJSON && (
-                  <Source id="nav-route-idle" type="geojson" data={fullRouteGeoJSON}>
-                    <Layer
-                      id="nav-route-idle-line"
-                      type="line"
-                      paint={{ "line-color": "#3b82f6", "line-width": 5, "line-opacity": 0.85 }}
-                      layout={{ "line-cap": "round", "line-join": "round" }}
-                    />
-                  </Source>
-                )}
-                {positions.length > 1 && (
-                  <Source id="trace-idle" type="geojson" data={traceGeoJSON}>
-                    <Layer
-                      {...((hasSpeedData ? speedTraceLayer : solidTraceLayer) as LayerProps)}
-                      id="trace-idle"
-                    />
-                  </Source>
-                )}
-                {navigation.destination && (
-                  <Marker
-                    longitude={navigation.destination.lon}
-                    latitude={navigation.destination.lat}
-                  >
-                    <div style={{ color: "#3b82f6" }}>
-                      <MapPin size={28} fill="currentColor" strokeWidth={1.5} />
-                    </div>
-                  </Marker>
-                )}
-                <Marker longitude={currentPos[1]} latitude={currentPos[0]}>
-                  <div
-                    style={{
-                      width: 16,
-                      height: 16,
-                      borderRadius: "50%",
-                      background: "#2ecc71",
-                      border: "2px solid #ffffff",
-                    }}
-                  />
-                </Marker>
-              </Map>
-              {(webglLost || mapLoadError) && (
-                <div className="absolute inset-0">
-                  <MapNoWebGL />
-                </div>
-              )}
-            </>
-          ) : (
-            <MapNoWebGL />
-          )}
+          <TripMapCanvas
+            mapRef={idleMapRef}
+            initialViewState={{
+              longitude: currentPos[1],
+              latitude: currentPos[0],
+              zoom: 15,
+              bearing: 0,
+              pitch: 0,
+            }}
+            mapStyle={MAP_STYLE}
+            webGLSupported={webGLSupported}
+            webglLost={webglLost}
+            mapLoadError={mapLoadError}
+            currentPos={currentPos}
+            currentHeading={null}
+            showHeadingMarker={false}
+            rotateHeadingMarker={false}
+            routeGeoJSON={fullRouteGeoJSON}
+            routeSourceId="nav-route-idle"
+            routeLayerId="nav-route-idle-line"
+            traceGeoJSON={traceGeoJSON}
+            hasSpeedData={hasSpeedData}
+            showTrace={positions.length > 1}
+            traceSourceId="trace-idle"
+            destination={navigation.destination}
+            onLoad={handleIdleMapLoad}
+            onError={handleMapLoadError}
+          />
         </div>
       )}
 
@@ -639,59 +547,18 @@ export function TripPage() {
 
       {/* Action buttons */}
       {uiState === "idle" && (
-        <div className="space-y-3 px-6 py-6">
-          {/* Fix 1.6: Disable start button during tracking */}
-          <button
-            onClick={startTracking}
-            disabled={uiState !== "idle" || createTrip.isPending}
-            className="flex w-full items-center justify-center gap-4 rounded-xl bg-primary py-6 shadow-[0px_20px_40px_rgba(0,0,0,0.4)] active:scale-95 disabled:opacity-50"
-          >
-            <Play size={28} className="text-bg" fill="currentColor" />
-            <span className="text-xl font-black uppercase tracking-widest text-bg">
-              {createTrip.isPending ? t("trip.start.saving") : t("trip.start.label")}
-            </span>
-          </button>
-          {navigation.destination ? (
-            <div className="flex items-center gap-2 rounded-xl bg-blue-50 px-4 py-3">
-              <MapPin size={16} className="shrink-0 text-blue-500" />
-              <span className="flex-1 truncate text-sm font-medium text-blue-700">
-                {navigation.destination.label}
-              </span>
-              {navigation.isLoading && (
-                <span className="text-xs text-blue-500">{t("trip.navigation.search.loading")}</span>
-              )}
-              <button
-                type="button"
-                onClick={() => navigation.clearRoute()}
-                className="shrink-0 text-blue-400 active:text-blue-600"
-              >
-                <X size={16} />
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setShowDestinationSearch(true)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-text-muted py-3 active:scale-95"
-            >
-              <MapPin size={16} className="text-text-muted" />
-              <span className="text-sm font-medium text-text-muted">
-                {t("trip.navigation.addDestination")}
-              </span>
-            </button>
-          )}
-
-          <button
-            onClick={() => {
-              manual.resetManualForm();
-              setUiState("manual");
-            }}
-            className="flex w-full items-center justify-center gap-3 rounded-xl bg-surface-container py-4 active:scale-95"
-          >
-            <Keyboard size={18} className="text-text-muted" />
-            <span className="text-sm font-bold text-text-muted">{t("trip.manualButton")}</span>
-          </button>
-        </div>
+        <TripIdleActions
+          isSaving={createTrip.isPending}
+          destination={navigation.destination}
+          destinationLoading={navigation.isLoading}
+          onStart={startTracking}
+          onOpenDestinationSearch={() => setShowDestinationSearch(true)}
+          onClearDestination={() => navigation.clearRoute()}
+          onOpenManual={() => {
+            manual.resetManualForm();
+            setUiState("manual");
+          }}
+        />
       )}
 
       {uiState === "tracking" && (

--- a/client/src/pages/__tests__/ProfilePage.feedback.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.feedback.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ProfilePage } from "../ProfilePage";
+import { I18nProvider } from "@/i18n/provider";
+
+const submitFeedbackMock = vi.fn();
+
+const createLocalStorageMock = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+};
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/hooks/queries", () => ({
+  useProfile: () => ({
+    data: {
+      user: {
+        id: "user-1",
+        name: "Lyra",
+        email: "lyra@example.com",
+        image: null,
+        vehicleModel: null,
+        fuelType: "sp95",
+        consumptionL100: 7,
+        mileage: null,
+        timezone: null,
+        leaderboardOptOut: false,
+        reminderEnabled: false,
+        reminderTime: null,
+        reminderDays: null,
+        isAdmin: false,
+        super73Enabled: false,
+        super73AutoModeEnabled: false,
+        super73DefaultMode: null,
+        super73DefaultAssist: null,
+        super73DefaultLight: null,
+        super73AutoModeLowSpeedKmh: null,
+        super73AutoModeHighSpeedKmh: null,
+        createdAt: "2026-04-08T10:00:00.000Z",
+      },
+      stats: {
+        totalDistanceKm: 100,
+        totalCo2SavedKg: 15,
+        totalMoneySavedEur: 20,
+        totalFuelSavedL: 8,
+        tripCount: 12,
+      },
+    },
+    isPending: false,
+  }),
+  useAchievements: () => ({ data: [], isPending: false }),
+  useTripPresets: () => ({ data: [] }),
+  useUpdateProfile: () => ({ mutate: vi.fn(), isPending: false }),
+  useFuelPrice: () => ({ data: null, isPending: false }),
+  useDeleteAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteTripPreset: () => ({ mutate: vi.fn(), isPending: false }),
+  useExportData: () => ({ mutate: vi.fn(), isPending: false }),
+  useImportData: () => ({ mutate: vi.fn(), isPending: false }),
+  useSubmitFeedback: () => ({ mutate: submitFeedbackMock, isPending: false, isError: false }),
+}));
+
+vi.mock("@/hooks/usePushNotifications", () => ({
+  usePushNotifications: () => ({
+    status: "unsupported",
+    busy: false,
+    toggle: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({ signOut: vi.fn() }));
+vi.mock("@/lib/super73-ble", () => ({ isBleSupported: () => false, scanAndConnect: vi.fn() }));
+vi.mock("@/components/LanguageSwitcher", () => ({ LanguageSwitcher: () => null }));
+vi.mock("@/components/MapCacheRow", () => ({ MapCacheRow: () => null }));
+
+describe("ProfilePage feedback section", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+    vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+    submitFeedbackMock.mockReset();
+    submitFeedbackMock.mockImplementation((_vars, options) => options?.onSuccess?.());
+    (globalThis as typeof globalThis & { __APP_VERSION__?: string }).__APP_VERSION__ = "test";
+  });
+
+  it("clears the thank-you state when the feedback form is reopened", () => {
+    render(
+      <I18nProvider>
+        <ProfilePage />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Signaler un problème" }));
+    fireEvent.change(screen.getByPlaceholderText("Titre"), {
+      target: { value: "Carte vide" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Décrivez le problème ou votre idée..."), {
+      target: { value: "La carte reste vide au lancement sur Safari iOS." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Envoyer" }));
+
+    expect(screen.getByText("Merci pour votre retour !")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Signaler un problème" }));
+    fireEvent.click(screen.getByRole("button", { name: "Signaler un problème" }));
+
+    expect(screen.queryByText("Merci pour votre retour !")).toBeNull();
+    expect(screen.getByPlaceholderText("Titre")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

- split `ProfilePage` into focused summary, badges, presets, vehicle editor, settings, feedback, and actions sections
- extract `TripMapCanvas` and `TripIdleActions` so `TripPage` keeps the trip state machine while shedding bulky map/action rendering branches
- keep critical trip/profile behavior intact and add targeted regression coverage for the extracted feedback and idle-action interactions

Closes #311.

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `cd client && bunx vitest run src/pages/__tests__/TripPage.interrupt.test.tsx src/pages/__tests__/TripPage.map-follow.test.tsx src/pages/__tests__/TripPage.super73-speed.test.tsx src/pages/__tests__/ProfilePage.preset.test.tsx src/pages/__tests__/ProfilePage.super73-settings.test.tsx src/pages/__tests__/ProfilePage.feedback.test.tsx src/components/trip/__tests__/TripIdleActions.test.tsx`
- `cd client && bunx playwright test e2e/feedback.spec.ts e2e/trip-interrupt-menu.spec.ts`

## Measured impact

- `TripPage.tsx`: 676 lines / FTA 74.28 → 542 lines / FTA 69.83
- `ProfilePage.tsx`: 760 lines / FTA 74.71 → 253 lines / FTA 59.73
- `bun run lint` no longer reports SonarJS cognitive-complexity warnings for `TripPage.tsx` or `ProfilePage.tsx`; remaining warnings are limited to `AdminPage.tsx`, `Super73ModeButton.tsx`, `GpsStatusBadge.tsx`, and the known `react-refresh` cases.

## Notes

- This pass deliberately keeps the trip state machine in `TripPage` and the async profile mutations in `ProfilePage`; it extracts rendering-heavy responsibilities first so the next hotspot passes can target smaller seams.