### PR TITLE
chore(test): expand risky coverage scope

### DIFF
--- a/client/src/hooks/queries/__tests__/admin.test.tsx
+++ b/client/src/hooks/queries/__tests__/admin.test.tsx
@@ -1,0 +1,269 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import {
+  useAdminHealth,
+  useAdminStats,
+  useGrantAdmin,
+  useRevokeAdmin,
+  useGrantSuper73Access,
+  useRevokeSuper73Access,
+  useDeleteAdminUser,
+  useAdminNotifications,
+  useSendAdminNotification,
+  useAdminAuditLogs,
+  useTriggerDeploy,
+  useActiveAnnouncement,
+  useAdminAnnouncements,
+  useCreateAnnouncement,
+  useDeleteAnnouncement,
+} from "../admin";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, invalidateQueriesSpy };
+}
+
+describe("admin queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useAdminHealth", () => {
+    it("fetches /admin/health and unwraps data", async () => {
+      const data = { version: "1.0", dbConnected: true };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminHealth(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/health");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+
+  describe("useAdminStats", () => {
+    it("fetches /admin/stats and unwraps data", async () => {
+      const data = { users: [], recentTrips: [], dailyTripCounts: [] };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminStats(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/stats");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+
+  describe("admin user access mutations", () => {
+    const cases = [
+      { name: "useGrantAdmin", hook: useGrantAdmin, url: "/admin/users/grant" },
+      { name: "useRevokeAdmin", hook: useRevokeAdmin, url: "/admin/users/revoke" },
+      {
+        name: "useGrantSuper73Access",
+        hook: useGrantSuper73Access,
+        url: "/admin/users/super73/grant",
+      },
+      {
+        name: "useRevokeSuper73Access",
+        hook: useRevokeSuper73Access,
+        url: "/admin/users/super73/revoke",
+      },
+    ] as const;
+
+    for (const { name, hook, url } of cases) {
+      it(`${name} POSTs to ${url} and invalidates admin stats`, async () => {
+        mockApiFetch.mockResolvedValue({ ok: true, data: { success: true } });
+        const { wrapper, invalidateQueriesSpy } = setup();
+
+        const { result } = renderHook(() => hook(), { wrapper });
+        const res = await result.current.mutateAsync({ userId: "u1" } as never);
+
+        expect(res).toEqual({ success: true });
+        expect(mockApiFetch).toHaveBeenCalledWith(url, {
+          method: "POST",
+          body: JSON.stringify({ userId: "u1" }),
+        });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["admin", "stats"] });
+      });
+    }
+  });
+
+  describe("useDeleteAdminUser", () => {
+    it("POSTs to /admin/users/delete and invalidates stats + audit logs", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: { deleted: true } });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useDeleteAdminUser(), { wrapper });
+      await result.current.mutateAsync({ userId: "u1" } as never);
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/users/delete", {
+        method: "POST",
+        body: JSON.stringify({ userId: "u1" }),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["admin", "stats"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["admin", "audit-logs"],
+      });
+    });
+  });
+
+  describe("useAdminNotifications", () => {
+    it("fetches /admin/notifications and unwraps data.notifications", async () => {
+      const notifications = [{ id: "n1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { notifications } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminNotifications(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/notifications");
+      expect(result.current.data).toEqual(notifications);
+    });
+  });
+
+  describe("useSendAdminNotification", () => {
+    it("POSTs a notification and invalidates notifications", async () => {
+      const data = { sent: 5, failed: 0, notificationId: "n1" };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useSendAdminNotification(), { wrapper });
+      const payload = { title: "Hi", body: "There" };
+      const res = await result.current.mutateAsync(payload);
+
+      expect(res).toEqual(data);
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/notifications", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["admin", "notifications"],
+      });
+    });
+  });
+
+  describe("useAdminAuditLogs", () => {
+    it("fetches without query string when no filters", async () => {
+      const auditLogs = [{ id: "a1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { auditLogs } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminAuditLogs(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/audit-logs");
+      expect(result.current.data).toEqual(auditLogs);
+    });
+
+    it("builds a query string from filters", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: { auditLogs: [] } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminAuditLogs({ userId: "u1", action: "delete" }), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/audit-logs?userId=u1&action=delete");
+    });
+  });
+
+  describe("useTriggerDeploy", () => {
+    it("POSTs to /admin/deploy", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useTriggerDeploy(), { wrapper });
+      await result.current.mutateAsync();
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/deploy", { method: "POST" });
+    });
+  });
+
+  describe("useActiveAnnouncement", () => {
+    it("fetches /announcements/active and unwraps the announcement", async () => {
+      const announcement = { id: "x1", title: "Hi" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { announcement } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useActiveAnnouncement(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/announcements/active");
+      expect(result.current.data).toEqual(announcement);
+    });
+  });
+
+  describe("useAdminAnnouncements", () => {
+    it("fetches /admin/announcements and unwraps data.announcements", async () => {
+      const announcements = [{ id: "x1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { announcements } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAdminAnnouncements(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/announcements");
+      expect(result.current.data).toEqual(announcements);
+    });
+  });
+
+  describe("useCreateAnnouncement", () => {
+    it("POSTs and invalidates admin announcements + active announcement", async () => {
+      const announcement = { id: "x1", title: "Hi" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { announcement } });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useCreateAnnouncement(), { wrapper });
+      const payload = { title: "Hi", body: "B" };
+      const res = await result.current.mutateAsync(payload);
+
+      expect(res).toEqual(announcement);
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/announcements", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["admin", "announcements"],
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["announcement", "active"],
+      });
+    });
+  });
+
+  describe("useDeleteAnnouncement", () => {
+    it("DELETEs and invalidates admin announcements + active announcement", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useDeleteAnnouncement(), { wrapper });
+      await result.current.mutateAsync("x1");
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/admin/announcements/x1", {
+        method: "DELETE",
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["admin", "announcements"],
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["announcement", "active"],
+      });
+    });
+  });
+});

--- a/client/src/hooks/queries/__tests__/feedback.test.tsx
+++ b/client/src/hooks/queries/__tests__/feedback.test.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import { useSubmitFeedback } from "../feedback";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe("feedback queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useSubmitFeedback", () => {
+    it("POSTs to /feedback and unwraps data", async () => {
+      const data = { issueNumber: 42, issueUrl: "https://example.com/42" };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useSubmitFeedback(), { wrapper });
+      const payload = {
+        type: "bug" as const,
+        title: "Crash",
+        description: "It crashes",
+      };
+      const res = await result.current.mutateAsync(payload);
+
+      expect(res).toEqual(data);
+      expect(mockApiFetch).toHaveBeenCalledWith("/feedback", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    });
+  });
+});

--- a/client/src/hooks/queries/__tests__/stats.test.tsx
+++ b/client/src/hooks/queries/__tests__/stats.test.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import {
+  useDashboardSummary,
+  useChartTrips,
+  useCommunityStats,
+  useCommunityTimeline,
+  useLeaderboard,
+  useAchievements,
+  useFuelPrice,
+} from "../stats";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe("stats queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useDashboardSummary", () => {
+    it("fetches the summary with the default week period", async () => {
+      const data = { totalDistanceKm: 10 };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useDashboardSummary(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/stats/summary?period=week");
+      expect(result.current.data).toEqual(data);
+    });
+
+    it("uses the provided period", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: {} });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useDashboardSummary("month"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/stats/summary?period=month");
+    });
+  });
+
+  describe("useChartTrips", () => {
+    it("fetches trips within the computed date range and unwraps trips", async () => {
+      const trips = [{ id: "t1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trips } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useChartTrips("week"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(trips);
+      const url = mockApiFetch.mock.calls[0]![0] as string;
+      expect(url).toContain("/trips?from=");
+      expect(url).toContain("&to=");
+      expect(url).toContain("&limit=100");
+    });
+
+    it("computes a month range", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trips: [] } });
+      const { wrapper } = setup();
+      const { result } = renderHook(() => useChartTrips("month"), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalled();
+    });
+
+    it("computes a year range", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trips: [] } });
+      const { wrapper } = setup();
+      const { result } = renderHook(() => useChartTrips("year"), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("useCommunityStats", () => {
+    it("fetches community stats with default all period", async () => {
+      const data = { totalCo2: 100 };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useCommunityStats(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/stats/community?period=all");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+
+  describe("useCommunityTimeline", () => {
+    it("fetches the timeline with default period+category", async () => {
+      const data = { points: [] };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useCommunityTimeline(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/stats/community/timeline?period=all&category=co2",
+      );
+      expect(result.current.data).toEqual(data);
+    });
+
+    it("passes through period and category", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: {} });
+      const { wrapper } = setup();
+      const { result } = renderHook(() => useCommunityTimeline("week", "trips"), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/stats/community/timeline?period=week&category=trips",
+      );
+    });
+  });
+
+  describe("useLeaderboard", () => {
+    it("fetches the leaderboard and unwraps data", async () => {
+      const data = { entries: [], userRank: null };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useLeaderboard("month", "speed"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/stats/leaderboard?period=month&category=speed");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+
+  describe("useAchievements", () => {
+    it("fetches achievements and unwraps data.achievements", async () => {
+      const achievements = [{ id: "a1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { achievements } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAchievements(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/achievements");
+      expect(result.current.data).toEqual(achievements);
+    });
+  });
+
+  describe("useFuelPrice", () => {
+    it("fetches the fuel price for the given type", async () => {
+      const data = { priceEur: 1.8, fuelType: "diesel", updatedAt: "now" };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useFuelPrice("diesel"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/fuel-price?type=diesel");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+});

--- a/client/src/hooks/queries/__tests__/trips.test.tsx
+++ b/client/src/hooks/queries/__tests__/trips.test.tsx
@@ -1,0 +1,171 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import {
+  useTrip,
+  useTripPresets,
+  useTrips,
+  useCreateTrip,
+  useCreateTripPresetFromTrip,
+  useDeleteTripPreset,
+  useDeleteTrip,
+} from "../trips";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper, invalidateQueriesSpy, setQueryDataSpy };
+}
+
+describe("trips queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useTrip", () => {
+    it("fetches a trip and unwraps data.trip", async () => {
+      const trip = { id: "t1" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trip } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useTrip("t1"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/trips/t1");
+      expect(result.current.data).toEqual(trip);
+    });
+
+    it("does not fetch when tripId is null", () => {
+      const { wrapper } = setup();
+      renderHook(() => useTrip(null), { wrapper });
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("useTripPresets", () => {
+    it("fetches presets and unwraps data.tripPresets", async () => {
+      const tripPresets = [{ id: "p1" }];
+      mockApiFetch.mockResolvedValue({ ok: true, data: { tripPresets } });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useTripPresets(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/trip-presets");
+      expect(result.current.data).toEqual(tripPresets);
+    });
+  });
+
+  describe("useTrips", () => {
+    it("fetches trips with pagination params and unwraps trips + pagination", async () => {
+      const trips = [{ id: "t1" }];
+      const pagination = { page: 2, limit: 10, total: 1, totalPages: 1 };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trips }, pagination });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useTrips(2, 10), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/trips?page=2&limit=10");
+      expect(result.current.data).toEqual({ trips, pagination });
+    });
+
+    it("defaults to page 1 limit 50", async () => {
+      mockApiFetch.mockResolvedValue({
+        ok: true,
+        data: { trips: [] },
+        pagination: { page: 1, limit: 50, total: 0, totalPages: 0 },
+      });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useTrips(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/trips?page=1&limit=50");
+    });
+  });
+
+  describe("useCreateTrip", () => {
+    it("POSTs and invalidates trips/stats/achievements/profile", async () => {
+      const trip = { id: "t1" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { trip } });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useCreateTrip(), { wrapper });
+      const created = await result.current.mutateAsync({ distanceKm: 5 } as never);
+
+      expect(created).toEqual(trip);
+      expect(mockApiFetch).toHaveBeenCalledWith("/trips", {
+        method: "POST",
+        body: JSON.stringify({ distanceKm: 5 }),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["stats"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["achievements"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["profile"] });
+    });
+  });
+
+  describe("useCreateTripPresetFromTrip", () => {
+    it("POSTs to from-trip URL and prepends preset to cache", async () => {
+      const tripPreset = { id: "np", label: "new" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { tripPreset } });
+      const { wrapper, queryClient, invalidateQueriesSpy } = setup();
+      queryClient.setQueryData(["trip-presets"], [{ id: "existing" }]);
+
+      const { result } = renderHook(() => useCreateTripPresetFromTrip(), { wrapper });
+      await result.current.mutateAsync({ tripId: "t1", label: "new" } as never);
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/trip-presets/from-trip/t1", {
+        method: "POST",
+        body: JSON.stringify({ label: "new" }),
+      });
+      expect(queryClient.getQueryData(["trip-presets"])).toEqual([tripPreset, { id: "existing" }]);
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["trip-presets"] });
+    });
+  });
+
+  describe("useDeleteTripPreset", () => {
+    it("DELETEs and removes the preset from cache", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true });
+      const { wrapper, queryClient, invalidateQueriesSpy } = setup();
+      queryClient.setQueryData(["trip-presets"], [{ id: "p1" }, { id: "p2" }]);
+
+      const { result } = renderHook(() => useDeleteTripPreset(), { wrapper });
+      await result.current.mutateAsync("p1");
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/trip-presets/p1", { method: "DELETE" });
+      expect(queryClient.getQueryData(["trip-presets"])).toEqual([{ id: "p2" }]);
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["trip-presets"] });
+    });
+  });
+
+  describe("useDeleteTrip", () => {
+    it("DELETEs and invalidates trips/stats/leaderboard/profile/achievements", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useDeleteTrip(), { wrapper });
+      await result.current.mutateAsync("t1");
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/trips/t1", { method: "DELETE" });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["trips"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["stats"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["leaderboard"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["profile"] });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["achievements"] });
+    });
+  });
+});

--- a/client/src/hooks/queries/__tests__/user.test.tsx
+++ b/client/src/hooks/queries/__tests__/user.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import {
+  useProfile,
+  useUpdateProfile,
+  useDeleteAccount,
+  useExportData,
+  useImportData,
+} from "../user";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper, invalidateQueriesSpy };
+}
+
+describe("user queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useProfile", () => {
+    it("fetches /user/profile and unwraps data", async () => {
+      const data = { user: { id: "u1" }, stats: { tripCount: 3 } };
+      mockApiFetch.mockResolvedValue({ ok: true, data });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useProfile(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockApiFetch).toHaveBeenCalledWith("/user/profile");
+      expect(result.current.data).toEqual(data);
+    });
+  });
+
+  describe("useUpdateProfile", () => {
+    it("PATCHes /user/profile and invalidates profile", async () => {
+      const user = { id: "u1", name: "New" };
+      mockApiFetch.mockResolvedValue({ ok: true, data: { user } });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+      const updated = await result.current.mutateAsync({ name: "New" } as never);
+
+      expect(updated).toEqual(user);
+      expect(mockApiFetch).toHaveBeenCalledWith("/user/profile", {
+        method: "PATCH",
+        body: JSON.stringify({ name: "New" }),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["profile"] });
+    });
+  });
+
+  describe("useDeleteAccount", () => {
+    it("DELETEs /user/profile", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+      await result.current.mutateAsync();
+
+      expect(mockApiFetch).toHaveBeenCalledWith("/user/profile", { method: "DELETE" });
+    });
+  });
+
+  describe("useExportData", () => {
+    it("fetches the export blob and triggers a download", async () => {
+      const blob = new Blob(["{}"], { type: "application/json" });
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(blob),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const createObjectURL = vi.fn().mockReturnValue("blob:url");
+      const revokeObjectURL = vi.fn();
+      vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+      const { wrapper } = setup();
+      const { result } = renderHook(() => useExportData(), { wrapper });
+      await result.current.mutateAsync();
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/user/export", { credentials: "include" });
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:url");
+
+      clickSpy.mockRestore();
+      vi.unstubAllGlobals();
+    });
+
+    it("throws when the export response is not ok", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { wrapper } = setup();
+      const { result } = renderHook(() => useExportData(), { wrapper });
+
+      await expect(result.current.mutateAsync()).rejects.toThrow("Export failed");
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("useImportData", () => {
+    it("parses the file, POSTs trips and invalidates caches", async () => {
+      mockApiFetch.mockResolvedValue({ ok: true, data: { imported: 2, skipped: 1 } });
+      const { wrapper, invalidateQueriesSpy } = setup();
+
+      const file = new File([JSON.stringify({ trips: [{ id: "t1" }] })], "export.json", {
+        type: "application/json",
+      });
+
+      const { result } = renderHook(() => useImportData(), { wrapper });
+      const res = await result.current.mutateAsync(file);
+
+      expect(res).toEqual({ imported: 2, skipped: 1 });
+      expect(mockApiFetch).toHaveBeenCalledWith("/user/import", {
+        method: "POST",
+        body: JSON.stringify({ trips: [{ id: "t1" }] }),
+      });
+      for (const key of ["profile", "trips", "achievements", "stats", "leaderboard"]) {
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: [key] });
+      }
+    });
+
+    it("rejects invalid JSON", async () => {
+      const { wrapper } = setup();
+      const file = new File(["not json"], "bad.json");
+      const { result } = renderHook(() => useImportData(), { wrapper });
+
+      await expect(result.current.mutateAsync(file)).rejects.toThrow("Fichier JSON invalide");
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects an export without a trips array", async () => {
+      const { wrapper } = setup();
+      const file = new File([JSON.stringify({ foo: 1 })], "bad.json");
+      const { result } = renderHook(() => useImportData(), { wrapper });
+
+      await expect(result.current.mutateAsync(file)).rejects.toThrow("Format d'export non reconnu");
+      expect(mockApiFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -17,12 +17,16 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],
-      include: ["src/lib/**"],
+      // Risk surfaces: pure logic (lib) and stateful hooks incl. the React
+      // Query data layer (hooks). View-only pages/components are left out for
+      // now — they are exercised by Playwright e2e, and including them would
+      // force artificially low thresholds dominated by untested JSX branches.
+      include: ["src/lib/**", "src/hooks/**"],
       thresholds: {
-        statements: 55,
-        branches: 50,
-        functions: 65,
-        lines: 58,
+        statements: 70,
+        branches: 60,
+        functions: 76,
+        lines: 72,
       },
     },
   },

--- a/server/src/routes/__tests__/push.test.ts
+++ b/server/src/routes/__tests__/push.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../../types/context";
+
+// vi.hoisted ensures these are initialized before the vi.mock factories run.
+const mocks = vi.hoisted(() => {
+  // Controllable result of db.select()...where() — tests mutate `.value`.
+  const selectResult = { value: [] as unknown[] };
+
+  const mockSelectWhere = vi.fn(() => Promise.resolve(selectResult.value));
+  const mockSelect = vi.fn(() => ({
+    from: () => ({ where: mockSelectWhere }),
+  }));
+
+  const mockUpdateWhere = vi.fn(() => Promise.resolve(undefined));
+  const mockUpdate = vi.fn(() => ({
+    set: () => ({ where: mockUpdateWhere }),
+  }));
+
+  const mockDeleteWhere = vi.fn(() => Promise.resolve(undefined));
+  const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+
+  const mockInsertReturning = vi.fn(() => Promise.resolve([{ id: "new-sub-id" }]));
+  const mockInsert = vi.fn(() => ({
+    values: () => ({ returning: mockInsertReturning }),
+  }));
+
+  const mockSendPushToUser = vi.fn(() => Promise.resolve(3));
+
+  return {
+    selectResult,
+    mockSelect,
+    mockSelectWhere,
+    mockUpdate,
+    mockUpdateWhere,
+    mockDelete,
+    mockDeleteWhere,
+    mockInsert,
+    mockInsertReturning,
+    mockSendPushToUser,
+  };
+});
+
+vi.mock("../../db", () => ({
+  db: {
+    select: mocks.mockSelect,
+    update: mocks.mockUpdate,
+    delete: mocks.mockDelete,
+    insert: mocks.mockInsert,
+  },
+}));
+
+vi.mock("../../db/schema", () => ({
+  pushSubscriptions: {
+    id: "id",
+    userId: "userId",
+    endpoint: "endpoint",
+    p256dh: "p256dh",
+    auth: "auth",
+  },
+}));
+
+vi.mock("../../env", () => ({
+  env: { VAPID_PUBLIC_KEY: "test-public-vapid-key" },
+}));
+
+vi.mock("../../lib/push", () => ({
+  sendPushToUser: mocks.mockSendPushToUser,
+}));
+
+import { pushRouter } from "../push.routes";
+
+function buildApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", {
+      id: "user-1",
+      name: "Lyra",
+      email: "lyra@example.com",
+    } as AuthEnv["Variables"]["user"]);
+    c.set("requestId", "req-push-1");
+    await next();
+  });
+  app.route("/push", pushRouter);
+  return app;
+}
+
+const validSubscribePayload = {
+  endpoint: "https://push.example.com/sub/abc",
+  keys: { p256dh: "p256dh-key", auth: "auth-key" },
+};
+
+describe("push routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectResult.value = [];
+    mocks.mockInsertReturning.mockResolvedValue([{ id: "new-sub-id" }]);
+    mocks.mockSendPushToUser.mockResolvedValue(3);
+  });
+
+  describe("GET /push/vapid-key", () => {
+    it("returns the public VAPID key", async () => {
+      const res = await buildApp().request("/push/vapid-key");
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        data: { publicKey: "test-public-vapid-key" },
+      });
+    });
+  });
+
+  describe("POST /push/subscribe", () => {
+    it("inserts a new subscription when none exists for the endpoint", async () => {
+      mocks.selectResult.value = [];
+
+      const res = await buildApp().request("/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validSubscribePayload),
+      });
+
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({
+        ok: true,
+        data: { subscriptionId: "new-sub-id" },
+      });
+      // New-endpoint path: stale subs deleted, then insert.
+      expect(mocks.mockDelete).toHaveBeenCalledTimes(1);
+      expect(mocks.mockInsert).toHaveBeenCalledTimes(1);
+      expect(mocks.mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("updates keys when a subscription already exists for the endpoint", async () => {
+      mocks.selectResult.value = [{ id: "existing-sub-id" }];
+
+      const res = await buildApp().request("/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validSubscribePayload),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        data: { subscriptionId: "existing-sub-id" },
+      });
+      // Existing path: update only, no insert, no stale delete.
+      expect(mocks.mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mocks.mockInsert).not.toHaveBeenCalled();
+      expect(mocks.mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid payload (bad endpoint url)", async () => {
+      const res = await buildApp().request("/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: "not-a-url", keys: { p256dh: "a", auth: "b" } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(mocks.mockSelect).not.toHaveBeenCalled();
+      expect(mocks.mockInsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /push/subscribe", () => {
+    it("deletes the subscription for the given endpoint", async () => {
+      const res = await buildApp().request("/push/subscribe", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: "https://push.example.com/sub/abc" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, data: null });
+      expect(mocks.mockDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects an invalid unsubscribe payload", async () => {
+      const res = await buildApp().request("/push/subscribe", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: "nope" }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(mocks.mockDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /push/test", () => {
+    it("sends a test notification to the current user and returns the sent count", async () => {
+      mocks.mockSendPushToUser.mockResolvedValue(2);
+
+      const res = await buildApp().request("/push/test", { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, data: { sent: 2 } });
+      expect(mocks.mockSendPushToUser).toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({ title: "ecoRide", url: "/" }),
+      );
+    });
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -13,12 +13,16 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],
-      include: ["src/lib/**"],
+      // Risk surfaces: business logic (lib), request validation (validators),
+      // authorization (auth), and HTTP handlers (routes). Declarative schema,
+      // bootstrap (index/env), cron wiring and type-only files are excluded
+      // so the numbers reflect code that can actually carry a regression.
+      include: ["src/lib/**", "src/validators/**", "src/auth/**", "src/routes/**"],
       thresholds: {
-        statements: 80,
-        branches: 70,
-        functions: 80,
-        lines: 80,
+        statements: 72,
+        branches: 62,
+        functions: 72,
+        lines: 72,
       },
     },
   },


### PR DESCRIPTION
Closes #315 (Cleanup 11/12).

## What

Make Vitest coverage measure the **real risk surfaces** instead of only `src/lib/**`:

| Package | New `include` | Thresholds (stmt/branch/func/lines) |
|---|---|---|
| server | lib + validators + auth + routes | 72 / 62 / 72 / 72 |
| client | lib + hooks (incl. React Query data layer) | 70 / 60 / 76 / 72 |

Declarative Drizzle schema, bootstrap (`index.ts`/`env.ts`), cron wiring and type-only files stay **out** of scope — including them would force artificially low thresholds dominated by code that can't carry a regression. Pages/components remain covered by Playwright e2e and are a future ratchet step.

## Tests added to lift the gaps the wider scope exposed

- `server/src/routes/push.routes.ts`: **0% → 100%** — new `push.test.ts` (7 tests: vapid-key, subscribe insert/update upsert branches, unsubscribe, validation, test-send).
- `client/src/hooks/queries/{trips,user,stats,admin,feedback}.ts`: **0% → 100%** — 45 tests across 5 new files (query keys, endpoint/method assertions, `enabled` guards, mutation cache invalidations).

## Threshold strategy

Set just under the measured floor (≈2pt anti-flake buffer) so CI is green now and can be ratcheted up as pages/components gain unit tests — matching the epic's "relever progressivement les seuils après avoir élargi le scope".

## Verification

- server: 297 tests pass, coverage ≥ thresholds, `tsc --noEmit` clean
- client: 361 tests pass, coverage ≥ thresholds, `tsc --noEmit` clean

Part of #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)