### PR TITLE
chore: bun audit in CI, Renovate config, ROADMAP refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
       - run: bun run lint
       - run: bun run format:check
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      # Gate on critical only — the moderate/high noise is almost entirely
+      # transitive build tooling. Renovate opens the PRs for the rest.
+      # Ignored, both reviewed as not exploitable here:
+      #   GHSA-w7jw-789q-3m8p  shell-quote via drizzle-kit — build/migration time only
+      #   GHSA-pw9m-5jxm-xr6h  better-auth — affects the oidc-provider/mcp plugins, unused
+      - run: bun audit --audit-level=critical --ignore=GHSA-w7jw-789q-3m8p --ignore=GHSA-pw9m-5jxm-xr6h
+
   typecheck:
     name: TypeScript check
     runs-on: ubuntu-latest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,8 @@
 # ecoRide — Roadmap
 
+> Dernière vérification contre le code : 2026-07-28 (v2.50.1).
+> Les sections « Livré » ont été recochées en lisant le code, pas la mémoire.
+
 ---
 
 ## v1.0–v1.6 — Livrés
@@ -12,113 +15,39 @@ Voir AUDIT-v1.2.md pour le détail des 31/35 findings corrigés.
 
 ---
 
-## v2.0 — Tests & linting (en cours)
+## v2.0 — Tests & linting — livré
 
-### Tests serveur — PR #72
-
-- [x] Config vitest pour server/ + script `bun run test` + job CI
-- [x] Tests `calculateSavings()` (8 tests)
-- [x] Tests `computeStreak()` / `computeStreakFromDates()` (12 tests)
-- [x] Tests BADGE_THRESHOLDS (27 tests — exact threshold + juste en dessous pour chaque badge)
-- [x] Tests createTripSchema (18 tests — validation Zod complète)
-- [x] Tests `denseRank()` (8 tests)
-- [ ] Objectif : coverage > 80% sur server/src/lib/ (à mesurer)
-
-### ESLint + Prettier — PR #71
-
-- [x] Config ESLint flat (client + server + shared)
-- [x] Config Prettier
-- [x] Husky + lint-staged pre-commit hook
-- [x] Fix erreurs de linting existantes (0 errors, 15 warnings)
-- [x] Job CI `lint` + `format:check`
-
-### Commit lint — en cours
-
-- [ ] commitlint config (conventional commits)
-- [ ] Hook commit-msg qui valide le format du message
-- [ ] Empêche les "wip", "fix stuff" et les messages qui cassent l'auto-bump
-
-### CLAUDE.md projet
-
-- [x] Créé — instructions complètes pour les agents (architecture, gotchas, rules)
+- [x] Vitest serveur + client, script `bun run test`, job CI
+- [x] Tests `calculateSavings()`, `computeStreak()`, BADGE_THRESHOLDS, `createTripSchema`, `denseRank()`
+- [x] ESLint flat (client + server + shared) + Prettier + husky/lint-staged
+- [x] Jobs CI `lint` + `format:check`
+- [x] commitlint (`.husky/commit-msg` + job CI `commitlint`)
+- [x] CLAUDE.md projet
 
 ---
 
-## v2.1 — Monitoring & admin
+## v2.1 — Monitoring & admin — livré
 
-### Page admin (/admin)
-
-- [ ] Route protégée (admin only — vérifier un flag `isAdmin` sur le user)
-- [ ] Dashboard : nb users, nb trips total, trips/jour (7 derniers jours), erreurs récentes
-- [ ] Infos système : version déployée, uptime serveur, taille DB
-- [ ] Liste des users avec stats (admin peut voir tous les users)
-- [ ] Bouton pour trigger un deploy manuellement
-
-### Health check enrichi
-
-- [ ] `/api/health` retourne aussi : DB connected (ping), nb users actifs (7j), disk usage si dispo
-- [ ] Endpoint `/api/health/detailed` (admin only) avec métriques complètes
-
-### Sentry (ou alternative)
-
-- [ ] Intégrer Sentry côté client (ErrorBoundary + unhandledrejection)
-- [ ] Source maps uploadées dans la CI (pour stack traces lisibles)
-- [ ] Alertes email/push sur erreurs critiques
-- [ ] Optionnel côté serveur (Hono error handler → Sentry)
-
-### Logs structurés
-
-- [ ] Remplacer console.log/warn/error par un logger structuré (JSON)
-- [ ] Chaque log inclut : timestamp, level, requestId, userId (si auth), message, data
-- [ ] Rotation/retention des logs (ou export vers un service externe)
-
-### Audit log
-
-- [ ] Table `audit_logs` : userId, action, target, metadata, createdAt
-- [ ] Actions tracées : suppression compte, suppression trajet, changement profil véhicule
-- [ ] Visible dans la page admin
+- [x] Page admin `/admin` protégée (`adminMiddleware`), stats users/trips, infos système
+- [x] Bouton de deploy manuel (`AdminSystemSection`)
+- [x] `/api/health` enrichi (db, activeUsers7d, version) + `/api/health/detailed` admin-only
+- [x] Sentry client + serveur, source maps uploadées via `sentryVitePlugin` (`sourcemap: "hidden"`)
+- [x] Webhook Sentry → notifications (`sentry-webhook.routes.ts`)
+- [x] Logger structuré JSON avec requestId + userId (`server/src/lib/logger.ts`)
+- [x] Table `audit_logs` + consultation dans la page admin (`GET /admin/audit-logs`)
+- [ ] Rotation / rétention des logs — aujourd'hui stdout capturé par Coolify, pas de politique explicite
 
 ---
 
-## v2.2 — CI avancée
+## v2.2 — CI avancée — livré, sauf preview deploys
 
-### Coverage report dans les PRs
-
-- [ ] vitest coverage (c8 ou istanbul) pour client + server
-- [ ] GitHub Action qui poste un commentaire avec le % et les diff de coverage
-- [ ] Seuil minimum : fail la CI si coverage < 70%
-
-### Bundle size check
-
-- [ ] Mesurer la taille du bundle JS/CSS après build
-- [ ] Comparer avec main et alerter si +50 KB
-- [ ] GitHub Action comment ou status check
-
-### Lighthouse CI
-
-- [ ] Lancer Lighthouse sur le build preview (performance, PWA, a11y, SEO)
-- [ ] Poster le score dans la PR
-- [ ] Seuils : performance > 80, PWA > 90, a11y > 85
-
-### Preview deployments
-
-- [ ] Chaque PR déployée sur une URL temporaire (ex: pr-42.ecoride.tiarkaerell.com)
-- [ ] Coolify ou Vercel-like preview
-- [ ] Auto-cleanup quand la PR est fermée
-
-### Seed script
-
-- [ ] `bun run db:seed` qui crée des données de test réalistes
-- [ ] 5 users fictifs avec noms/emails anonymes
-- [ ] ~50 trips répartis sur 2 semaines avec GPS points réalistes
-- [ ] Badges débloqués, streaks en cours
-- [ ] Utile pour démo, screenshots, dev local
-
-### Dependabot / Renovate
-
-- [ ] Config Renovate ou Dependabot pour auto-update des deps
-- [ ] PRs automatiques avec changelog
-- [ ] Auto-merge si CI passe pour les patches
+- [x] Coverage vitest client + server, commentaire PR, seuil bloquant
+- [x] Bundle size check (budget +50 KB gzip, commentaire PR)
+- [x] Lighthouse CI avec seuil a11y bloquant
+- [x] Analyse dead code : Knip + dependency-cruiser (scripts `knip`, `depcruise`)
+- [x] Renovate (`renovate.json`, auto-merge des patches)
+- [ ] Preview deployments par PR (URL temporaire + auto-cleanup) — infra Coolify, gros chantier
+- [ ] Seed script `bun run db:seed` (users fictifs + ~50 trips réalistes) pour démo et dev local
 
 ---
 
@@ -126,29 +55,40 @@ Voir AUDIT-v1.2.md pour le détail des 31/35 findings corrigés.
 
 ### Sécurité
 
-- [ ] Content-Security-Policy header strict
-- [ ] `bun audit` dans la CI (ou npm audit)
+- [x] Headers HSTS / X-Frame-Options / nosniff / Referrer-Policy
+- [x] Content-Security-Policy strict (`server/src/lib/security-headers.ts`)
+- [x] `bun audit` dans la CI (bloquant sur `critical`)
 - [ ] Documenter la procédure de rotation des secrets (VAPID, auth secret, DB password)
 - [ ] Pen test checklist automatisée (OWASP top 10)
 
-### Précision des calculs
+### Précision des calculs — livré
 
-- [ ] Migrer colonnes `real` → `numeric(10,3)` pour CO₂ et fuel
-- [ ] Migrer `moneySavedEur` → `numeric(10,2)`
-- [ ] Script de migration des données existantes
-- [ ] Tests de précision sur les agrégations SUM
+- [x] Colonnes CO₂ / fuel en `numeric(10,3)`, `moneySavedEur` en `numeric(10,2)`
+- [x] Migration des données existantes
+- [x] Tests de précision sur les agrégations
 
 ### DX
 
-- [ ] API docs auto-générées (OpenAPI/Swagger depuis routes Hono + Zod)
-- [ ] Dev containers (docker-compose pour dev en 1 commande)
+- [ ] API docs auto-générées (OpenAPI depuis routes Hono + Zod)
+- [ ] Dev containers (docker-compose, dev en 1 commande)
 - [ ] Storybook pour les composants UI
-- [ ] Dead code analysis automatique dans la CI
+
+---
+
+## Dette connue
+
+- better-auth < 1.6.11 et drizzle-kit 0.30 traînent des CVE critiques, non exploitables ici
+  (plugins oidc-provider/mcp non utilisés, shell-quote uniquement au build). Ignorées
+  explicitement dans le job `audit` de la CI. Renovate ouvrira les PRs d'upgrade —
+  à revoir à la main, ce sont l'auth et les migrations.
 
 ---
 
 ## v3.0+ — Features (après consolidation)
 
+> i18n fr/en : déjà livré (`client/src/i18n/`), retiré de la liste.
+
+- Adresses favorites ([#273](https://github.com/vlebourl/ecoride/issues/273))
 - Défis entre amis ("Je te défie de faire 50 km cette semaine")
 - Fil d'activité (voir les derniers trajets de tous les utilisateurs)
 - Partager son impact (Web Share API)
@@ -160,4 +100,3 @@ Voir AUDIT-v1.2.md pour le détail des 31/35 findings corrigés.
 - Intégration Strava
 - Gamification avancée (niveaux, XP)
 - Widget Android
-- i18n (multi-langue)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "platformAutomerge": true,
+  "lockFileMaintenance": { "enabled": true, "automerge": true },
+  "packageRules": [
+    {
+      "description": "Patches and lockfile pins are auto-merged once CI is green",
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Dev dependency minors too — they never reach production",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor"],
+      "automerge": true
+    },
+    {
+      "description": "Auth and DB are hand-reviewed, whatever the bump size",
+      "matchPackageNames": ["better-auth", "drizzle-orm", "drizzle-kit"],
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "automerge": false
+  }
+}


### PR DESCRIPTION
Trois items du ROADMAP v2.2/v2.3, aucun changement fonctionnel (pas de bump, pas de deploy).

## 1. `bun audit` en CI

Nouveau job `audit`, bloquant sur `--audit-level=critical` uniquement. Le reste (37 high, 42 moderate) est quasi exclusivement du picomatch/fdir transitif dans l'outillage de build — gate au niveau `high` = CI rouge en permanence et plus personne ne la lit.

Deux CVE critiques existent aujourd'hui, ignorées explicitement avec la raison en commentaire :

| CVE | Paquet | Pourquoi ignorée |
|---|---|---|
| `GHSA-w7jw-789q-3m8p` | shell-quote via drizzle-kit | build / migrations uniquement, pas de chemin runtime |
| `GHSA-pw9m-5jxm-xr6h` | better-auth < 1.6.11 | affecte les plugins `oidc-provider` et `mcp` — non utilisés, ecoRide est client OAuth, pas provider |

Les deux vrais correctifs sont des upgrades à risque (better-auth 1.2 → 1.6, drizzle-kit 0.30 → 0.31). Je ne les fais pas en douce dans un PR chore : Renovate ouvrira les PRs, à revoir à la main.

## 2. Renovate

`renovate.json` : schedule hebdo lundi matin, 5 PRs max, auto-merge des `patch`/`pin`/`digest` et des minors devDeps, `lockFileMaintenance` activé. `better-auth`, `drizzle-orm` et `drizzle-kit` restent en revue manuelle. Alertes de vulnérabilité hors schedule, jamais auto-mergées.

⚠️ Deux choses à savoir :
- Il faut **installer la GitHub App Renovate** sur le repo pour que ça tourne.
- Renovate commite les deps de prod en `fix(deps):` → l'auto-bump déclenchera un patch + deploy sur les patches auto-mergés. C'est voulu (un patch de sécu part en prod tout seul), mais c'est un deploy sans revue humaine — dis-moi si tu préfères forcer `chore(deps):` partout.

## 3. ROADMAP

Il annonçait « v2.0 en cours » alors que tu es en v2.50.1. ~20 cases étaient faites mais non cochées : commitlint, coverage/bundle-size/lighthouse en CI, page admin + bouton deploy, `/api/health/detailed`, audit log, logger structuré, Sentry + source maps, colonnes `numeric`, Knip/dependency-cruiser, i18n fr/en.

Réécrit contre le code (chaque case vérifiée par lecture, pas de mémoire), avec une section « Dette connue » pour les deux CVE ci-dessus et #273 rangée dans v3.0+.

Reste réellement ouvert : rotation des logs, preview deploys, seed script, rotation des secrets, checklist OWASP, OpenAPI, dev containers, Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBWrRrCQT6Jea4Ldtk1Q3A