### PR TITLE
feat(super73): pin trip mode/assist gauges to screen edges

### DIFF
--- a/client/src/components/__tests__/TrackingDashboard.test.tsx
+++ b/client/src/components/__tests__/TrackingDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { TrackingDashboard } from "../trip/TrackingDashboard";
 import { I18nProvider } from "@/i18n/provider";
@@ -24,6 +24,43 @@ describe("TrackingDashboard", () => {
   it("renders speed only when no levels are provided (unchanged dashboard)", () => {
     const { container } = wrap(<TrackingDashboard {...base} />);
     expect(container.querySelectorAll('[data-filled="true"]').length).toBe(0);
+    expect(screen.getByText("24")).toBeTruthy();
+  });
+
+  it("lays the hero out as a 3-column grid so the speed stays centered between edge gauges", () => {
+    const { container } = wrap(<TrackingDashboard {...base} assistLevel={2} classeLevel={1} />);
+    const hero = container.querySelector('[data-testid="tracking-hero"]');
+    expect(hero).toBeTruthy();
+    expect(hero!.className).toContain("grid-cols-3");
+  });
+
+  it("pins the assist gauge to the left edge and the classe gauge to the right edge", () => {
+    wrap(<TrackingDashboard {...base} assistLevel={3} classeLevel={4} />);
+    const left = screen.getByTestId("hero-gauge-left");
+    const right = screen.getByTestId("hero-gauge-right");
+    // assist gauge sits in the left slot, classe gauge in the right slot
+    expect(within(left).getByLabelText(/Assist 3\/4/)).toBeTruthy();
+    expect(within(right).getByLabelText(/Class 4\/4/)).toBeTruthy();
+    expect(left.className).toContain("justify-self-start");
+    expect(right.className).toContain("justify-self-end");
+  });
+
+  it("keeps the speed centered when only the assist gauge is present (US mode, no classe)", () => {
+    wrap(<TrackingDashboard {...base} assistLevel={2} />);
+    // left slot holds the assist gauge, right slot exists but is empty
+    expect(
+      within(screen.getByTestId("hero-gauge-left")).getByLabelText(/Assist 2\/4/),
+    ).toBeTruthy();
+    expect(within(screen.getByTestId("hero-gauge-right")).queryByRole("img")).toBeNull();
+    expect(screen.getByText("24")).toBeTruthy();
+  });
+
+  it("keeps the speed centered when only the classe gauge is present", () => {
+    wrap(<TrackingDashboard {...base} classeLevel={1} />);
+    expect(within(screen.getByTestId("hero-gauge-left")).queryByRole("img")).toBeNull();
+    expect(
+      within(screen.getByTestId("hero-gauge-right")).getByLabelText(/Class 1\/4/),
+    ).toBeTruthy();
     expect(screen.getByText("24")).toBeTruthy();
   });
 });

--- a/client/src/components/trip/TrackingDashboard.tsx
+++ b/client/src/components/trip/TrackingDashboard.tsx
@@ -28,18 +28,22 @@ export function TrackingDashboard({
 
   return (
     <>
-      {/* Speed hero, optionally flanked by assist (left) and classe (right) gauges */}
-      <div className="flex items-center justify-center gap-4 py-6">
-        {assistLevel != null && (
-          <LevelStack
-            level={assistLevel}
-            activeColor="bg-primary"
-            label={t("trip.dashboard.assistLabel")}
-            ariaLabel={`${t("trip.dashboard.assistLabel")} ${assistLevel}/4`}
-          />
-        )}
+      {/* Speed hero centered between edge-pinned gauges. A 3-column grid keeps the
+          speed centered even when only one gauge is present (e.g. US mode shows no
+          classe): the empty slot still holds its column. */}
+      <div className="grid grid-cols-3 items-center px-4 py-6" data-testid="tracking-hero">
+        <div className="justify-self-start" data-testid="hero-gauge-left">
+          {assistLevel != null && (
+            <LevelStack
+              level={assistLevel}
+              activeColor="bg-primary"
+              label={t("trip.dashboard.assistLabel")}
+              ariaLabel={`${t("trip.dashboard.assistLabel")} ${assistLevel}/4`}
+            />
+          )}
+        </div>
 
-        <div className="flex flex-col items-center">
+        <div className="flex flex-col items-center justify-self-center">
           {isPaused ? (
             <span
               className="text-5xl font-black tracking-tighter text-warning"
@@ -57,14 +61,16 @@ export function TrackingDashboard({
           </span>
         </div>
 
-        {classeLevel != null && (
-          <LevelStack
-            level={classeLevel}
-            activeColor="bg-[#60A5FA]"
-            label={t("trip.dashboard.classeLabel")}
-            ariaLabel={`${t("trip.dashboard.classeLabel")} ${classeLevel}/4`}
-          />
-        )}
+        <div className="justify-self-end" data-testid="hero-gauge-right">
+          {classeLevel != null && (
+            <LevelStack
+              level={classeLevel}
+              activeColor="bg-[#60A5FA]"
+              label={t("trip.dashboard.classeLabel")}
+              ariaLabel={`${t("trip.dashboard.classeLabel")} ${classeLevel}/4`}
+            />
+          )}
+        </div>
       </div>
 
       {/* Distance / CO₂ / Temps — row */}


### PR DESCRIPTION
Closes #337.

## What

The assist (left) and classe (right) gauges on the trip screen were clustered **next to the speed counter** (`flex justify-center gap-4`). They now **hug the screen edges**.

**Before:** `[ assist | speed | classe ]` centered as a group
**After:** `assist ........ speed ........ classe` — assist pinned left, classe pinned right, speed centered.

## How

A **3-column grid** (`grid grid-cols-3`):
- left slot → `justify-self-start` (assist)
- middle slot → speed, centered
- right slot → `justify-self-end` (classe)

The grid keeps the speed **centered even when only one gauge is present** (US mode shows no classe) — the empty slot still holds its column. A flex `justify-between` could not guarantee that single-gauge centering, which is why the grid was chosen.

## Tests

Extends `TrackingDashboard.test.tsx` (+4 cases): grid layout class, edge placement of both gauges (assist in left slot / classe in right slot with the right `justify-self-*`), and speed-stays-centered for assist-only and classe-only.

## Verification

- `tsc --noEmit` clean
- client suite: 368 tests pass (+4)
- Component lives in `components/` (outside lib+hooks coverage scope) → no threshold impact
- Non-Super73 trip screen unchanged (speed-only case still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)