### PR TITLE
fix: add strict Content-Security-Policy header

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import { initCronJobs } from "./cron";
 import { AppError } from "./lib/errors";
 import { getHealthSnapshot } from "./lib/health";
 import { rateLimit } from "./lib/rate-limit";
+import { securityHeaders } from "./lib/security-headers";
 import { logger } from "./lib/logger";
 import { sentryWebhookRouter } from "./routes/sentry-webhook.routes";
 
@@ -50,15 +51,7 @@ app.use("*", async (c, next) => {
 });
 
 // ---- HTTP security headers ----
-app.use("*", async (c, next) => {
-  if (env.NODE_ENV === "production") {
-    c.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
-  }
-  c.header("X-Frame-Options", "DENY");
-  c.header("X-Content-Type-Options", "nosniff");
-  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-  await next();
-});
+app.use("*", securityHeaders(env.NODE_ENV === "production"));
 
 // ---- CORS for auth routes (before handler, with explicit methods) ----
 app.use(

--- a/server/src/lib/__tests__/security-headers.test.ts
+++ b/server/src/lib/__tests__/security-headers.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { securityHeaders } from "../security-headers";
+
+function buildApp(isProduction: boolean) {
+  const app = new Hono();
+  app.use("*", securityHeaders(isProduction));
+  app.get("/", (c) => c.text("ok"));
+  return app;
+}
+
+async function csp(isProduction = true) {
+  const res = await buildApp(isProduction).request("/");
+  return res.headers.get("Content-Security-Policy") ?? "";
+}
+
+describe("securityHeaders", () => {
+  it("sets a Content-Security-Policy header", async () => {
+    expect(await csp()).toContain("default-src 'self'");
+  });
+
+  it("locks down the directives that block injection and clickjacking", async () => {
+    const header = await csp();
+    expect(header).toContain("script-src 'self'");
+    expect(header).toContain("object-src 'none'");
+    expect(header).toContain("frame-ancestors 'none'");
+    expect(header).toContain("base-uri 'self'");
+    expect(header).not.toContain("unsafe-eval");
+  });
+
+  it("allows the third-party origins the app actually uses", async () => {
+    const header = await csp();
+    // Breaking any of these breaks the map, the destination search,
+    // the fuel price fallback or the Google avatars.
+    for (const origin of [
+      "https://*.cartocdn.com",
+      "https://nominatim.openstreetmap.org",
+      "https://data.economie.gouv.fr",
+      "https://*.sentry.io",
+      "https://*.googleusercontent.com",
+    ]) {
+      expect(header).toContain(origin);
+    }
+    expect(header).toContain("worker-src 'self' blob:");
+  });
+
+  it("keeps the pre-existing headers", async () => {
+    const res = await buildApp(true).request("/");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(res.headers.get("Strict-Transport-Security")).toContain("max-age=63072000");
+  });
+
+  it("only sends HSTS in production", async () => {
+    const res = await buildApp(false).request("/");
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+});

--- a/server/src/lib/security-headers.ts
+++ b/server/src/lib/security-headers.ts
@@ -1,0 +1,46 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Third-party origins the client legitimately talks to.
+ * - cartocdn: MapLibre style.json, vector tiles, sprites and glyphs
+ * - nominatim: destination search (client/src/lib/nominatim.ts)
+ * - data.economie.gouv.fr: fuel price fallback fetched client-side
+ * - sentry.io: error tracking + session replay ingest
+ *   (self-hosted Sentry would need its origin added here)
+ * - googleusercontent: Google OAuth avatars
+ */
+const CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "script-src 'self'",
+  // React and MapLibre both inject inline styles at runtime
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.cartocdn.com https://*.googleusercontent.com",
+  "font-src 'self' data:",
+  // MapLibre and the Sentry replay compressor run workers from blob: URLs
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  [
+    "connect-src 'self' blob:",
+    "https://*.cartocdn.com",
+    "https://nominatim.openstreetmap.org",
+    "https://data.economie.gouv.fr",
+    "https://*.sentry.io",
+  ].join(" "),
+].join("; ");
+
+export function securityHeaders(isProduction: boolean): MiddlewareHandler {
+  return async (c, next) => {
+    if (isProduction) {
+      c.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+    }
+    c.header("Content-Security-Policy", CSP_DIRECTIVES);
+    c.header("X-Frame-Options", "DENY");
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+    await next();
+  };
+}


### PR DESCRIPTION
## Quoi

Ajoute un header `Content-Security-Policy` strict, dernier item sécurité ouvert du ROADMAP (v2.3).

Le middleware headers est extrait de `index.ts` vers `server/src/lib/security-headers.ts` pour être testable unitairement.

## La policy

- `script-src 'self'` — pas de `unsafe-eval`, pas d'inline
- `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`
- `style-src 'unsafe-inline'` — React et MapLibre injectent des styles au runtime, pas contournable sans nonce
- `worker-src blob:` — workers MapLibre + compresseur Sentry Replay

Origines tierces autorisées, vérifiées dans le code :

| Origine | Usage |
|---|---|
| `*.cartocdn.com` | style MapLibre + tuiles + glyphes (`style.json` ne référence que `tiles.basemaps.cartocdn.com`, vérifié) |
| `nominatim.openstreetmap.org` | recherche de destination |
| `data.economie.gouv.fr` | fallback prix carburant côté client |
| `*.sentry.io` | ingest erreurs + replay |
| `*.googleusercontent.com` | avatars Google OAuth |

⚠️ Un Sentry self-hosted casserait le reporting — il faudrait ajouter son origine dans `connect-src`.

## Tests

5 tests unitaires dans `server/src/lib/__tests__/security-headers.test.ts` : présence du CSP, directives de lockdown, chacune des 5 origines tierces (un retrait accidentel casse la carte / la recherche / les avatars), headers pré-existants inchangés, HSTS prod-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBWrRrCQT6Jea4Ldtk1Q3A