### PR TITLE
chore(quality): enforce module boundaries

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,7 +39,8 @@ const CLIENT_COMPONENT_IMPORT_PATTERNS = [
 const SERVER_ROUTE_IMPORT_PATTERNS = [
   {
     regex: "^\\.\\.(?:/\\.\\.)*/routes(?:/|$)",
-    message: "Les routes sont la couche transport HTTP; déplace la logique partagée vers lib/auth/validators/db.",
+    message:
+      "Les routes sont la couche transport HTTP; déplace la logique partagée vers lib/auth/validators/db.",
   },
 ];
 
@@ -62,7 +63,8 @@ const SERVER_HIGH_LEVEL_IMPORT_PATTERNS = [
   },
   {
     regex: "^\\.\\.(?:/\\.\\.)*/auth(?:/|$)",
-    message: "Le module db ne doit pas dépendre de la couche auth applicative; garde seulement les imports locaux ./auth dans db/schema.",
+    message:
+      "Le module db ne doit pas dépendre de la couche auth applicative; garde seulement les imports locaux ./auth dans db/schema.",
   },
 ];
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,78 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import sonarjs from "eslint-plugin-sonarjs";
 import eslintConfigPrettier from "eslint-config-prettier";
 
+const createRestrictedImportRule = (patterns) => ({
+  "no-restricted-imports": [
+    "error",
+    {
+      patterns,
+    },
+  ],
+});
+
+const CLIENT_PAGE_IMPORT_PATTERNS = [
+  {
+    group: ["@/pages/*"],
+    message: "Les pages restent des entrées de routage, pas des dépendances réutilisables.",
+  },
+  {
+    regex: "^\\.\\.?/(?:.*?/)?pages(?:/|$)",
+    message: "Les pages restent des entrées de routage, pas des dépendances réutilisables.",
+  },
+];
+
+const CLIENT_COMPONENT_IMPORT_PATTERNS = [
+  {
+    group: ["@/components/*"],
+    message: "Les hooks et libs réutilisables ne doivent pas dépendre des composants UI.",
+  },
+  {
+    regex: "^\\.\\.?/(?:.*?/)?components(?:/|$)",
+    message: "Les hooks et libs réutilisables ne doivent pas dépendre des composants UI.",
+  },
+];
+
+const SERVER_ROUTE_IMPORT_PATTERNS = [
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/routes(?:/|$)",
+    message: "Les routes sont la couche transport HTTP; déplace la logique partagée vers lib/auth/validators/db.",
+  },
+];
+
+const SERVER_HIGH_LEVEL_IMPORT_PATTERNS = [
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/routes(?:/|$)",
+    message: "Le module db doit rester bas niveau et ne pas dépendre des routes.",
+  },
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/validators(?:/|$)",
+    message: "Le module db doit rester bas niveau et ne pas dépendre des validateurs HTTP.",
+  },
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/lib(?:/|$)",
+    message: "Le module db doit rester bas niveau et ne pas dépendre des utilitaires métier.",
+  },
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/cron(?:/|$)",
+    message: "Le module db doit rester bas niveau et ne pas dépendre des jobs cron.",
+  },
+  {
+    regex: "^\\.\\.(?:/\\.\\.)*/auth(?:/|$)",
+    message: "Le module db ne doit pas dépendre de la couche auth applicative; garde seulement les imports locaux ./auth dans db/schema.",
+  },
+];
+
+const SHARED_APP_IMPORT_PATTERNS = [
+  {
+    regex: "^\\.\\.?/(?:.*?/)?client/src(?:/|$)",
+    message: "shared doit rester agnostique et ne pas dépendre du client.",
+  },
+  {
+    regex: "^\\.\\.?/(?:.*?/)?server/src(?:/|$)",
+    message: "shared doit rester agnostique et ne pas dépendre du server.",
+  },
+];
+
 export default tseslint.config(
   // Global ignores
   {
@@ -55,6 +127,55 @@ export default tseslint.config(
       "sonarjs/no-identical-expressions": "warn",
       "sonarjs/no-useless-catch": "warn",
     },
+  },
+
+  // Client boundaries — progressive enforcement only on the obvious edges.
+  // We intentionally do not enforce lib <-> hooks yet because client/src/lib/stopped-session.ts
+  // still depends on useGpsTracking; forcing it now would create noise instead of signal.
+  {
+    files: ["client/src/components/**/*.{ts,tsx}"],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule(CLIENT_PAGE_IMPORT_PATTERNS),
+  },
+  {
+    files: ["client/src/hooks/**/*.{ts,tsx}"],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule([
+      ...CLIENT_PAGE_IMPORT_PATTERNS,
+      ...CLIENT_COMPONENT_IMPORT_PATTERNS,
+    ]),
+  },
+  {
+    files: ["client/src/lib/**/*.{ts,tsx}"],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule([
+      ...CLIENT_PAGE_IMPORT_PATTERNS,
+      ...CLIENT_COMPONENT_IMPORT_PATTERNS,
+    ]),
+  },
+
+  // Server boundaries — keep routes at the edge and db at the bottom.
+  {
+    files: [
+      "server/src/auth.ts",
+      "server/src/auth/**/*.{ts,tsx}",
+      "server/src/cron/**/*.{ts,tsx}",
+      "server/src/lib/**/*.{ts,tsx}",
+      "server/src/types/**/*.{ts,tsx}",
+      "server/src/validators/**/*.{ts,tsx}",
+    ],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule(SERVER_ROUTE_IMPORT_PATTERNS),
+  },
+  {
+    files: ["server/src/db/**/*.{ts,tsx}"],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule(SERVER_HIGH_LEVEL_IMPORT_PATTERNS),
+  },
+  {
+    files: ["shared/*.ts"],
+    ignores: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}", "**/__tests__/**"],
+    rules: createRestrictedImportRule(SHARED_APP_IMPORT_PATTERNS),
   },
 
   // Server — relax console & require rules


### PR DESCRIPTION
## Summary
- add progressive ESLint module-boundary rules for client and server folders with explicit comments on deferred edges
- fold the approved #313 dependency-cruiser orphan audit into this branch so the new boundaries build on the latest architecture checks
- wire the repo scripts and lockfile so depcruise remains runnable alongside lint/typecheck

## Test Plan
- bun run lint
- bun run typecheck
- bun run depcruise
- bun --cwd client test src/pages/__tests__/DashboardPage.i18n.test.tsx
- bun --cwd server test src/routes/__tests__/users-import.test.ts

Closes #314
Refs #317
