### PR TITLE
fix(super73): serialize GATT ops and reset stale mode selection on EPAC

### DIFF
--- a/client/src/hooks/__tests__/useSuper73.test.tsx
+++ b/client/src/hooks/__tests__/useSuper73.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import {
   Super73Provider,
   useSuper73,
@@ -21,6 +21,7 @@ const startStateNotificationsMock = vi.fn().mockResolvedValue(null);
 
 vi.mock("@/lib/super73-ble", () => ({
   isBleSupported: () => true,
+  isBleDebugEnabled: () => false,
   scanAndConnect: (...args: unknown[]) => scanAndConnectMock(...args),
   reconnectPairedDevice: (...args: unknown[]) => reconnectPairedDeviceMock(...args),
   readState: (...args: unknown[]) => readStateMock(...args),
@@ -53,6 +54,7 @@ function Consumer({ label }: { label: string }) {
   return (
     <div>
       <button onClick={() => ble.connect()}>{label} connect</button>
+      <button onClick={() => void ble.toggleMode()}>{label} toggle</button>
       <span>
         {label}:{ble.status}
       </span>
@@ -64,6 +66,9 @@ function Consumer({ label }: { label: string }) {
       </span>
       <span>
         {label}-light:{ble.bikeState?.light ? "on" : "off"}
+      </span>
+      <span>
+        {label}-selection:{ble.tripModeSelection}
       </span>
       <span>
         {label}-poll-warning:{ble.epacPollFallbackWarning ? "yes" : "no"}
@@ -338,5 +343,77 @@ describe("useSuper73 provider", () => {
         mode: "eco",
       });
     });
+  });
+});
+
+// Regression for issue #326: in connected-bike mode, selecting Off-Road then using
+// the bike's assist-3 button to force EPAC must NOT leave a stale "race" selection
+// behind. Otherwise, once the rider moves assist back to 4, the mode stays EPAC
+// (eco) but the compact icon resurfaces as Off-Road (blue triangle).
+describe("useSuper73 provider — EPAC enforcement resets stale trip-mode selection (issue #326)", () => {
+  let notify: ((state: Super73State) => void) | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageStub());
+    reconnectPairedDeviceMock.mockResolvedValue(null);
+    writeStateMock.mockResolvedValue(undefined);
+    // Bike starts in EPAC (eco) at assist 4 so toggleMode flips the selection to race.
+    readStateMock.mockResolvedValue({ mode: "eco", assist: 4, light: false, region: "eu" });
+    scanAndConnectMock.mockResolvedValue(buildDevice());
+    // Capture the notifier callback so the test can simulate bike-side state pushes.
+    notify = undefined;
+    startStateNotificationsMock.mockImplementation((_server: unknown, onState: unknown) => {
+      notify = onState as (state: Super73State) => void;
+      return Promise.resolve(() => {});
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    // Restore the default (notifier unavailable) for the rest of the suite.
+    startStateNotificationsMock.mockReset().mockResolvedValue(null);
+  });
+
+  it("keeps the icon on EPAC after assist 3 → 4 when Off-Road was previously selected", async () => {
+    render(
+      <Super73Provider enabled tracking={{ isTracking: true, speedKmh: 20 }}>
+        <Consumer label="trip" />
+      </Super73Provider>,
+    );
+
+    fireEvent.click(screen.getByText("trip connect"));
+    await waitFor(() => {
+      expect(screen.getByText("trip:connected")).toBeTruthy();
+    });
+
+    // Rider selects Off-Road → intent becomes "race", icon shows Off-Road.
+    fireEvent.click(screen.getByText("trip toggle"));
+    await waitFor(() => {
+      expect(screen.getByText("trip-mode:race")).toBeTruthy();
+      expect(screen.getByText("trip-selection:race")).toBeTruthy();
+    });
+
+    // Rider sets assist to 3 on the bike → EPAC enforcement forces mode back to eco.
+    await act(async () => {
+      notify?.({ mode: "race", assist: 3, light: false, region: "eu" });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("trip-mode:eco")).toBeTruthy();
+      // Masked by the assist===3 branch while assist stays at the trigger level.
+      expect(screen.getByText("trip-selection:eco")).toBeTruthy();
+    });
+
+    // Rider sets assist back to 4 → mode stays EPAC; the icon MUST stay EPAC too.
+    await act(async () => {
+      notify?.({ mode: "eco", assist: 4, light: false, region: "eu" });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("trip-assist:4")).toBeTruthy();
+    });
+    expect(screen.getByText("trip-mode:eco")).toBeTruthy();
+    // Before the fix this resurfaced as "race" (Off-Road icon) — the bug.
+    expect(screen.getByText("trip-selection:eco")).toBeTruthy();
   });
 });

--- a/client/src/hooks/__tests__/useSuper73.test.tsx
+++ b/client/src/hooks/__tests__/useSuper73.test.tsx
@@ -189,6 +189,13 @@ describe("useSuper73 helpers", () => {
       );
     });
 
+    it("shows off-road at assist=3 when the bike is actually still in race (EPAC write pending or failed)", () => {
+      const state = { ...baseState, assist: 3, mode: "race" as const };
+      // The icon must reflect reality, not blindly assume EPAC landed.
+      expect(deriveTripModeSelection(state, prefs, tracking, "eco")).toBe("race");
+      expect(deriveTripModeSelection(state, prefs, tracking, "race")).toBe("race");
+    });
+
     it("keeps an explicit eco or race override while tracking with profile auto mode enabled", () => {
       const state = { ...baseState, assist: 2, mode: "tour" as const };
       expect(deriveTripModeSelection(state, prefs, tracking, "eco")).toBe("eco");
@@ -443,6 +450,12 @@ describe("useSuper73 provider — EPAC enforcement resets stale trip-mode select
     // bike stays in race.
     await act(async () => {
       notify?.({ mode: "race", assist: 3, light: false, region: "eu" });
+    });
+    // While assist stays at 3, the icon must NOT claim EPAC — the bike is still in
+    // off-road because the write failed.
+    await waitFor(() => {
+      expect(screen.getByText("trip-mode:race")).toBeTruthy();
+      expect(screen.getByText("trip-selection:race")).toBeTruthy();
     });
 
     // Rider sets assist back to 4 — the bike is still in race (the write failed).

--- a/client/src/hooks/__tests__/useSuper73.test.tsx
+++ b/client/src/hooks/__tests__/useSuper73.test.tsx
@@ -416,4 +416,46 @@ describe("useSuper73 provider — EPAC enforcement resets stale trip-mode select
     // Before the fix this resurfaced as "race" (Off-Road icon) — the bug.
     expect(screen.getByText("trip-selection:eco")).toBeTruthy();
   });
+
+  it("keeps the icon on the real off-road mode when the EPAC write fails", async () => {
+    render(
+      <Super73Provider enabled tracking={{ isTracking: true, speedKmh: 20 }}>
+        <Consumer label="trip" />
+      </Super73Provider>,
+    );
+
+    fireEvent.click(screen.getByText("trip connect"));
+    await waitFor(() => {
+      expect(screen.getByText("trip:connected")).toBeTruthy();
+    });
+
+    // Rider selects Off-Road → intent "race".
+    fireEvent.click(screen.getByText("trip toggle"));
+    await waitFor(() => {
+      expect(screen.getByText("trip-mode:race")).toBeTruthy();
+      expect(screen.getByText("trip-selection:race")).toBeTruthy();
+    });
+
+    // The EPAC enforcement write fails (bike out of range, GATT error, ...).
+    writeStateMock.mockRejectedValueOnce(new Error("BLE write failed"));
+
+    // Rider sets assist to 3 — enforcement is attempted but the write fails, so the
+    // bike stays in race.
+    await act(async () => {
+      notify?.({ mode: "race", assist: 3, light: false, region: "eu" });
+    });
+
+    // Rider sets assist back to 4 — the bike is still in race (the write failed).
+    await act(async () => {
+      notify?.({ mode: "race", assist: 4, light: false, region: "eu" });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("trip-assist:4")).toBeTruthy();
+    });
+
+    // The icon must reflect the bike's real mode (off-road), not a phantom EPAC.
+    // An over-eager intent reset (before the write is confirmed) would lie here.
+    expect(screen.getByText("trip-mode:race")).toBeTruthy();
+    expect(screen.getByText("trip-selection:race")).toBeTruthy();
+  });
 });

--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -218,16 +218,25 @@ function useSuper73Controller(
     cacheState(state);
     if (shouldTriggerEpac(state) && serverRef.current?.connected) {
       const epacState: Super73State = { ...state, mode: "eco" };
-      // EPAC enforcement overrides the bike mode to eco. Clear any stale trip-mode
-      // intent (e.g. "race") so the compact icon doesn't resurface as off-road once
-      // the rider moves assist away from the trigger level — without this reset the
-      // assist===3 branch in deriveTripModeSelection only masks the stale intent,
-      // which reappears at assist 4 while the mode legitimately stays eco. See #326.
-      setTripModeSelectionIntent("eco");
-      void writeState(serverRef.current, epacState).then(() => {
-        setBikeState(epacState);
-        cacheState(epacState);
-      });
+      void writeState(serverRef.current, epacState)
+        .then(() => {
+          setBikeState(epacState);
+          cacheState(epacState);
+          // Reset the stale trip-mode intent (e.g. "race") ONLY after the bike has
+          // confirmed eco. The assist===3 branch in deriveTripModeSelection masks the
+          // stale intent while assist stays at the trigger level; without this reset
+          // it would resurface as the off-road icon once assist returns to 4 even
+          // though the mode legitimately stays eco. Gating on write success is what
+          // keeps the icon honest: a *failed* write must leave the icon on the bike's
+          // real (still off-road) mode rather than claiming EPAC. See #326.
+          setTripModeSelectionIntent("eco");
+        })
+        .catch(() => {
+          // Write failed: leave bikeState and the trip-mode intent untouched so the
+          // icon keeps reflecting the bike's real mode. The bike is still at the
+          // trigger assist level with a non-eco mode, so the next notifier packet
+          // re-triggers EPAC enforcement.
+        });
     }
     if (isBleDebugEnabled() && !isPollActiveRef.current && serverRef.current?.connected) {
       isPollActiveRef.current = true;

--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -218,6 +218,12 @@ function useSuper73Controller(
     cacheState(state);
     if (shouldTriggerEpac(state) && serverRef.current?.connected) {
       const epacState: Super73State = { ...state, mode: "eco" };
+      // EPAC enforcement overrides the bike mode to eco. Clear any stale trip-mode
+      // intent (e.g. "race") so the compact icon doesn't resurface as off-road once
+      // the rider moves assist away from the trigger level — without this reset the
+      // assist===3 branch in deriveTripModeSelection only masks the stale intent,
+      // which reappears at assist 4 while the mode legitimately stays eco. See #326.
+      setTripModeSelectionIntent("eco");
       void writeState(serverRef.current, epacState).then(() => {
         setBikeState(epacState);
         cacheState(epacState);

--- a/client/src/hooks/useSuper73.ts
+++ b/client/src/hooks/useSuper73.ts
@@ -53,8 +53,12 @@ export function deriveTripModeSelection(
   tracking: Super73TrackingInput,
   currentSelection: Super73TripModeSelection | null = null,
 ): Super73TripModeSelection {
-  // Assist 3 = EPAC enforcement — auto mode doesn't apply
-  if (state?.assist === 3) return "eco";
+  // Assist 3 = EPAC enforcement — auto mode doesn't apply. The icon must stay
+  // honest: show off-road only while the bike actually reports race (e.g. the EPAC
+  // write is still pending or failed). Once enforcement lands (mode === eco) it
+  // shows EPAC. Don't blindly assume eco, or a failed write would claim EPAC while
+  // the bike is still in off-road for as long as assist stays at 3. See #326.
+  if (state?.assist === 3) return state.mode === "race" ? "race" : "eco";
   if (currentSelection === "auto")
     return tracking.isTracking ? "auto" : state?.mode === "race" ? "race" : "eco";
   if (currentSelection === "eco" || currentSelection === "race") return currentSelection;

--- a/client/src/lib/__tests__/super73-ble.test.ts
+++ b/client/src/lib/__tests__/super73-ble.test.ts
@@ -510,3 +510,82 @@ describe("writeState", () => {
     ]);
   });
 });
+
+// Regression for issue #326: Web Bluetooth rejects overlapping GATT operations and
+// rapid concurrent reads/writes (mode cycling + EPAC notifier write + auto-mode
+// effect) can destabilize the link and drop the connection. readState/writeState
+// must be funneled through a single FIFO queue so only one operation runs at a time.
+describe("GATT operation serialization", () => {
+  function makeGatedGATT(stateBytes: number[]) {
+    let active = 0;
+    let maxActive = 0;
+    // Each gated op holds the "GATT busy" slot until a real timer fires, so any
+    // overlap between concurrent operations is observable via maxActive.
+    const gate = () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      return new Promise<void>((resolve) =>
+        setTimeout(() => {
+          active -= 1;
+          resolve();
+        }, 0),
+      );
+    };
+
+    const registerIdChar = { writeValue: vi.fn().mockImplementation(gate) };
+    const registerChar = {
+      writeValue: vi.fn().mockImplementation(gate),
+      readValue: vi.fn().mockImplementation(async () => {
+        await gate();
+        return { buffer: new Uint8Array(stateBytes).buffer };
+      }),
+    };
+    const service = {
+      getCharacteristic: vi.fn().mockImplementation((uuid: string) => {
+        if (uuid === "00001564-1212-efde-1523-785feabcd123") return Promise.resolve(registerIdChar);
+        if (uuid === "0000155f-1212-efde-1523-785feabcd123") return Promise.resolve(registerChar);
+        return Promise.reject(new Error("Unknown char"));
+      }),
+    };
+    const server = {
+      connected: true,
+      getPrimaryService: vi.fn().mockResolvedValue(service),
+    } as unknown as BluetoothRemoteGATTServer;
+
+    return { server, getMaxActive: () => maxActive };
+  }
+
+  it("never runs two GATT operations concurrently across reads and writes", async () => {
+    const { server, getMaxActive } = makeGatedGATT([3, 0, 2, 0, 1, 6, 0, 0, 0, 0]);
+    const state: Super73State = { mode: "race", assist: 4, light: true, region: "eu" };
+
+    // Fire several operations at once — exactly the pattern that overloads the bike
+    // when the rider cycles modes while the notifier and auto-mode effect also write.
+    await Promise.all([
+      readState(server),
+      writeState(server, state),
+      readState(server),
+      writeState(server, state),
+    ]);
+
+    expect(getMaxActive()).toBe(1);
+  });
+
+  it("does not wedge the queue when one operation fails", async () => {
+    const failing = {
+      connected: true,
+      getPrimaryService: vi.fn().mockRejectedValue(new Error("GATT error")),
+    } as unknown as BluetoothRemoteGATTServer;
+
+    await expect(readState(failing)).rejects.toThrow();
+
+    // A subsequent healthy operation must still run.
+    const { server } = makeGatedGATT([3, 0, 2, 0, 1, 6, 0, 0, 0, 0]);
+    await expect(readState(server)).resolves.toEqual({
+      mode: "sport",
+      assist: 2,
+      light: true,
+      region: "eu",
+    });
+  });
+});

--- a/client/src/lib/super73-ble.ts
+++ b/client/src/lib/super73-ble.ts
@@ -176,24 +176,46 @@ async function getCharacteristics(server: BluetoothRemoteGATTServer) {
   return { registerIdChar, registerChar };
 }
 
+// Web Bluetooth rejects overlapping GATT operations ("GATT operation already in
+// progress") and rapid concurrent reads/writes can destabilize the link and drop
+// the connection. Mode cycling, the EPAC notifier write, and the auto-mode effect
+// can all issue operations at once, so every read/write is funneled through a single
+// FIFO queue to guarantee only one GATT operation runs at a time.
+let gattQueue: Promise<unknown> = Promise.resolve();
+
+function serializeGatt<T>(operation: () => Promise<T>): Promise<T> {
+  // Chain onto the queue regardless of whether the previous op resolved or rejected,
+  // so a single failed operation never wedges the queue for subsequent ones.
+  const result = gattQueue.then(operation, operation);
+  gattQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 export async function readState(
   server: BluetoothRemoteGATTServer,
   source = "poll",
 ): Promise<Super73State> {
-  const { registerIdChar, registerChar } = await getCharacteristics(server);
-  // Request state by writing [3, 0] to register ID
-  await withTimeout(registerIdChar.writeValue(new Uint8Array([3, 0])));
-  const value = await withTimeout(registerChar.readValue());
-  return parseStateBytes(new Uint8Array(value.buffer), source);
+  return serializeGatt(async () => {
+    const { registerIdChar, registerChar } = await getCharacteristics(server);
+    // Request state by writing [3, 0] to register ID
+    await withTimeout(registerIdChar.writeValue(new Uint8Array([3, 0])));
+    const value = await withTimeout(registerChar.readValue());
+    return parseStateBytes(new Uint8Array(value.buffer), source);
+  });
 }
 
 export async function writeState(
   server: BluetoothRemoteGATTServer,
   state: Super73State,
 ): Promise<void> {
-  const { registerChar } = await getCharacteristics(server);
-  const command = buildWriteCommand(state);
-  await withTimeout(registerChar.writeValue(command as unknown as BufferSource));
+  return serializeGatt(async () => {
+    const { registerChar } = await getCharacteristics(server);
+    const command = buildWriteCommand(state);
+    await withTimeout(registerChar.writeValue(command as unknown as BufferSource));
+  });
 }
 
 /**


### PR DESCRIPTION
## What

Fixes two connected-bike (Super73) bugs reported in #326, both triggered while cycling modes during a trip.

### 1. BLE disconnect when cycling modes
`readState`/`writeState` issued **overlapping GATT operations** — rapid mode cycling, compounded by the EPAC notifier write and the auto-mode effect, fired concurrent reads/writes. Web Bluetooth rejects overlapping GATT ops (`GATT operation already in progress`) and the load can drop the link.

**Fix:** every read/write is now funneled through a single FIFO queue (`serializeGatt`) so only one GATT operation runs at a time. The queue survives a failed op (no wedging).

### 2. Off-Road icon persisting after EPAC
Using the bike's assist-3 button forces EPAC (`eco`). The enforcement changed `bikeState.mode` to `eco` but **never cleared the stale `"race"` trip-mode intent**. While assist stayed at 3, `deriveTripModeSelection` masked it (assist===3 → eco). Once assist returned to 4, the stale `"race"` intent resurfaced → compact icon showed Off-Road (blue triangle) while the mode legitimately stayed EPAC.

**Fix:** EPAC enforcement now resets `tripModeSelectionIntent` to `"eco"`.

## Regression tests (fail before, pass after)

- `super73-ble.test.ts` — concurrent reads/writes never overlap (`maxActive === 1`); queue still runs after a failed op.
- `useSuper73.test.tsx` — selecting Off-Road, then assist 3 → 4, leaves the icon on EPAC (not Off-Road).

## Verification

- `bun run format:check` ✓
- `bun run lint` ✓ (0 errors; remaining warnings are pre-existing AdminPage/ProfilePage/TripPage complexity + react-refresh)
- `bun run typecheck` ✓ (server + client)
- `cd client && bunx vitest run` ✓ 295/295

## Note

Bug #1 (BLE disconnect) is fixed at its most probable root cause — unserialized GATT operations, a well-documented Web Bluetooth failure mode clearly present in this code. It could not be hardware-verified in this environment; the regression test proves operations are now serialized.

Closes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
