### PR TITLE
fix: show full stats trip history with exact times

### DIFF
--- a/client/src/components/stats/StatsRecentTripsSection.tsx
+++ b/client/src/components/stats/StatsRecentTripsSection.tsx
@@ -1,6 +1,6 @@
 import { Bike } from "lucide-react";
 import type { Trip } from "@ecoride/shared/types";
-import { formatDayMonth } from "@/lib/format-utils";
+import { formatDayMonthTime } from "@/lib/format-utils";
 import { tripLabelKey } from "@/lib/trip-utils";
 import { useT } from "@/i18n/provider";
 
@@ -39,7 +39,7 @@ export function StatsRecentTripsSection({
               <div>
                 <p className="text-sm font-bold">{t(tripLabelKey(trip.startedAt))}</p>
                 <p className="text-xs font-medium text-on-surface-variant">
-                  {formatDayMonth(trip.startedAt, userTimezone)}
+                  {formatDayMonthTime(trip.startedAt, userTimezone)}
                 </p>
               </div>
             </div>

--- a/client/src/components/stats/StatsTripDetailSheet.tsx
+++ b/client/src/components/stats/StatsTripDetailSheet.tsx
@@ -3,7 +3,7 @@ import { Save, Trash2, X } from "lucide-react";
 import type { MouseEvent } from "react";
 import type { Trip } from "@ecoride/shared/types";
 import { TripMiniMap } from "@/components/TripMiniMap";
-import { formatLongDate } from "@/lib/format-utils";
+import { formatLongDateTime } from "@/lib/format-utils";
 import { tripLabelKey } from "@/lib/trip-utils";
 import { useT } from "@/i18n/provider";
 
@@ -67,7 +67,7 @@ export function StatsTripDetailSheet({
           <div>
             <h3 className="text-lg font-bold">{t(tripLabelKey(selectedTrip.startedAt))}</h3>
             <p className="text-sm text-text-muted">
-              {formatLongDate(selectedTrip.startedAt, userTimezone)}
+              {formatLongDateTime(selectedTrip.startedAt, userTimezone)}
             </p>
           </div>
           <button

--- a/client/src/components/stats/__tests__/StatsRecentTripsSection.test.tsx
+++ b/client/src/components/stats/__tests__/StatsRecentTripsSection.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Trip } from "@ecoride/shared/types";
+import { I18nProvider } from "@/i18n/provider";
+import { StatsRecentTripsSection } from "../StatsRecentTripsSection";
+
+const makeTrip = (id: string, startedAt: string): Trip => ({
+  id,
+  userId: "user-1",
+  distanceKm: 8.4,
+  durationSec: 1500,
+  co2SavedKg: 1.2,
+  moneySavedEur: 2.1,
+  fuelSavedL: 0.5,
+  fuelPriceEur: 1.8,
+  startedAt,
+  endedAt: "2026-04-08T07:25:00.000Z",
+  gpsPoints: null,
+});
+
+describe("StatsRecentTripsSection", () => {
+  it("renders every provided trip and includes the exact start time", () => {
+    const onSelectTrip = vi.fn();
+    const trips = [
+      makeTrip("trip-1", "2026-04-08T07:00:00.000Z"),
+      makeTrip("trip-2", "2026-04-07T16:30:00.000Z"),
+      makeTrip("trip-3", "2026-04-06T20:15:00.000Z"),
+    ];
+
+    render(
+      <I18nProvider>
+        <StatsRecentTripsSection
+          trips={trips}
+          userTimezone="Europe/Paris"
+          onSelectTrip={onSelectTrip}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("8 avr., 09:00")).toBeTruthy();
+    expect(screen.getByText("7 avr., 18:30")).toBeTruthy();
+    expect(screen.getByText("6 avr., 22:15")).toBeTruthy();
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+
+    fireEvent.click(screen.getAllByRole("button")[2]);
+    expect(onSelectTrip).toHaveBeenCalledWith(trips[2]);
+  });
+});

--- a/client/src/hooks/queries/__tests__/trips.test.tsx
+++ b/client/src/hooks/queries/__tests__/trips.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { apiFetch } from "@/lib/api";
 import {
+  useAllTrips,
   useTrip,
   useTripPresets,
   useTrips,
@@ -94,6 +95,35 @@ describe("trips queries", () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(mockApiFetch).toHaveBeenCalledWith("/trips?page=1&limit=50");
+    });
+  });
+
+  describe("useAllTrips", () => {
+    it("loads every trips page so stats recent activity exposes the full history", async () => {
+      mockApiFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { trips: [{ id: "trip-1" }] },
+          pagination: { page: 1, limit: 100, total: 3, totalPages: 2 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { trips: [{ id: "trip-2" }, { id: "trip-3" }] },
+          pagination: { page: 2, limit: 100, total: 3, totalPages: 2 },
+        });
+      const { wrapper } = setup();
+
+      const { result } = renderHook(() => useAllTrips(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.data?.trips.map((trip) => trip.id)).toEqual([
+          "trip-1",
+          "trip-2",
+          "trip-3",
+        ]);
+      });
+      expect(mockApiFetch).toHaveBeenNthCalledWith(1, "/trips?page=1&limit=100");
+      expect(mockApiFetch).toHaveBeenNthCalledWith(2, "/trips?page=2&limit=100");
     });
   });
 

--- a/client/src/hooks/queries/trips.ts
+++ b/client/src/hooks/queries/trips.ts
@@ -27,18 +27,49 @@ export function useTripPresets() {
   });
 }
 
+const TRIPS_HISTORY_PAGE_SIZE = 100;
+
+type TripsListResponse = {
+  ok: boolean;
+  data: { trips: Trip[] };
+  pagination: { page: number; limit: number; total: number; totalPages: number };
+};
+
+function fetchTripsPage(page: number, limit: number) {
+  return apiFetch<TripsListResponse>(`/trips?page=${page}&limit=${limit}`).then((response) => ({
+    trips: response.data.trips,
+    pagination: response.pagination,
+  }));
+}
+
 export function useTrips(page = 1, limit = 50) {
   return useQuery({
     queryKey: ["trips", page, limit],
-    queryFn: () =>
-      apiFetch<{
-        ok: boolean;
-        data: { trips: Trip[] };
-        pagination: { page: number; limit: number; total: number; totalPages: number };
-      }>(`/trips?page=${page}&limit=${limit}`).then((response) => ({
-        trips: response.data.trips,
-        pagination: response.pagination,
-      })),
+    queryFn: () => fetchTripsPage(page, limit),
+  });
+}
+
+export function useAllTrips() {
+  return useQuery({
+    queryKey: ["trips", "all"],
+    queryFn: async () => {
+      const firstPage = await fetchTripsPage(1, TRIPS_HISTORY_PAGE_SIZE);
+      const allTrips = [...firstPage.trips];
+
+      for (let page = 2; page <= firstPage.pagination.totalPages; page += 1) {
+        const nextPage = await fetchTripsPage(page, TRIPS_HISTORY_PAGE_SIZE);
+        allTrips.push(...nextPage.trips);
+      }
+
+      return {
+        trips: allTrips,
+        pagination: {
+          ...firstPage.pagination,
+          limit: allTrips.length,
+          page: 1,
+        },
+      };
+    },
   });
 }
 

--- a/client/src/lib/__tests__/format-utils.test.ts
+++ b/client/src/lib/__tests__/format-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatDayMonth, formatFullDate, formatMonthYear } from "../format-utils";
+import {
+  formatDayMonth,
+  formatDayMonthTime,
+  formatFullDate,
+  formatLongDateTime,
+  formatMonthYear,
+} from "../format-utils";
 
 describe("timezone-aware formatting helpers", () => {
   it("formats the same UTC instant differently depending on the saved timezone", () => {
@@ -21,5 +27,12 @@ describe("timezone-aware formatting helpers", () => {
 
     expect(formatFullDate(iso, "UTC")).toBe("1 janvier 2026");
     expect(formatFullDate(iso, "Pacific/Honolulu")).toBe("31 décembre 2025");
+  });
+
+  it("formats exact trip times using the saved profile timezone", () => {
+    const iso = "2026-04-08T07:00:00.000Z";
+
+    expect(formatDayMonthTime(iso, "Europe/Paris")).toBe("8 avr., 09:00");
+    expect(formatLongDateTime(iso, "Europe/Paris")).toBe("mercredi 8 avril à 09:00");
   });
 });

--- a/client/src/lib/format-utils.ts
+++ b/client/src/lib/format-utils.ts
@@ -45,6 +45,19 @@ export function formatDayMonth(iso: string, timeZone?: string | null): string {
   );
 }
 
+export function formatDayMonthTime(iso: string, timeZone?: string | null): string {
+  return formatWithTimezone(
+    iso,
+    {
+      day: "numeric",
+      month: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+    },
+    timeZone,
+  );
+}
+
 export function formatLongDate(iso: string, timeZone?: string | null): string {
   return formatWithTimezone(
     iso,
@@ -52,6 +65,20 @@ export function formatLongDate(iso: string, timeZone?: string | null): string {
       weekday: "long",
       day: "numeric",
       month: "long",
+    },
+    timeZone,
+  );
+}
+
+export function formatLongDateTime(iso: string, timeZone?: string | null): string {
+  return formatWithTimezone(
+    iso,
+    {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      hour: "2-digit",
+      minute: "2-digit",
     },
     timeZone,
   );

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -4,12 +4,12 @@ import type { Trip } from "@ecoride/shared/types";
 import {
   useAchievements,
   useChartTrips,
+  useAllTrips,
   useCreateTripPresetFromTrip,
   useDashboardSummary,
   useDeleteTrip,
   useProfile,
   useTrip,
-  useTrips,
 } from "@/hooks/queries";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useT } from "@/i18n/provider";
@@ -45,7 +45,7 @@ export function StatsPage() {
     message: string;
   } | null>(null);
   const { data: summary, isPending: summaryLoading } = useDashboardSummary("month");
-  const { data: tripsData, isPending: tripsLoading } = useTrips(1, 10);
+  const { data: tripsData, isPending: tripsLoading } = useAllTrips();
   const { data: chartTripsData, isPending: chartLoading } = useChartTrips(period);
   const { data: achievements, isPending: achievementsLoading } = useAchievements();
   const { data: profileData } = useProfile();

--- a/client/src/pages/__tests__/StatsPage.i18n.test.tsx
+++ b/client/src/pages/__tests__/StatsPage.i18n.test.tsx
@@ -42,7 +42,7 @@ vi.mock("@/hooks/queries", () => ({
     },
     isPending: false,
   }),
-  useTrips: () => ({
+  useAllTrips: () => ({
     data: {
       trips: [
         {

--- a/client/src/pages/__tests__/StatsPage.preset.test.tsx
+++ b/client/src/pages/__tests__/StatsPage.preset.test.tsx
@@ -45,7 +45,7 @@ vi.mock("@/hooks/queries", () => ({
     },
     isPending: false,
   }),
-  useTrips: () => ({
+  useAllTrips: () => ({
     data: {
       trips: [
         {


### PR DESCRIPTION
## Summary
- Load all paginated trip pages for the stats recent activity section instead of only the first 10 trips.
- Display exact start times in the recent activity list and trip detail sheet.
- Add regression coverage for full-history fetching and exact time rendering.

## Validation
- bunx vitest run src/lib/__tests__/format-utils.test.ts src/components/stats/__tests__/StatsRecentTripsSection.test.tsx src/hooks/queries/__tests__/trips.test.tsx src/pages/__tests__/StatsPage.i18n.test.tsx src/pages/__tests__/StatsPage.preset.test.tsx
- bun run typecheck
- bun run lint
- bun run build