### PR TITLE
feat(super73): add headlight on/off indicator to trip header

### DIFF
--- a/client/src/components/__tests__/HeadlightIndicator.test.tsx
+++ b/client/src/components/__tests__/HeadlightIndicator.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HeadlightIndicator } from "../trip/HeadlightIndicator";
+import { I18nProvider } from "@/i18n/provider";
+
+const wrap = (ui: React.ReactNode) => render(<I18nProvider>{ui}</I18nProvider>);
+
+describe("HeadlightIndicator", () => {
+  it("renders the ON state with an accessible label when the headlight is on", () => {
+    wrap(<HeadlightIndicator on={true} />);
+    const el = screen.getByTestId("headlight-indicator");
+    expect(el).toBeTruthy();
+    expect(el.getAttribute("data-state")).toBe("on");
+    expect(screen.getByLabelText("Headlight on")).toBeTruthy();
+  });
+
+  it("renders the OFF state with an accessible label when the headlight is off", () => {
+    wrap(<HeadlightIndicator on={false} />);
+    const el = screen.getByTestId("headlight-indicator");
+    expect(el.getAttribute("data-state")).toBe("off");
+    expect(screen.getByLabelText("Headlight off")).toBeTruthy();
+  });
+
+  it("renders nothing when the headlight state is unknown (null)", () => {
+    const { container } = wrap(<HeadlightIndicator on={null} />);
+    expect(container.querySelector('[data-testid="headlight-indicator"]')).toBeNull();
+  });
+});

--- a/client/src/components/trip/HeadlightIndicator.tsx
+++ b/client/src/components/trip/HeadlightIndicator.tsx
@@ -1,0 +1,33 @@
+import { Lightbulb, LightbulbOff } from "lucide-react";
+import { useT } from "@/i18n/provider";
+
+interface HeadlightIndicatorProps {
+  /** Headlight state from the bike (BLE `light` bit), or null when unknown (component hides). */
+  on: boolean | null;
+}
+
+/**
+ * Compact headlight on/off status for the trip screen, fed by the already-decoded
+ * `Super73State.light` BLE bit. Grouped with the battery indicator in the page
+ * header so all bike telemetry status sits together. Read-only.
+ */
+export function HeadlightIndicator({ on }: HeadlightIndicatorProps) {
+  const t = useT();
+  if (on == null) return null;
+
+  const label = on ? t("super73.compact.lightOn") : t("super73.compact.lightOff");
+
+  return (
+    <span
+      data-testid="headlight-indicator"
+      data-state={on ? "on" : "off"}
+      role="img"
+      aria-label={label}
+      className={`flex items-center rounded-md px-2 py-0.5 ${
+        on ? "bg-warning/20 text-warning" : "bg-surface-low/80 text-text-dim"
+      }`}
+    >
+      {on ? <Lightbulb size={16} aria-hidden /> : <LightbulbOff size={16} aria-hidden />}
+    </span>
+  );
+}

--- a/client/src/pages/TripPage.tsx
+++ b/client/src/pages/TripPage.tsx
@@ -33,6 +33,7 @@ import { NavigationBanner } from "@/components/trip/NavigationBanner";
 import { useSuper73 } from "@/hooks/useSuper73";
 import { modeIndex } from "@/lib/super73-ble";
 import { BatteryIndicator } from "@/components/trip/BatteryIndicator";
+import { HeadlightIndicator } from "@/components/trip/HeadlightIndicator";
 
 type TripState = "idle" | "tracking" | "stopped" | "manual";
 
@@ -358,7 +359,10 @@ export function TripPage() {
         titleHidden
         center={
           s73Connected ? (
-            <BatteryIndicator percent={ble.batteryPercent} rangeKm={ble.rangeKm} />
+            <div className="flex items-center gap-2">
+              <BatteryIndicator percent={ble.batteryPercent} rangeKm={ble.rangeKm} />
+              <HeadlightIndicator on={ble.bikeState?.light ?? null} />
+            </div>
           ) : undefined
         }
         right={


### PR DESCRIPTION
Closes #338.

## What

Surfaces the Super 73 **headlight state** on the trip screen as a dedicated read-only indicator.

The data is **already decoded** from the BLE state packet — `Super73State.light` (`bytes[4] === 1` in `parseStateBytes`) — so **no new GATT read** is introduced. The bit was previously only shown buried in the connection/mode card (`Super73ModeButton`, Sun/SunDim); this adds a clear indicator where the rider actually looks during a trip.

## Icons & states

- **On** → `Lightbulb` (amber, `bg-warning/20`)
- **Off** → `LightbulbOff` (dimmed, `text-text-dim`)
- Accessible `aria-label` reusing existing `super73.compact.lightOn` / `lightOff` strings ("Phare allumé/éteint" · "Headlight on/off"), `data-state` for styling, and hides entirely when the state is unknown (`null`).

## Positioning ("intelligently")

Placed in the `PageHeader` **center cluster next to `BatteryIndicator`**, so all bike telemetry status — battery %, range, headlight — sits together in one place, keeping the speed dashboard uncluttered. Visible whenever the bike is connected, across all trip states.

## Tests

`HeadlightIndicator.test.tsx`: on/off accessible labels + `data-state`, and the hidden (`null`) case.

## Verification

- `tsc --noEmit` clean
- client suite: 364 tests pass (+3)
- Component lives in `components/` (outside the lib+hooks coverage scope) → no threshold impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)