### PR TITLE
fix(super73): show compact light state

### DIFF
--- a/client/src/components/Super73ModeButton.tsx
+++ b/client/src/components/Super73ModeButton.tsx
@@ -1,4 +1,4 @@
-import { BluetoothOff, Loader2, Star } from "lucide-react";
+import { BluetoothOff, Loader2, Star, Sun, SunDim } from "lucide-react";
 import { useSuper73, type BleStatus, type Super73TripModeSelection } from "@/hooks/useSuper73";
 import { useT } from "@/i18n/provider";
 
@@ -104,14 +104,34 @@ export function Super73ModeButton({ enabled, compact = false }: Props) {
         : selection === "race"
           ? t("super73.compact.modeOffRoad")
           : t("super73.compact.modeEpac");
+    const lightLabel = ble.bikeState
+      ? ble.bikeState.light
+        ? t("super73.compact.lightOn")
+        : t("super73.compact.lightOff")
+      : null;
+    const compactAriaLabel = lightLabel ? `${labelBySelection} · ${lightLabel}` : labelBySelection;
 
     return (
       <button
         onClick={() => void ble.cycleTripModeSelection()}
-        className={`${compactBaseClass} ${compactClassBySelection}`}
-        aria-label={labelBySelection}
+        className={`relative ${compactBaseClass} ${compactClassBySelection}`}
+        aria-label={compactAriaLabel}
       >
         <CompactModeIcon selection={selection} />
+        {ble.bikeState && (
+          <span
+            data-testid="super73-light-state-icon"
+            data-state={ble.bikeState.light ? "on" : "off"}
+            className={`absolute bottom-1.5 right-1.5 flex h-5 w-5 items-center justify-center rounded-full border ${
+              ble.bikeState.light
+                ? "border-primary/30 bg-primary/15 text-primary-light"
+                : "border-surface-highest bg-surface-container text-text-muted"
+            }`}
+            aria-hidden="true"
+          >
+            {ble.bikeState.light ? <Sun size={12} /> : <SunDim size={12} />}
+          </span>
+        )}
       </button>
     );
   }

--- a/client/src/components/__tests__/Super73ModeButton.test.tsx
+++ b/client/src/components/__tests__/Super73ModeButton.test.tsx
@@ -42,7 +42,7 @@ describe("Super73ModeButton compact", () => {
     expect(button.className).toContain("self-stretch");
   });
 
-  it("renders the EPAC icon state", () => {
+  it("renders the EPAC icon state with the real light status", () => {
     useSuper73Mock.mockReturnValue({
       status: "connected",
       bikeState: { mode: "eco", assist: 2, light: false, region: "eu" },
@@ -59,7 +59,8 @@ describe("Super73ModeButton compact", () => {
 
     renderWithI18n(<Super73ModeButton enabled compact />);
 
-    expect(screen.getByRole("button", { name: "Mode EPAC" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Mode EPAC · Phare éteint" })).toBeTruthy();
+    expect(screen.getByTestId("super73-light-state-icon").getAttribute("data-state")).toBe("off");
   });
 
   it("renders the Off-Road icon state", () => {
@@ -79,7 +80,7 @@ describe("Super73ModeButton compact", () => {
 
     renderWithI18n(<Super73ModeButton enabled compact />);
 
-    expect(screen.getByRole("button", { name: "Mode Off-Road" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Mode Off-Road · Phare éteint" })).toBeTruthy();
   });
 
   it("renders the Auto icon state", () => {
@@ -99,6 +100,6 @@ describe("Super73ModeButton compact", () => {
 
     renderWithI18n(<Super73ModeButton enabled compact />);
 
-    expect(screen.getByRole("button", { name: "Mode Auto" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Mode Auto · Phare éteint" })).toBeTruthy();
   });
 });

--- a/client/src/components/__tests__/Super73ModeButton.test.tsx
+++ b/client/src/components/__tests__/Super73ModeButton.test.tsx
@@ -59,8 +59,62 @@ describe("Super73ModeButton compact", () => {
 
     renderWithI18n(<Super73ModeButton enabled compact />);
 
-    expect(screen.getByRole("button", { name: "Mode EPAC · Phare éteint" })).toBeTruthy();
-    expect(screen.getByTestId("super73-light-state-icon").getAttribute("data-state")).toBe("off");
+    const button = screen.getByRole("button", { name: "Mode EPAC · Phare éteint" });
+    const lightIcon = screen.getByTestId("super73-light-state-icon");
+    const lightSvg = lightIcon.querySelector("svg");
+
+    expect(button).toBeTruthy();
+    expect(lightIcon.getAttribute("data-state")).toBe("off");
+    expect(lightSvg?.getAttribute("class")).toContain("lucide-sun-dim");
+  });
+
+  it("renders the light-on state with the accessible label and sun icon", () => {
+    useSuper73Mock.mockReturnValue({
+      status: "connected",
+      bikeState: { mode: "eco", assist: 2, light: true, region: "eu" },
+      error: null,
+      tripModeSelection: "eco",
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      setMode: vi.fn(),
+      setAssist: vi.fn(),
+      setLight: vi.fn(),
+      toggleMode: vi.fn(),
+      cycleTripModeSelection: vi.fn(),
+    });
+
+    renderWithI18n(<Super73ModeButton enabled compact />);
+
+    const button = screen.getByRole("button", { name: "Mode EPAC · Phare allumé" });
+    const lightIcon = screen.getByTestId("super73-light-state-icon");
+    const lightSvg = lightIcon.querySelector("svg");
+
+    expect(button).toBeTruthy();
+    expect(lightIcon.getAttribute("data-state")).toBe("on");
+    expect(lightSvg?.getAttribute("class")).toContain("lucide-sun");
+    expect(lightSvg?.querySelectorAll("circle")).toHaveLength(1);
+    expect(lightSvg?.querySelectorAll("path")).toHaveLength(8);
+  });
+
+  it("falls back to the mode label when bikeState is unavailable", () => {
+    useSuper73Mock.mockReturnValue({
+      status: "connected",
+      bikeState: null,
+      error: null,
+      tripModeSelection: "eco",
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      setMode: vi.fn(),
+      setAssist: vi.fn(),
+      setLight: vi.fn(),
+      toggleMode: vi.fn(),
+      cycleTripModeSelection: vi.fn(),
+    });
+
+    renderWithI18n(<Super73ModeButton enabled compact />);
+
+    expect(screen.getByRole("button", { name: "Mode EPAC" })).toBeTruthy();
+    expect(screen.queryByTestId("super73-light-state-icon")).toBeNull();
   });
 
   it("renders the Off-Road icon state", () => {

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -518,6 +518,8 @@ export const en: Record<TranslationKey, string> = {
   "super73.compact.modeAuto": "Auto mode",
   "super73.compact.modeEpac": "EPAC mode",
   "super73.compact.modeOffRoad": "Off-Road mode",
+  "super73.compact.lightOn": "Headlight on",
+  "super73.compact.lightOff": "Headlight off",
   "super73.full.connected": "Connected",
   "super73.full.connecting": "Connecting…",
   "super73.full.error": "Error",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -521,6 +521,8 @@ export const fr = {
   "super73.compact.modeAuto": "Mode Auto",
   "super73.compact.modeEpac": "Mode EPAC",
   "super73.compact.modeOffRoad": "Mode Off-Road",
+  "super73.compact.lightOn": "Phare allumé",
+  "super73.compact.lightOff": "Phare éteint",
   "super73.full.connected": "Connecté",
   "super73.full.connecting": "Connexion...",
   "super73.full.error": "Erreur",


### PR DESCRIPTION
Fixes #329

Adds compact Super73 light on/off indication when the connected bike state exposes real light data, including accessible labels and regression coverage.

Kanban follow-up tests: t_1425de90.

Validation:
- targeted Super73ModeButton tests passed
- client typecheck passed
- full client Vitest suite passed