### PR TITLE
feat(badges): 46 badges en 6 catégories et défis glissants

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,8 @@ bun.lock
 
 # Local workspace artifacts
 client/test-results
+.superpowers
+.worktrees
 /entities.json
 /mempalace.yaml
 /quality-gate.md

--- a/client/e2e/badges-categories.spec.ts
+++ b/client/e2e/badges-categories.spec.ts
@@ -7,8 +7,12 @@ import { test, expect } from "@playwright/test";
  * Strategy: stub /api/** (this suite runs against `vite preview`, a static
  * build with no API server) and assert on:
  * 1. all 6 category headings render — catches a dropped/renamed category.
- * 2. the weekly challenge progressbar's aria-valuenow is the correct
- *    clamped, rounded percentage — catches a wrong or unclamped computation.
+ * 2. the weekly challenge progressbar's aria-valuenow is the expected
+ *    percentage for the stubbed fixture — catches a wrong computation or the
+ *    week/month cards being swapped. It does NOT cover the >100 % clamp: the
+ *    fixture is 32/50 = 64 %, far from the boundary, so an implementation
+ *    without Math.min(100, …) would produce 64 too. The clamp is covered in
+ *    client/src/components/badges/__tests__/ChallengeCard.test.tsx (vitest).
  *
  * Note: the real client fetches achievements from /achievements (not nested
  * inside /stats/summary as an earlier draft of this spec assumed) and reads
@@ -178,8 +182,9 @@ test.describe("Badges par catégorie et défis", () => {
   test("affiche la barre de progression du défi hebdo", async ({ page }) => {
     await page.goto("/stats", { waitUntil: "networkidle" });
 
-    // 32 / 50 = 64 % — would fail if the percentage were computed wrong,
-    // left unclamped, or the week/month cards were swapped.
+    // 32 / 50 = 64 % — would fail if the percentage were computed wrong or the
+    // week/month cards were swapped. Says nothing about the >100 % clamp (64 is
+    // nowhere near the boundary) — that lives in ChallengeCard.test.tsx.
     await expect(page.getByRole("progressbar").first()).toHaveAttribute("aria-valuenow", "64");
   });
 });

--- a/client/e2e/badges-categories.spec.ts
+++ b/client/e2e/badges-categories.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * e2e coverage for the 6-category badge grid and the weekly/monthly
+ * challenge cards on /stats (tasks 6-7 of the badges-categories plan).
+ *
+ * Strategy: stub /api/** (this suite runs against `vite preview`, a static
+ * build with no API server) and assert on:
+ * 1. all 6 category headings render — catches a dropped/renamed category.
+ * 2. the weekly challenge progressbar's aria-valuenow is the correct
+ *    clamped, rounded percentage — catches a wrong or unclamped computation.
+ *
+ * Note: the real client fetches achievements from /achievements (not nested
+ * inside /stats/summary as an earlier draft of this spec assumed) and reads
+ * the challenge/period summary from /stats/summary?period=... — StatsPage
+ * hardcodes period=month for that call. Endpoints below mirror the actual
+ * hooks in client/src/hooks/queries/stats.ts.
+ */
+
+const CHALLENGES = {
+  week: { distanceKm: 32, goalKm: 50, tripCount: 6, activeDays: 3, co2Kg: 7.4 },
+  month: { distanceKm: 178, goalKm: 250, tripCount: 24, activeDays: 14, co2Kg: 41 },
+};
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify(body),
+});
+
+test.describe("Badges par catégorie et défis", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+      // The FR assertions below rely on detectInitialLocale() falling back to
+      // navigator.language (forced to fr-FR in playwright.config.ts). A stale
+      // "en" left in storage would silently break them.
+      localStorage.removeItem("ecoride-locale");
+    });
+
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill(
+          json({
+            session: {
+              id: "s",
+              userId: "u",
+              expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            },
+            user: {
+              id: "u",
+              name: "Test",
+              email: "t@t.com",
+              emailVerified: true,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+        );
+      }
+
+      if (url.includes("/api/user/profile")) {
+        return route.fulfill(
+          json({
+            ok: true,
+            data: {
+              user: {
+                id: "u",
+                name: "Test",
+                email: "t@t.com",
+                image: null,
+                vehicleModel: null,
+                fuelType: null,
+                consumptionL100: null,
+                mileage: null,
+                timezone: "Europe/Paris",
+                leaderboardOptOut: false,
+                reminderEnabled: false,
+                reminderTime: null,
+                reminderDays: null,
+                isAdmin: false,
+                super73Enabled: false,
+                super73AutoModeEnabled: false,
+                super73DefaultMode: null,
+                super73DefaultAssist: null,
+                super73DefaultLight: null,
+                super73AutoModeLowSpeedKmh: null,
+                super73AutoModeHighSpeedKmh: null,
+                createdAt: new Date().toISOString(),
+              },
+              stats: {
+                totalDistanceKm: 178,
+                totalCo2SavedKg: 41,
+                totalMoneySavedEur: 25,
+                totalFuelSavedL: 10,
+                tripCount: 24,
+              },
+            },
+          }),
+        );
+      }
+
+      if (url.includes("/api/stats/summary")) {
+        return route.fulfill(
+          json({
+            ok: true,
+            data: {
+              totalDistanceKm: 178,
+              totalCo2SavedKg: 41,
+              totalMoneySavedEur: 25,
+              totalFuelSavedL: 10,
+              tripCount: 24,
+              currentStreak: 3,
+              longestStreak: 14,
+              challenges: CHALLENGES,
+            },
+          }),
+        );
+      }
+
+      if (url.includes("/api/achievements")) {
+        return route.fulfill(
+          json({
+            ok: true,
+            data: { achievements: [{ badgeId: "first_trip" }, { badgeId: "km_1000" }] },
+          }),
+        );
+      }
+
+      if (url.includes("/api/trips")) {
+        return route.fulfill(
+          json({
+            ok: true,
+            data: {
+              trips: [
+                {
+                  id: "t1",
+                  userId: "u",
+                  distanceKm: 10,
+                  durationSec: 1800,
+                  co2SavedKg: 1.5,
+                  moneySavedEur: 2.1,
+                  fuelSavedL: 0.7,
+                  startedAt: new Date().toISOString(),
+                  endedAt: new Date().toISOString(),
+                  gpsPoints: null,
+                },
+              ],
+              pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+            },
+          }),
+        );
+      }
+
+      return route.fulfill(json({ ok: true, data: {} }));
+    });
+  });
+
+  test("affiche les 6 catégories de badges", async ({ page }) => {
+    await page.goto("/stats", { waitUntil: "networkidle" });
+
+    // Would fail if a category is dropped, renamed, or its i18n key mismatched.
+    for (const label of ["Volume", "Impact", "Régularité", "Records", "Habitudes", "Performance"]) {
+      await expect(page.getByRole("heading", { name: label, exact: true })).toBeVisible();
+    }
+  });
+
+  test("affiche la barre de progression du défi hebdo", async ({ page }) => {
+    await page.goto("/stats", { waitUntil: "networkidle" });
+
+    // 32 / 50 = 64 % — would fail if the percentage were computed wrong,
+    // left unclamped, or the week/month cards were swapped.
+    await expect(page.getByRole("progressbar").first()).toHaveAttribute("aria-valuenow", "64");
+  });
+});

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -13,9 +13,12 @@ export default defineConfig({
     locale: "fr-FR",
   },
   webServer: {
-    command: "bun run preview --port 4173",
+    // Build first: `vite preview` sert `dist/` tel quel. Sans ce build, la suite
+    // teste une version antérieure de l'app et affiche un vert trompeur — ça a
+    // déjà coûté une tâche entière. Le timeout couvre build + démarrage.
+    command: "bun run build && bun run preview --port 4173",
     port: 4173,
-    timeout: 30_000,
+    timeout: 120_000,
     reuseExistingServer: false,
   },
 });

--- a/client/src/components/badges/BadgeGrid.tsx
+++ b/client/src/components/badges/BadgeGrid.tsx
@@ -1,0 +1,64 @@
+import { BADGES, BADGE_CATEGORIES, type BadgeId } from "@ecoride/shared/types";
+import type { Achievement } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+const badgesByCategory = BADGE_CATEGORIES.map((category) => ({
+  category,
+  ids: (Object.keys(BADGES) as BadgeId[]).filter((id) => BADGES[id].category === category),
+}));
+
+interface BadgeGridProps {
+  achievements: Achievement[];
+}
+
+export function BadgeGrid({ achievements }: BadgeGridProps) {
+  const t = useT();
+  const unlocked = new Set(achievements.map((a) => a.badgeId));
+
+  return (
+    <div className="space-y-6">
+      {badgesByCategory.map(({ category, ids }) => {
+        const count = ids.filter((id) => unlocked.has(id)).length;
+
+        return (
+          <section key={category} className="space-y-3">
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+                {t(`badges.category.${category}` as Parameters<typeof t>[0])}
+              </h3>
+              <span className="text-xs font-bold text-text-dim">
+                {count}/{ids.length}
+              </span>
+            </div>
+            <ul className="grid grid-cols-4 gap-4">
+              {ids.map((id) => {
+                const badge = BADGES[id];
+                const isUnlocked = unlocked.has(id);
+
+                return (
+                  <li
+                    key={id}
+                    className={`flex flex-col items-center gap-2 ${!isUnlocked ? "opacity-40" : ""}`}
+                  >
+                    <div
+                      className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
+                        isUnlocked
+                          ? "bg-primary/10 text-primary-light"
+                          : "bg-surface-high text-text-dim"
+                      }`}
+                    >
+                      <span className="text-2xl">{badge.icon}</span>
+                    </div>
+                    <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
+                      {badge.label}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/badges/ChallengeCard.tsx
+++ b/client/src/components/badges/ChallengeCard.tsx
@@ -1,0 +1,41 @@
+import type { ChallengeProgressDto } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+interface ChallengeCardProps {
+  period: "week" | "month";
+  progress: ChallengeProgressDto;
+  compact?: boolean;
+}
+
+export function ChallengeCard({ period, progress, compact = false }: ChallengeCardProps) {
+  const t = useT();
+  const pct = Math.min(100, Math.round((progress.distanceKm / progress.goalKm) * 100));
+
+  return (
+    <section className="space-y-2 rounded-2xl bg-surface-high p-4">
+      <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+        {t(`badges.challenge.${period}` as Parameters<typeof t>[0])}
+      </h3>
+
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="h-2 overflow-hidden rounded-full bg-surface"
+      >
+        <div className="h-full rounded-full bg-primary" style={{ width: `${pct}%` }} />
+      </div>
+
+      <p className="text-sm font-bold">
+        {Math.round(progress.distanceKm)} / {progress.goalKm} km
+      </p>
+
+      {!compact && (
+        <p className="text-xs text-text-muted">
+          {progress.tripCount} · {progress.activeDays} · {progress.co2Kg.toFixed(1)} kg CO₂
+        </p>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/badges/__tests__/BadgeGrid.test.tsx
+++ b/client/src/components/badges/__tests__/BadgeGrid.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BadgeGrid } from "../BadgeGrid";
+import { I18nProvider } from "@/i18n/provider";
+
+// Install a Storage-like mock so tests do not rely on the host localStorage
+// implementation — bun on macOS ships a broken one when running under vitest
+// (see src/i18n/__tests__/provider.test.tsx).
+const createLocalStorageMock = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", createLocalStorageMock());
+  // I18nProvider defaults to the browser locale; jsdom reports "en-US" by
+  // default, so force French to match the labels asserted below.
+  vi.spyOn(navigator, "language", "get").mockReturnValue("fr-FR");
+});
+
+function renderGrid(achievements: { badgeId: string }[] = []) {
+  return render(
+    <I18nProvider>
+      <BadgeGrid achievements={achievements as never} />
+    </I18nProvider>,
+  );
+}
+
+describe("BadgeGrid", () => {
+  it("affiche les 6 catégories", () => {
+    renderGrid();
+    for (const label of ["Volume", "Impact", "Régularité", "Records", "Habitudes", "Performance"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("affiche le compteur de débloqués par catégorie", () => {
+    renderGrid([{ badgeId: "first_trip" }, { badgeId: "trips_10" }]);
+    expect(screen.getByText("2/12")).toBeTruthy();
+  });
+
+  it("affiche les 46 badges", () => {
+    renderGrid();
+    expect(screen.getAllByRole("listitem")).toHaveLength(46);
+  });
+});

--- a/client/src/components/badges/__tests__/ChallengeCard.test.tsx
+++ b/client/src/components/badges/__tests__/ChallengeCard.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChallengeCard } from "../ChallengeCard";
+import { I18nProvider } from "@/i18n/provider";
+
+const progress = { distanceKm: 32, goalKm: 50, tripCount: 6, activeDays: 3, co2Kg: 7.4 };
+
+const wrap = (ui: React.ReactNode) => render(<I18nProvider>{ui}</I18nProvider>);
+
+describe("ChallengeCard", () => {
+  it("affiche la distance et l'objectif", () => {
+    wrap(<ChallengeCard period="week" progress={progress} />);
+    expect(screen.getByText(/32/)).toBeTruthy();
+    expect(screen.getByText(/50/)).toBeTruthy();
+  });
+
+  it("calcule le pourcentage arrondi de progression (non borné)", () => {
+    // 32 / 50 = 64% exactly. This fails if the formula is inverted (50/32 -> 156, clamped to
+    // 100 — a different, distinguishable wrong answer) or if rounding is dropped/changed.
+    wrap(<ChallengeCard period="week" progress={progress} />);
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("64");
+  });
+
+  it("borne la barre de progression à 100 % au-delà de l'objectif", () => {
+    wrap(<ChallengeCard period="week" progress={{ ...progress, distanceKm: 80 }} />);
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("masque les compteurs secondaires en mode compact", () => {
+    wrap(<ChallengeCard period="week" progress={progress} compact />);
+    expect(screen.queryByText(/7,4/)).toBeNull();
+    expect(screen.queryByText(/7\.4/)).toBeNull();
+  });
+
+  it("affiche les compteurs secondaires hors mode compact", () => {
+    wrap(<ChallengeCard period="week" progress={progress} />);
+    expect(screen.getByText(/7[.,]4/)).toBeTruthy();
+  });
+});

--- a/client/src/components/profile/ProfileBadgesSection.tsx
+++ b/client/src/components/profile/ProfileBadgesSection.tsx
@@ -1,8 +1,6 @@
-import { BADGES } from "@ecoride/shared/types";
-import type { Achievement, BadgeId } from "@ecoride/shared/types";
+import type { Achievement } from "@ecoride/shared/types";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
 import { useT } from "@/i18n/provider";
-
-const allBadgeIds = Object.keys(BADGES) as BadgeId[];
 
 interface ProfileBadgesSectionProps {
   achievements: Achievement[];
@@ -13,33 +11,8 @@ export function ProfileBadgesSection({ achievements }: ProfileBadgesSectionProps
 
   return (
     <section className="space-y-4">
-      <div className="flex items-end justify-between">
-        <h2 className="text-lg font-bold tracking-tight">{t("profile.badges.title")}</h2>
-      </div>
-      <div className="grid grid-cols-4 gap-4">
-        {allBadgeIds.map((id) => {
-          const badge = BADGES[id];
-          const unlocked = achievements.some((achievement) => achievement.badgeId === id);
-
-          return (
-            <div
-              key={id}
-              className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
-            >
-              <div
-                className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
-                  unlocked ? "bg-primary/10 text-primary-light" : "bg-surface-high text-text-dim"
-                }`}
-              >
-                <span className="text-2xl">{badge.icon}</span>
-              </div>
-              <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
-                {badge.label}
-              </span>
-            </div>
-          );
-        })}
-      </div>
+      <h2 className="text-lg font-bold tracking-tight">{t("profile.badges.title")}</h2>
+      <BadgeGrid achievements={achievements} />
     </section>
   );
 }

--- a/client/src/components/stats/StatsBadgesSection.tsx
+++ b/client/src/components/stats/StatsBadgesSection.tsx
@@ -1,8 +1,6 @@
-import { BADGES, type BadgeId } from "@ecoride/shared/types";
 import type { Achievement } from "@ecoride/shared/types";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
 import { useT } from "@/i18n/provider";
-
-const allBadgeIds = Object.keys(BADGES) as BadgeId[];
 
 type StatsBadgesSectionProps = {
   achievements: Achievement[];
@@ -16,30 +14,7 @@ export function StatsBadgesSection({ achievements }: StatsBadgesSectionProps) {
       <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
         {t("stats.badges.title")}
       </h3>
-      <div className="grid grid-cols-4 gap-4">
-        {allBadgeIds.map((id) => {
-          const badge = BADGES[id];
-          const unlocked = achievements.some((achievement) => achievement.badgeId === id);
-
-          return (
-            <div
-              key={id}
-              className={`flex flex-col items-center gap-2 ${!unlocked ? "opacity-40" : ""}`}
-            >
-              <div
-                className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
-                  unlocked ? "bg-primary/10 text-primary-light" : "bg-surface-high text-text-dim"
-                }`}
-              >
-                <span className="text-2xl">{badge.icon}</span>
-              </div>
-              <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
-                {badge.label}
-              </span>
-            </div>
-          );
-        })}
-      </div>
+      <BadgeGrid achievements={achievements} />
     </section>
   );
 }

--- a/client/src/components/stats/StatsBadgesSection.tsx
+++ b/client/src/components/stats/StatsBadgesSection.tsx
@@ -1,16 +1,24 @@
-import type { Achievement } from "@ecoride/shared/types";
+import type { Achievement, ChallengeProgressDto } from "@ecoride/shared/types";
 import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { ChallengeCard } from "@/components/badges/ChallengeCard";
 import { useT } from "@/i18n/provider";
 
 type StatsBadgesSectionProps = {
   achievements: Achievement[];
+  challenges?: { week: ChallengeProgressDto; month: ChallengeProgressDto };
 };
 
-export function StatsBadgesSection({ achievements }: StatsBadgesSectionProps) {
+export function StatsBadgesSection({ achievements, challenges }: StatsBadgesSectionProps) {
   const t = useT();
 
   return (
     <section className="space-y-4">
+      {challenges && (
+        <div className="space-y-3">
+          <ChallengeCard period="week" progress={challenges.week} />
+          <ChallengeCard period="month" progress={challenges.month} />
+        </div>
+      )}
       <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
         {t("stats.badges.title")}
       </h3>

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -162,6 +162,8 @@ export const en: Record<TranslationKey, string> = {
   "badges.category.records": "Records",
   "badges.category.habits": "Habits",
   "badges.category.performance": "Performance",
+  "badges.challenge.week": "Weekly challenge",
+  "badges.challenge.month": "Monthly challenge",
   "profile.presets.title": "Saved trips",
   "profile.presets.subtitle":
     "Manage your favourite trips here. To create a new one, open a trip from the Stats tab and choose “Create a saved trip”.",

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -156,6 +156,12 @@ export const en: Record<TranslationKey, string> = {
   "profile.stats.eurUnit": "EUR",
   "profile.fuel.nationalAverage": "National average price",
   "profile.badges.title": "Badges",
+  "badges.category.volume": "Volume",
+  "badges.category.impact": "Impact",
+  "badges.category.regularity": "Consistency",
+  "badges.category.records": "Records",
+  "badges.category.habits": "Habits",
+  "badges.category.performance": "Performance",
   "profile.presets.title": "Saved trips",
   "profile.presets.subtitle":
     "Manage your favourite trips here. To create a new one, open a trip from the Stats tab and choose “Create a saved trip”.",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -154,6 +154,12 @@ export const fr = {
   "profile.stats.eurUnit": "EUR",
   "profile.fuel.nationalAverage": "Prix moyen national",
   "profile.badges.title": "Badges",
+  "badges.category.volume": "Volume",
+  "badges.category.impact": "Impact",
+  "badges.category.regularity": "Régularité",
+  "badges.category.records": "Records",
+  "badges.category.habits": "Habitudes",
+  "badges.category.performance": "Performance",
   "profile.presets.title": "Trajets pré-enregistrés",
   "profile.presets.subtitle":
     "Gérez ici votre liste de trajets favoris. Pour en créer un nouveau, ouvrez un trajet dans l'onglet Stats puis choisissez « Créer un trajet pré-enregistré ».",

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -160,6 +160,8 @@ export const fr = {
   "badges.category.records": "Records",
   "badges.category.habits": "Habitudes",
   "badges.category.performance": "Performance",
+  "badges.challenge.week": "Défi de la semaine",
+  "badges.challenge.month": "Défi du mois",
   "profile.presets.title": "Trajets pré-enregistrés",
   "profile.presets.subtitle":
     "Gérez ici votre liste de trajets favoris. Pour en créer un nouveau, ouvrez un trajet dans l'onglet Stats puis choisissez « Créer un trajet pré-enregistré ».",

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { useDashboardSummary, useProfile, useActiveAnnouncement } from "@/hooks/queries";
+import { ChallengeCard } from "@/components/badges/ChallengeCard";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { getPendingTrips, getRejectedTrips } from "@/lib/offline-queue";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -305,6 +306,11 @@ export function DashboardPage() {
               className="text-bg/60 transition-transform group-hover:translate-x-1"
             />
           </Link>
+
+          {/* Weekly challenge progress */}
+          {today.challenges && (
+            <ChallengeCard period="week" progress={today.challenges.week} compact />
+          )}
 
           {/* Vehicle onboarding prompt */}
           {!vehiclePromptDismissed &&

--- a/client/src/pages/StatsPage.tsx
+++ b/client/src/pages/StatsPage.tsx
@@ -172,7 +172,7 @@ export function StatsPage() {
           </>
         )}
 
-        <StatsBadgesSection achievements={achievements ?? []} />
+        <StatsBadgesSection achievements={achievements ?? []} challenges={summary.challenges} />
       </div>
 
       <StatsTripDetailSheet

--- a/docs/superpowers/plans/2026-07-28-badges-categories.md
+++ b/docs/superpowers/plans/2026-07-28-badges-categories.md
@@ -19,7 +19,8 @@
 - **Tout badge est une fonction pure de `UserStats`** — jamais d'événement daté, sinon `reevaluateBadges()` ne peut pas le révoquer correctement.
 - **Seuils des défis** : 50 km/semaine (lundi→dimanche), 250 km/mois (mois civil).
 - **Garde-fou vitesse** : `maxTripSpeedKmh` ne considère que les trajets `distanceKm >= 5`.
-- **Vérification à chaque tâche** : `bun run typecheck` et `bun run lint` doivent passer avant chaque commit.
+- **Vérification à chaque tâche** : `bun run lint` et les tests de la tâche doivent passer avant chaque commit.
+- **Exception typecheck, tâches 1 à 3** : `BadgeId` est dérivé des clés de `BADGES`, donc ajouter 33 ids casse mécaniquement `BADGE_THRESHOLDS` tant que les prédicats ne suivent pas. Le typecheck est **attendu rouge** aux tâches 1, 2 et 3, et **doit être vert à partir de la tâche 4** et pour toutes les suivantes. Ne pas « réparer » ce rouge en tâche 1 ou 2 — la tâche 4 le résout en supprimant le bloc dupliqué qui portait `currentStreak`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-28-badges-categories.md
+++ b/docs/superpowers/plans/2026-07-28-badges-categories.md
@@ -60,7 +60,7 @@
 **Files:**
 
 - Modify: `shared/types.ts:113-129`
-- Test: `shared/__tests__/badges-catalog.test.ts` (créer)
+- Test: `server/src/lib/__tests__/badges-catalog.test.ts` (créer)
 
 **Interfaces:**
 
@@ -68,11 +68,14 @@
 
 - [ ] **Step 1: Écrire le test qui échoue**
 
-Créer `shared/__tests__/badges-catalog.test.ts` :
+Créer `server/src/lib/__tests__/badges-catalog.test.ts`. **Pas dans `shared/__tests__/`** : la CI
+lance `cd client && bunx vitest run` et `cd server && bun run test:coverage`, aucune des deux ne
+ramasse `shared/`, un test posé là ne tournerait jamais. Il vit donc à côté de `badges.test.ts`,
+qui teste déjà les seuils.
 
 ```ts
 import { describe, it, expect } from "vitest";
-import { BADGES, BADGE_CATEGORIES, type BadgeId } from "../types";
+import { BADGES, BADGE_CATEGORIES, type BadgeId } from "@ecoride/shared/types";
 
 describe("BADGES catalog", () => {
   it("contient 46 badges", () => {
@@ -123,7 +126,7 @@ describe("BADGES catalog", () => {
 
 - [ ] **Step 2: Lancer le test pour vérifier qu'il échoue**
 
-Run: `cd client && bunx vitest run ../shared/__tests__/badges-catalog.test.ts`
+Run: `cd server && bunx vitest run src/lib/__tests__/badges-catalog.test.ts`
 Expected: FAIL — `BADGE_CATEGORIES` n'existe pas, et `Object.keys(BADGES)` vaut 13.
 
 - [ ] **Step 3: Écrire le catalogue**
@@ -252,7 +255,7 @@ export interface ChallengeProgressDto {
 
 - [ ] **Step 4: Lancer les tests**
 
-Run: `cd client && bunx vitest run ../shared/__tests__/badges-catalog.test.ts`
+Run: `cd server && bunx vitest run src/lib/__tests__/badges-catalog.test.ts`
 Expected: PASS (5 tests).
 
 Puis `bun run typecheck` à la racine. Il **doit échouer** dans `server/src/lib/badges.ts` : `BADGE_THRESHOLDS` est un `Record<BadgeId, ...>` et il manque désormais 33 clés. C'est attendu — la tâche 2 le répare.
@@ -260,7 +263,7 @@ Puis `bun run typecheck` à la racine. Il **doit échouer** dans `server/src/lib
 - [ ] **Step 5: Commit**
 
 ```bash
-git add shared/types.ts shared/__tests__/badges-catalog.test.ts
+git add shared/types.ts server/src/lib/__tests__/badges-catalog.test.ts
 git commit -m "feat(badges): catalogue de 46 badges répartis en 6 catégories"
 ```
 

--- a/docs/superpowers/plans/2026-07-28-badges-categories.md
+++ b/docs/superpowers/plans/2026-07-28-badges-categories.md
@@ -1,0 +1,1498 @@
+# Badges — catégories, nouveaux paliers et défis glissants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Faire passer le catalogue de 13 à 46 badges répartis en 6 catégories, corriger les badges streak indexés sur la mauvaise métrique, et ajouter deux défis glissants hebdo/mensuel calculés à la lecture.
+
+**Architecture:** `BADGE_THRESHOLDS` garde sa forme `Record<BadgeId, (s: UserStats) => boolean>` — on élargit `UserStats` de 5 à 16 champs plutôt que de changer le moteur. Les agrégats coûteux (records journée, mois actifs, objectifs atteints, défis courants) se replient en TypeScript depuis une seule requête « sommes par jour UTC », dans une fonction pure testable sans base. Côté client, la grille de badges dupliquée entre profil et stats devient un composant unique groupé par catégorie.
+
+**Tech Stack:** Bun, Hono, Drizzle ORM, PostgreSQL, vitest, React 19, TailwindCSS v4, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-badges-categories-design.md`
+
+## Global Constraints
+
+- **Branche** : partir de `main` à jour (`git checkout main && git pull`), jamais commiter sur `main`. Une seule branche `feat/badges-categories` pour tout le plan, une PR à la fin.
+- **Conventional commits** : `feat:` pour les tâches 1 à 8. Le message déclenche l'auto-bump.
+- **Les 13 ids existants ne changent pas** : `first_trip`, `trips_10`, `trips_50`, `trips_100`, `km_100`, `km_500`, `km_1000`, `co2_10kg`, `co2_100kg`, `co2_1t`, `streak_7`, `streak_30`, `money_100`. Aucune migration de données.
+- **Modèle temporel** : tout est en **UTC** (`DATE(started_at AT TIME ZONE 'UTC')`, même expression que `computeStreak`), **sauf** `early_bird` et `night_owl` qui lisent l'heure locale via `user.timezone`. C'est la seule exception à la règle « backend UTC-only » documentée dans `server/src/lib/streaks.ts:13`.
+- **Tout badge est une fonction pure de `UserStats`** — jamais d'événement daté, sinon `reevaluateBadges()` ne peut pas le révoquer correctement.
+- **Seuils des défis** : 50 km/semaine (lundi→dimanche), 250 km/mois (mois civil).
+- **Garde-fou vitesse** : `maxTripSpeedKmh` ne considère que les trajets `distanceKm >= 5`.
+- **Vérification à chaque tâche** : `bun run typecheck` et `bun run lint` doivent passer avant chaque commit.
+
+---
+
+## File Structure
+
+**Créés :**
+
+| Fichier                                          | Responsabilité                                                                                                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `server/src/lib/derived-stats.ts`                | Fonction pure `computeDerivedStats()` : replie les sommes journalières en records semaine/mois, mois actifs, compteurs d'objectifs, et état des deux défis courants. Aucun accès DB. |
+| `server/src/lib/__tests__/derived-stats.test.ts` | Tests de la fonction pure : frontières de semaine, changement d'heure, tableau vide.                                                                                                 |
+| `client/src/components/badges/BadgeGrid.tsx`     | Grille de badges groupée par catégorie, avec compteur par catégorie. Remplace la duplication profil/stats.                                                                           |
+| `client/src/components/badges/ChallengeCard.tsx` | Carte de défi, prop `compact` pour la version dashboard.                                                                                                                             |
+| `client/e2e/badges-categories.spec.ts`           | e2e : 6 catégories affichées, barre de progression du défi.                                                                                                                          |
+
+**Modifiés :**
+
+| Fichier                                                  | Changement                                                                                                             |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `shared/types.ts:113-129`                                | `BADGES` passe à 46 entrées avec un champ `category`; ajout de `BADGE_CATEGORIES` et du type `BadgeCategory`.          |
+| `server/src/lib/badges.ts`                               | `UserStats` élargi, 33 prédicats ajoutés, streaks passés sur `longest`, agrégats A/B branchés dans les deux fonctions. |
+| `server/src/lib/__tests__/badges.test.ts`                | `makeStats()` élargi, 33 badges × 2 cas ajoutés.                                                                       |
+| `server/src/routes/stats.routes.ts`                      | La réponse expose `challenges`.                                                                                        |
+| `client/src/components/profile/ProfileBadgesSection.tsx` | Délègue à `BadgeGrid`.                                                                                                 |
+| `client/src/components/stats/StatsBadgesSection.tsx`     | Délègue à `BadgeGrid`, plus `ChallengeCard` en tête.                                                                   |
+| `client/src/pages/DashboardPage.tsx`                     | `ChallengeCard` en version compacte.                                                                                   |
+| `client/src/i18n/locales/fr.ts` et `en.ts`               | Clés des catégories et des défis.                                                                                      |
+
+**Décision de périmètre — libellés des badges :** la spec prévoyait de basculer les libellés vers i18n. **Reporté**, pour une raison technique découverte au moment du plan : `server/src/routes/trips.routes.ts:138` construit le texte de la notification push avec `BADGES[badgeId].label`. Déplacer les libellés côté client casserait le push, ou imposerait de dupliquer 46 chaînes françaises. Les libellés restent donc dans `BADGES`. Seuls les **noms de catégories** et les textes des **défis** passent par i18n, parce qu'eux n'existent que côté client.
+
+---
+
+### Task 1: Catalogue de badges et catégories (shared)
+
+`BadgeId` est dérivé des clés de `BADGES`. Cette tâche doit donc précéder toute modification de `BADGE_THRESHOLDS`, sinon le typecheck échoue.
+
+**Files:**
+
+- Modify: `shared/types.ts:113-129`
+- Test: `shared/__tests__/badges-catalog.test.ts` (créer)
+
+**Interfaces:**
+
+- Produces: `BADGES` (46 entrées, chacune `{ id, label, icon, category }`), `type BadgeId`, `type BadgeCategory`, `BADGE_CATEGORIES: readonly BadgeCategory[]`, `interface ChallengeProgressDto`.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `shared/__tests__/badges-catalog.test.ts` :
+
+```ts
+import { describe, it, expect } from "vitest";
+import { BADGES, BADGE_CATEGORIES, type BadgeId } from "../types";
+
+describe("BADGES catalog", () => {
+  it("contient 46 badges", () => {
+    expect(Object.keys(BADGES)).toHaveLength(46);
+  });
+
+  it("garde les 13 ids historiques intacts", () => {
+    const legacy: BadgeId[] = [
+      "first_trip",
+      "trips_10",
+      "trips_50",
+      "trips_100",
+      "km_100",
+      "km_500",
+      "km_1000",
+      "co2_10kg",
+      "co2_100kg",
+      "co2_1t",
+      "streak_7",
+      "streak_30",
+      "money_100",
+    ];
+    for (const id of legacy) {
+      expect(BADGES[id]).toBeDefined();
+    }
+  });
+
+  it("donne à chaque badge une catégorie connue", () => {
+    for (const badge of Object.values(BADGES)) {
+      expect(BADGE_CATEGORIES).toContain(badge.category);
+    }
+  });
+
+  it("a un id cohérent avec sa clé", () => {
+    for (const [key, badge] of Object.entries(BADGES)) {
+      expect(badge.id).toBe(key);
+    }
+  });
+
+  it("répartit les badges dans les 6 catégories aux bons effectifs", () => {
+    const counts = BADGE_CATEGORIES.map(
+      (c) => Object.values(BADGES).filter((b) => b.category === c).length,
+    );
+    expect(counts).toEqual([12, 13, 9, 5, 4, 3]);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer le test pour vérifier qu'il échoue**
+
+Run: `cd client && bunx vitest run ../shared/__tests__/badges-catalog.test.ts`
+Expected: FAIL — `BADGE_CATEGORIES` n'existe pas, et `Object.keys(BADGES)` vaut 13.
+
+- [ ] **Step 3: Écrire le catalogue**
+
+Dans `shared/types.ts`, remplacer le bloc `BADGES` (lignes 113-129) par :
+
+```ts
+export const BADGE_CATEGORIES = [
+  "volume",
+  "impact",
+  "regularity",
+  "records",
+  "habits",
+  "performance",
+] as const;
+
+export type BadgeCategory = (typeof BADGE_CATEGORIES)[number];
+
+export const BADGES = {
+  // ---- 🚴 Volume (12) ----
+  first_trip: { id: "first_trip", label: "Premier trajet", icon: "🚴", category: "volume" },
+  trips_10: { id: "trips_10", label: "10 trajets", icon: "🔟", category: "volume" },
+  trips_50: { id: "trips_50", label: "50 trajets", icon: "🏅", category: "volume" },
+  trips_100: { id: "trips_100", label: "100 trajets", icon: "💯", category: "volume" },
+  trips_250: { id: "trips_250", label: "250 trajets", icon: "🎖️", category: "volume" },
+  trips_500: { id: "trips_500", label: "500 trajets", icon: "🏆", category: "volume" },
+  km_100: { id: "km_100", label: "100 km", icon: "🛤️", category: "volume" },
+  km_500: { id: "km_500", label: "500 km", icon: "🗺️", category: "volume" },
+  km_1000: { id: "km_1000", label: "1 000 km", icon: "🌍", category: "volume" },
+  km_2500: { id: "km_2500", label: "2 500 km", icon: "🧭", category: "volume" },
+  km_5000: { id: "km_5000", label: "5 000 km", icon: "🛰️", category: "volume" },
+  km_10000: { id: "km_10000", label: "10 000 km", icon: "🌐", category: "volume" },
+
+  // ---- 🌱 Impact (13) ----
+  co2_10kg: { id: "co2_10kg", label: "10 kg CO₂ économisés", icon: "🌱", category: "impact" },
+  co2_100kg: { id: "co2_100kg", label: "100 kg CO₂ économisés", icon: "🌳", category: "impact" },
+  co2_250kg: { id: "co2_250kg", label: "250 kg CO₂ économisés", icon: "🌿", category: "impact" },
+  co2_500kg: { id: "co2_500kg", label: "500 kg CO₂ économisés", icon: "🍃", category: "impact" },
+  co2_1t: { id: "co2_1t", label: "1 tonne CO₂ économisée", icon: "🌲", category: "impact" },
+  fuel_25l: { id: "fuel_25l", label: "25 L économisés", icon: "⛽", category: "impact" },
+  fuel_50l: { id: "fuel_50l", label: "50 L économisés", icon: "🛢️", category: "impact" },
+  fuel_100l: { id: "fuel_100l", label: "100 L économisés", icon: "🚫", category: "impact" },
+  fuel_250l: { id: "fuel_250l", label: "250 L économisés", icon: "🏭", category: "impact" },
+  money_100: { id: "money_100", label: "100 € économisés", icon: "💰", category: "impact" },
+  money_250: { id: "money_250", label: "250 € économisés", icon: "💶", category: "impact" },
+  money_500: { id: "money_500", label: "500 € économisés", icon: "💸", category: "impact" },
+  money_1000: { id: "money_1000", label: "1 000 € économisés", icon: "💎", category: "impact" },
+
+  // ---- 🔥 Régularité (9) ----
+  streak_3: { id: "streak_3", label: "3 jours d'affilée", icon: "🌤️", category: "regularity" },
+  streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥", category: "regularity" },
+  streak_14: { id: "streak_14", label: "14 jours d'affilée", icon: "🌗", category: "regularity" },
+  streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡", category: "regularity" },
+  streak_100: {
+    id: "streak_100",
+    label: "100 jours d'affilée",
+    icon: "🌟",
+    category: "regularity",
+  },
+  months_active_6: {
+    id: "months_active_6",
+    label: "6 mois actifs",
+    icon: "📆",
+    category: "regularity",
+  },
+  months_active_12: {
+    id: "months_active_12",
+    label: "12 mois actifs",
+    icon: "🎂",
+    category: "regularity",
+  },
+  weekly_goal_10: {
+    id: "weekly_goal_10",
+    label: "10 objectifs hebdo",
+    icon: "🎯",
+    category: "regularity",
+  },
+  monthly_goal_3: {
+    id: "monthly_goal_3",
+    label: "3 objectifs mensuels",
+    icon: "🗓️",
+    category: "regularity",
+  },
+
+  // ---- 🏆 Records (5) ----
+  day_30: { id: "day_30", label: "30 km en un jour", icon: "☀️", category: "records" },
+  day_50: { id: "day_50", label: "50 km en un jour", icon: "🌞", category: "records" },
+  trip_25: { id: "trip_25", label: "Trajet de 25 km", icon: "🚀", category: "records" },
+  trip_50: { id: "trip_50", label: "Trajet de 50 km", icon: "🛫", category: "records" },
+  trip_2h: { id: "trip_2h", label: "2 h en selle", icon: "⏱️", category: "records" },
+
+  // ---- 🕐 Habitudes (4) ----
+  early_bird: { id: "early_bird", label: "Lève-tôt", icon: "🌅", category: "habits" },
+  night_owl: { id: "night_owl", label: "Noctambule", icon: "🦉", category: "habits" },
+  weekend_20: { id: "weekend_20", label: "20 trajets le week-end", icon: "🎒", category: "habits" },
+  all_week: {
+    id: "all_week",
+    label: "Tous les jours de la semaine",
+    icon: "📅",
+    category: "habits",
+  },
+
+  // ---- ⚡ Performance (3) ----
+  speed_20: { id: "speed_20", label: "20 km/h de moyenne", icon: "⚡", category: "performance" },
+  speed_22: { id: "speed_22", label: "22 km/h de moyenne", icon: "💨", category: "performance" },
+  speed_25: { id: "speed_25", label: "25 km/h de moyenne", icon: "🔥", category: "performance" },
+} as const satisfies Record<
+  string,
+  { id: string; label: string; icon: string; category: BadgeCategory }
+>;
+
+export type BadgeId = keyof typeof BADGES;
+
+/**
+ * État d'un défi glissant. Défini ici parce que le serveur le produit
+ * (derived-stats.ts) et le client le consomme (ChallengeCard.tsx).
+ */
+export interface ChallengeProgressDto {
+  distanceKm: number;
+  goalKm: number;
+  tripCount: number;
+  activeDays: number;
+  co2Kg: number;
+}
+```
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd client && bunx vitest run ../shared/__tests__/badges-catalog.test.ts`
+Expected: PASS (5 tests).
+
+Puis `bun run typecheck` à la racine. Il **doit échouer** dans `server/src/lib/badges.ts` : `BADGE_THRESHOLDS` est un `Record<BadgeId, ...>` et il manque désormais 33 clés. C'est attendu — la tâche 2 le répare.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/types.ts shared/__tests__/badges-catalog.test.ts
+git commit -m "feat(badges): catalogue de 46 badges répartis en 6 catégories"
+```
+
+---
+
+### Task 2: UserStats élargi et les 33 nouveaux prédicats
+
+**Files:**
+
+- Modify: `server/src/lib/badges.ts:11-33`
+- Modify: `server/src/lib/__tests__/badges.test.ts:9-18`
+
+**Interfaces:**
+
+- Consumes: `BadgeId` (Task 1).
+- Produces: `UserStats` à 16 champs, `BADGE_THRESHOLDS` à 46 entrées.
+
+- [ ] **Step 1: Élargir le constructeur de test**
+
+Dans `server/src/lib/__tests__/badges.test.ts`, remplacer `makeStats` :
+
+```ts
+function makeStats(overrides: Partial<UserStats> = {}): UserStats {
+  return {
+    totalDistanceKm: 0,
+    totalCo2SavedKg: 0,
+    totalMoneySavedEur: 0,
+    totalFuelSavedL: 0,
+    tripCount: 0,
+    longestStreak: 0,
+    maxTripDistanceKm: 0,
+    maxTripDurationSec: 0,
+    maxTripSpeedKmh: 0,
+    maxDayDistanceKm: 0,
+    monthsActive: 0,
+    earlyTripCount: 0,
+    nightTripCount: 0,
+    weekendTripCount: 0,
+    distinctWeekdayCount: 0,
+    weeklyGoalsMet: 0,
+    monthlyGoalsMet: 0,
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 2: Écrire les tests des nouveaux badges**
+
+Ajouter dans le même fichier, à la suite des `describe` existants. Le pattern du repo est « seuil exact + juste en dessous » ; on le tient pour les 33.
+
+```ts
+describe("nouveaux paliers cumulatifs", () => {
+  const cases: [BadgeId, keyof UserStats, number][] = [
+    ["trips_250", "tripCount", 250],
+    ["trips_500", "tripCount", 500],
+    ["km_2500", "totalDistanceKm", 2500],
+    ["km_5000", "totalDistanceKm", 5000],
+    ["km_10000", "totalDistanceKm", 10000],
+    ["co2_250kg", "totalCo2SavedKg", 250],
+    ["co2_500kg", "totalCo2SavedKg", 500],
+    ["fuel_25l", "totalFuelSavedL", 25],
+    ["fuel_50l", "totalFuelSavedL", 50],
+    ["fuel_100l", "totalFuelSavedL", 100],
+    ["fuel_250l", "totalFuelSavedL", 250],
+    ["money_250", "totalMoneySavedEur", 250],
+    ["money_500", "totalMoneySavedEur", 500],
+    ["money_1000", "totalMoneySavedEur", 1000],
+    ["streak_3", "longestStreak", 3],
+    ["streak_14", "longestStreak", 14],
+    ["streak_100", "longestStreak", 100],
+    ["months_active_6", "monthsActive", 6],
+    ["months_active_12", "monthsActive", 12],
+    ["weekly_goal_10", "weeklyGoalsMet", 10],
+    ["monthly_goal_3", "monthlyGoalsMet", 3],
+    ["day_30", "maxDayDistanceKm", 30],
+    ["day_50", "maxDayDistanceKm", 50],
+    ["trip_25", "maxTripDistanceKm", 25],
+    ["trip_50", "maxTripDistanceKm", 50],
+    ["trip_2h", "maxTripDurationSec", 7200],
+    ["early_bird", "earlyTripCount", 10],
+    ["night_owl", "nightTripCount", 10],
+    ["weekend_20", "weekendTripCount", 20],
+    ["all_week", "distinctWeekdayCount", 7],
+    ["speed_20", "maxTripSpeedKmh", 20],
+    ["speed_22", "maxTripSpeedKmh", 22],
+    ["speed_25", "maxTripSpeedKmh", 25],
+  ];
+
+  for (const [badgeId, field, threshold] of cases) {
+    it(`${badgeId} se débloque au seuil exact et pas juste en dessous`, () => {
+      expect(BADGE_THRESHOLDS[badgeId](makeStats({ [field]: threshold }))).toBe(true);
+      expect(BADGE_THRESHOLDS[badgeId](makeStats({ [field]: threshold - 1 }))).toBe(false);
+    });
+  }
+});
+
+describe("badges streak indexés sur longestStreak", () => {
+  it("garde streak_7 quand la série actuelle est cassée mais que le record tient", () => {
+    expect(BADGE_THRESHOLDS.streak_7(makeStats({ longestStreak: 12 }))).toBe(true);
+  });
+
+  it("ne débloque pas streak_30 avec un record de 29", () => {
+    expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 29 }))).toBe(false);
+  });
+});
+```
+
+Ajouter `import type { BadgeId } from "@ecoride/shared/types";` en tête du fichier de test.
+
+- [ ] **Step 3: Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `cd server && bunx vitest run src/lib/__tests__/badges.test.ts`
+Expected: FAIL — les prédicats n'existent pas et `UserStats` n'a pas les champs.
+
+- [ ] **Step 4: Écrire l'implémentation**
+
+Dans `server/src/lib/badges.ts`, remplacer `UserStats` et `BADGE_THRESHOLDS` :
+
+```ts
+export interface UserStats {
+  totalDistanceKm: number;
+  totalCo2SavedKg: number;
+  totalMoneySavedEur: number;
+  totalFuelSavedL: number;
+  tripCount: number;
+  /** Plus longue série jamais réalisée. Les badges streak s'appuient dessus, pas sur la série en cours. */
+  longestStreak: number;
+  maxTripDistanceKm: number;
+  maxTripDurationSec: number;
+  /** Vitesse du meilleur trajet d'au moins 5 km. Sous ce seuil, une descente courte fausserait tout. */
+  maxTripSpeedKmh: number;
+  maxDayDistanceKm: number;
+  monthsActive: number;
+  /** Trajets démarrés avant 7 h — heure LOCALE, seule exception à la règle UTC-only du backend. */
+  earlyTripCount: number;
+  /** Trajets démarrés à 21 h ou après — heure LOCALE. */
+  nightTripCount: number;
+  weekendTripCount: number;
+  /** Nombre de jours de la semaine distincts (UTC). 7 = all_week. */
+  distinctWeekdayCount: number;
+  weeklyGoalsMet: number;
+  monthlyGoalsMet: number;
+}
+
+export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
+  // Volume
+  first_trip: (s) => s.tripCount >= 1,
+  trips_10: (s) => s.tripCount >= 10,
+  trips_50: (s) => s.tripCount >= 50,
+  trips_100: (s) => s.tripCount >= 100,
+  trips_250: (s) => s.tripCount >= 250,
+  trips_500: (s) => s.tripCount >= 500,
+  km_100: (s) => s.totalDistanceKm >= 100,
+  km_500: (s) => s.totalDistanceKm >= 500,
+  km_1000: (s) => s.totalDistanceKm >= 1000,
+  km_2500: (s) => s.totalDistanceKm >= 2500,
+  km_5000: (s) => s.totalDistanceKm >= 5000,
+  km_10000: (s) => s.totalDistanceKm >= 10000,
+
+  // Impact
+  co2_10kg: (s) => s.totalCo2SavedKg >= 10,
+  co2_100kg: (s) => s.totalCo2SavedKg >= 100,
+  co2_250kg: (s) => s.totalCo2SavedKg >= 250,
+  co2_500kg: (s) => s.totalCo2SavedKg >= 500,
+  co2_1t: (s) => s.totalCo2SavedKg >= 1000,
+  fuel_25l: (s) => s.totalFuelSavedL >= 25,
+  fuel_50l: (s) => s.totalFuelSavedL >= 50,
+  fuel_100l: (s) => s.totalFuelSavedL >= 100,
+  fuel_250l: (s) => s.totalFuelSavedL >= 250,
+  money_100: (s) => s.totalMoneySavedEur >= 100,
+  money_250: (s) => s.totalMoneySavedEur >= 250,
+  money_500: (s) => s.totalMoneySavedEur >= 500,
+  money_1000: (s) => s.totalMoneySavedEur >= 1000,
+
+  // Régularité — sur longestStreak, pas sur la série en cours
+  streak_3: (s) => s.longestStreak >= 3,
+  streak_7: (s) => s.longestStreak >= 7,
+  streak_14: (s) => s.longestStreak >= 14,
+  streak_30: (s) => s.longestStreak >= 30,
+  streak_100: (s) => s.longestStreak >= 100,
+  months_active_6: (s) => s.monthsActive >= 6,
+  months_active_12: (s) => s.monthsActive >= 12,
+  weekly_goal_10: (s) => s.weeklyGoalsMet >= 10,
+  monthly_goal_3: (s) => s.monthlyGoalsMet >= 3,
+
+  // Records
+  day_30: (s) => s.maxDayDistanceKm >= 30,
+  day_50: (s) => s.maxDayDistanceKm >= 50,
+  trip_25: (s) => s.maxTripDistanceKm >= 25,
+  trip_50: (s) => s.maxTripDistanceKm >= 50,
+  trip_2h: (s) => s.maxTripDurationSec >= 7200,
+
+  // Habitudes
+  early_bird: (s) => s.earlyTripCount >= 10,
+  night_owl: (s) => s.nightTripCount >= 10,
+  weekend_20: (s) => s.weekendTripCount >= 20,
+  all_week: (s) => s.distinctWeekdayCount >= 7,
+
+  // Performance
+  speed_20: (s) => s.maxTripSpeedKmh >= 20,
+  speed_22: (s) => s.maxTripSpeedKmh >= 22,
+  speed_25: (s) => s.maxTripSpeedKmh >= 25,
+};
+```
+
+`currentStreak` disparaît de `UserStats` : plus aucun badge ne s'en sert. Les deux appels `currentStreak: streaks.current` dans `evaluateAndUnlockBadges` et `reevaluateBadges` seront corrigés en tâche 4 — d'ici là le typecheck reste rouge sur ces deux lignes, c'est attendu.
+
+- [ ] **Step 5: Lancer les tests**
+
+Run: `cd server && bunx vitest run src/lib/__tests__/badges.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/lib/badges.ts server/src/lib/__tests__/badges.test.ts
+git commit -m "feat(badges): 33 nouveaux prédicats et bascule des streaks sur longest"
+```
+
+---
+
+### Task 3: computeDerivedStats — fonction pure
+
+Toute la logique risquée (frontières de semaine, changement d'heure, mois civils) vit ici, sans base de données, sans horloge implicite. Même pattern que `computeStreakFromDates`.
+
+**Files:**
+
+- Create: `server/src/lib/derived-stats.ts`
+- Test: `server/src/lib/__tests__/derived-stats.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ChallengeProgressDto` (Task 1).
+- Produces:
+
+  ```ts
+  export const WEEKLY_GOAL_KM = 50;
+  export const MONTHLY_GOAL_KM = 250;
+  export interface DailyRow {
+    day: string;
+    distanceKm: number;
+    co2Kg: number;
+    tripCount: number;
+  }
+  export interface DerivedStats {
+    maxDayDistanceKm: number;
+    monthsActive: number;
+    weeklyGoalsMet: number;
+    monthlyGoalsMet: number;
+    currentWeek: ChallengeProgressDto;
+    currentMonth: ChallengeProgressDto;
+  }
+  export function computeDerivedStats(rows: DailyRow[], today: string): DerivedStats;
+  ```
+
+  `day` et `today` sont au format `YYYY-MM-DD`, en UTC.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `server/src/lib/__tests__/derived-stats.test.ts` :
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeDerivedStats, WEEKLY_GOAL_KM, type DailyRow } from "../derived-stats";
+
+function row(day: string, distanceKm: number, tripCount = 1): DailyRow {
+  return { day, distanceKm, co2Kg: distanceKm * 0.1617, tripCount };
+}
+
+describe("computeDerivedStats", () => {
+  it("renvoie des compteurs à zéro sur un historique vide", () => {
+    const d = computeDerivedStats([], "2026-07-28");
+    expect(d.maxDayDistanceKm).toBe(0);
+    expect(d.monthsActive).toBe(0);
+    expect(d.weeklyGoalsMet).toBe(0);
+    expect(d.monthlyGoalsMet).toBe(0);
+    expect(d.currentWeek.distanceKm).toBe(0);
+    expect(d.currentWeek.goalKm).toBe(WEEKLY_GOAL_KM);
+  });
+
+  it("retient la meilleure journée", () => {
+    const d = computeDerivedStats([row("2026-07-01", 12), row("2026-07-02", 41)], "2026-07-28");
+    expect(d.maxDayDistanceKm).toBe(41);
+  });
+
+  it("compte les mois civils distincts", () => {
+    const d = computeDerivedStats(
+      [row("2026-05-30", 10), row("2026-06-01", 10), row("2026-06-20", 10)],
+      "2026-07-28",
+    );
+    expect(d.monthsActive).toBe(2);
+  });
+
+  it("fait démarrer la semaine le lundi", () => {
+    // 2026-07-26 est un dimanche, 2026-07-27 le lundi suivant.
+    const d = computeDerivedStats([row("2026-07-26", 30), row("2026-07-27", 20)], "2026-07-28");
+    // Seul le lundi et après comptent dans la semaine en cours.
+    expect(d.currentWeek.distanceKm).toBe(20);
+  });
+
+  it("compte une semaine réussie quand le cumul lundi-dimanche atteint l'objectif", () => {
+    const d = computeDerivedStats(
+      [row("2026-07-06", 25), row("2026-07-08", 25), row("2026-07-13", 10)],
+      "2026-07-28",
+    );
+    expect(d.weeklyGoalsMet).toBe(1);
+  });
+
+  it("compte les mois réussis à 250 km", () => {
+    const d = computeDerivedStats(
+      [row("2026-05-02", 150), row("2026-05-20", 100), row("2026-06-02", 40)],
+      "2026-07-28",
+    );
+    expect(d.monthlyGoalsMet).toBe(1);
+  });
+
+  it("agrège trajets, jours actifs et CO₂ du mois en cours", () => {
+    const d = computeDerivedStats(
+      [row("2026-07-02", 20, 3), row("2026-07-15", 30, 2), row("2026-06-30", 99, 9)],
+      "2026-07-28",
+    );
+    expect(d.currentMonth.distanceKm).toBe(50);
+    expect(d.currentMonth.tripCount).toBe(5);
+    expect(d.currentMonth.activeDays).toBe(2);
+    expect(d.currentMonth.co2Kg).toBeCloseTo(50 * 0.1617, 3);
+  });
+
+  it("n'est pas perturbé par le passage à l'heure d'hiver", () => {
+    // 2026-10-25 est le dimanche du changement d'heure en Europe.
+    // Les jours arrivent en UTC : la semaine doit rester à 7 jours.
+    const d = computeDerivedStats(
+      [row("2026-10-19", 10), row("2026-10-25", 10), row("2026-10-26", 10)],
+      "2026-10-26",
+    );
+    expect(d.currentWeek.distanceKm).toBe(10);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `cd server && bunx vitest run src/lib/__tests__/derived-stats.test.ts`
+Expected: FAIL — `Cannot find module '../derived-stats'`.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `server/src/lib/derived-stats.ts` :
+
+```ts
+/**
+ * Repli des sommes journalières en records, mois actifs, objectifs atteints
+ * et état des deux défis en cours.
+ *
+ * Fonction pure : aucun accès base, aucune lecture d'horloge. `today` est
+ * injecté pour que les tests soient déterministes. Toutes les dates sont des
+ * jours UTC au format YYYY-MM-DD, cohérent avec computeStreak().
+ */
+
+import type { ChallengeProgressDto } from "@ecoride/shared/types";
+
+export const WEEKLY_GOAL_KM = 50;
+export const MONTHLY_GOAL_KM = 250;
+
+export interface DailyRow {
+  day: string; // YYYY-MM-DD, UTC
+  distanceKm: number;
+  co2Kg: number;
+  tripCount: number;
+}
+
+export interface DerivedStats {
+  maxDayDistanceKm: number;
+  monthsActive: number;
+  weeklyGoalsMet: number;
+  monthlyGoalsMet: number;
+  currentWeek: ChallengeProgressDto;
+  currentMonth: ChallengeProgressDto;
+}
+
+interface Bucket {
+  distanceKm: number;
+  co2Kg: number;
+  tripCount: number;
+  activeDays: number;
+}
+
+function emptyBucket(): Bucket {
+  return { distanceKm: 0, co2Kg: 0, tripCount: 0, activeDays: 0 };
+}
+
+/** Lundi de la semaine ISO contenant `day`, au format YYYY-MM-DD. */
+export function isoWeekStart(day: string): string {
+  const d = new Date(`${day}T00:00:00Z`);
+  // getUTCDay(): 0 = dimanche. On ramène dimanche à 7 pour que lundi = 1.
+  const dow = d.getUTCDay() === 0 ? 7 : d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - (dow - 1));
+  return d.toISOString().slice(0, 10);
+}
+
+function monthKey(day: string): string {
+  return day.slice(0, 7); // YYYY-MM
+}
+
+function fold(rows: DailyRow[], keyOf: (day: string) => string): Map<string, Bucket> {
+  const buckets = new Map<string, Bucket>();
+  for (const r of rows) {
+    const key = keyOf(r.day);
+    const b = buckets.get(key) ?? emptyBucket();
+    b.distanceKm += r.distanceKm;
+    b.co2Kg += r.co2Kg;
+    b.tripCount += r.tripCount;
+    b.activeDays += 1;
+    buckets.set(key, b);
+  }
+  return buckets;
+}
+
+function toProgress(b: Bucket | undefined, goalKm: number): ChallengeProgressDto {
+  const bucket = b ?? emptyBucket();
+  return {
+    distanceKm: bucket.distanceKm,
+    goalKm,
+    tripCount: bucket.tripCount,
+    activeDays: bucket.activeDays,
+    co2Kg: bucket.co2Kg,
+  };
+}
+
+export function computeDerivedStats(rows: DailyRow[], today: string): DerivedStats {
+  const weeks = fold(rows, isoWeekStart);
+  const months = fold(rows, monthKey);
+
+  let maxDayDistanceKm = 0;
+  for (const r of rows) {
+    if (r.distanceKm > maxDayDistanceKm) maxDayDistanceKm = r.distanceKm;
+  }
+
+  let weeklyGoalsMet = 0;
+  for (const b of weeks.values()) {
+    if (b.distanceKm >= WEEKLY_GOAL_KM) weeklyGoalsMet += 1;
+  }
+
+  let monthlyGoalsMet = 0;
+  for (const b of months.values()) {
+    if (b.distanceKm >= MONTHLY_GOAL_KM) monthlyGoalsMet += 1;
+  }
+
+  return {
+    maxDayDistanceKm,
+    monthsActive: months.size,
+    weeklyGoalsMet,
+    monthlyGoalsMet,
+    currentWeek: toProgress(weeks.get(isoWeekStart(today)), WEEKLY_GOAL_KM),
+    currentMonth: toProgress(months.get(monthKey(today)), MONTHLY_GOAL_KM),
+  };
+}
+```
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd server && bunx vitest run src/lib/__tests__/derived-stats.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/derived-stats.ts server/src/lib/__tests__/derived-stats.test.ts
+git commit -m "feat(badges): fonction pure de repli des stats journalières"
+```
+
+---
+
+### Task 4: Brancher les agrégats sur les deux fonctions d'évaluation
+
+**Files:**
+
+- Modify: `server/src/lib/badges.ts` (les deux fonctions et leurs requêtes)
+
+**Interfaces:**
+
+- Consumes: `computeDerivedStats`, `DailyRow` (Task 3); `UserStats` (Task 2).
+- Produces: `collectUserStats(userId: string): Promise<UserStats>` — exportée, réutilisée par la route stats en tâche 5.
+
+- [ ] **Step 1: Écrire le test de non-régression sur la révocation**
+
+Ajouter dans `server/src/lib/__tests__/badges.test.ts` :
+
+```ts
+describe("révocation", () => {
+  it("retire un badge de palier dont le seuil n'est plus atteint", () => {
+    expect(BADGE_THRESHOLDS.km_2500(makeStats({ totalDistanceKm: 2499 }))).toBe(false);
+  });
+
+  it("ne retire pas un badge streak quand la série en cours est nulle mais le record tient", () => {
+    // Régression : avant, les badges streak lisaient currentStreak et
+    // disparaissaient à la première suppression de trajet.
+    expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 31 }))).toBe(true);
+  });
+
+  it("ignore un trajet court et rapide pour les badges de vitesse", () => {
+    // maxTripSpeedKmh n'est alimenté que par les trajets >= 5 km,
+    // donc une descente de 500 m à 40 km/h laisse le champ à 0.
+    expect(BADGE_THRESHOLDS.speed_25(makeStats({ maxTripSpeedKmh: 0 }))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer les tests**
+
+Run: `cd server && bunx vitest run src/lib/__tests__/badges.test.ts`
+Expected: PASS — ces trois assertions passent déjà grâce à la tâche 2. Elles verrouillent le comportement avant qu'on touche aux requêtes.
+
+- [ ] **Step 3: Extraire la collecte des stats**
+
+Dans `server/src/lib/badges.ts`, remplacer les deux blocs d'agrégation dupliqués (ils sont aujourd'hui copiés à l'identique dans `evaluateAndUnlockBadges` et `reevaluateBadges`) par une fonction unique.
+
+Ajouter les imports :
+
+```ts
+import { eq, and, sum, count, max, sql, inArray } from "drizzle-orm";
+import { user } from "../db/schema";
+import { computeDerivedStats, type DailyRow } from "./derived-stats";
+import { normalizeTimezone } from "./timezone";
+```
+
+Puis :
+
+```ts
+/**
+ * Agrège toutes les métriques dont dépendent les badges.
+ *
+ * Trois requêtes :
+ *   A — agrégat une-ligne (sommes, maxima, compteurs d'habitudes)
+ *   B — sommes par jour UTC, repliées en TypeScript par computeDerivedStats
+ *   C — computeStreak, dont on ne garde que `longest`
+ */
+export async function collectUserStats(userId: string): Promise<UserStats> {
+  const [profile] = await db
+    .select({ timezone: user.timezone })
+    .from(user)
+    .where(eq(user.id, userId));
+
+  // Seule exception à la règle UTC-only du backend : l'heure de la journée est
+  // intrinsèquement locale, sinon "avant 7 h" devient "avant 9 h" à Paris en été.
+  const tz = normalizeTimezone(profile?.timezone);
+  const localHour = sql<number>`EXTRACT(hour FROM ${trips.startedAt} AT TIME ZONE ${tz})`;
+  const utcDow = sql<number>`EXTRACT(dow FROM ${trips.startedAt} AT TIME ZONE 'UTC')`;
+
+  const [agg] = await db
+    .select({
+      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
+      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
+      totalFuelSavedL: sum(trips.fuelSavedL).mapWith(Number),
+      tripCount: count(),
+      maxTripDistanceKm: max(trips.distanceKm).mapWith(Number),
+      maxTripDurationSec: max(trips.durationSec).mapWith(Number),
+      maxTripSpeedKmh: sql<number>`coalesce(max(
+        case when ${trips.distanceKm} >= 5 and ${trips.durationSec} > 0
+        then ${trips.distanceKm} / (${trips.durationSec} / 3600.0)
+        end
+      ), 0)`.mapWith(Number),
+      earlyTripCount: sql<number>`count(*) filter (where ${localHour} < 7)`.mapWith(Number),
+      nightTripCount: sql<number>`count(*) filter (where ${localHour} >= 21)`.mapWith(Number),
+      weekendTripCount: sql<number>`count(*) filter (where ${utcDow} in (0, 6))`.mapWith(Number),
+      distinctWeekdayCount: sql<number>`count(distinct ${utcDow})`.mapWith(Number),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId));
+
+  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
+  const dailyRows: DailyRow[] = await db
+    .select({
+      day: dayExpr.as("day"),
+      distanceKm: sum(trips.distanceKm).mapWith(Number),
+      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId))
+    .groupBy(dayExpr);
+
+  const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
+  const streaks = await computeStreak(userId);
+
+  return {
+    totalDistanceKm: agg?.totalDistanceKm ?? 0,
+    totalCo2SavedKg: agg?.totalCo2SavedKg ?? 0,
+    totalMoneySavedEur: agg?.totalMoneySavedEur ?? 0,
+    totalFuelSavedL: agg?.totalFuelSavedL ?? 0,
+    tripCount: agg?.tripCount ?? 0,
+    longestStreak: streaks.longest,
+    maxTripDistanceKm: agg?.maxTripDistanceKm ?? 0,
+    maxTripDurationSec: agg?.maxTripDurationSec ?? 0,
+    maxTripSpeedKmh: agg?.maxTripSpeedKmh ?? 0,
+    maxDayDistanceKm: derived.maxDayDistanceKm,
+    monthsActive: derived.monthsActive,
+    earlyTripCount: agg?.earlyTripCount ?? 0,
+    nightTripCount: agg?.nightTripCount ?? 0,
+    weekendTripCount: agg?.weekendTripCount ?? 0,
+    distinctWeekdayCount: agg?.distinctWeekdayCount ?? 0,
+    weeklyGoalsMet: derived.weeklyGoalsMet,
+    monthlyGoalsMet: derived.monthlyGoalsMet,
+  };
+}
+```
+
+Puis remplacer, **dans les deux fonctions**, tout le bloc « 1. Aggregate lifetime stats » (de `const [stats] = await db` jusqu'à la fermeture de l'objet `userStats`) par :
+
+```ts
+const userStats = await collectUserStats(userId);
+```
+
+- [ ] **Step 4: Vérifier**
+
+Run: `cd server && bunx vitest run && bun run typecheck`
+Expected: PASS, plus aucune erreur de typecheck (les `currentStreak: streaks.current` ont disparu avec le bloc dupliqué).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/badges.ts
+git commit -m "feat(badges): collecte unifiée des agrégats pour les 46 badges"
+```
+
+---
+
+### Task 5: Exposer les défis dans /api/stats
+
+**Files:**
+
+- Modify: `server/src/routes/stats.routes.ts:62-80`
+- Test: `server/src/routes/__tests__/stats.test.ts`
+
+**Interfaces:**
+
+- Consumes: `computeDerivedStats` (Task 3), `ChallengeProgressDto` (Task 1).
+- Produces: la réponse `/api/stats` gagne `challenges: { week: ChallengeProgressDto; month: ChallengeProgressDto }`.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Ajouter dans `server/src/routes/__tests__/stats.test.ts`, en suivant le harnais de mock déjà présent dans le fichier :
+
+```ts
+it("expose la progression des défis hebdo et mensuel", async () => {
+  const res = await app.request("/stats");
+  const body = (await res.json()) as {
+    data: { challenges: { week: { goalKm: number }; month: { goalKm: number } } };
+  };
+  expect(body.data.challenges.week.goalKm).toBe(50);
+  expect(body.data.challenges.month.goalKm).toBe(250);
+});
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `cd server && bunx vitest run src/routes/__tests__/stats.test.ts`
+Expected: FAIL — `challenges` est `undefined`.
+
+- [ ] **Step 3: Implémenter**
+
+Dans `server/src/routes/stats.routes.ts`, à la suite du calcul existant de `stats` et `streaks`, ajouter la requête journalière et le repli, puis inclure le bloc dans la réponse :
+
+```ts
+const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
+const dailyRows = await db
+  .select({
+    day: dayExpr.as("day"),
+    distanceKm: sum(trips.distanceKm).mapWith(Number),
+    co2Kg: sum(trips.co2SavedKg).mapWith(Number),
+    tripCount: count(),
+  })
+  .from(trips)
+  .where(eq(trips.userId, currentUser.id))
+  .groupBy(dayExpr);
+
+const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
+```
+
+et dans le `c.json({ ok: true, data: { ... } })` :
+
+```ts
+      challenges: { week: derived.currentWeek, month: derived.currentMonth },
+```
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd server && bunx vitest run src/routes/__tests__/stats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/stats.routes.ts server/src/routes/__tests__/stats.test.ts
+git commit -m "feat(badges): expose la progression des défis dans /api/stats"
+```
+
+---
+
+### Task 6: BadgeGrid — grille unique groupée par catégorie
+
+`ProfileBadgesSection` et `StatsBadgesSection` contiennent aujourd'hui la même grille, copiée au caractère près. Cette tâche supprime la duplication en même temps qu'elle ajoute le regroupement.
+
+**Files:**
+
+- Create: `client/src/components/badges/BadgeGrid.tsx`
+- Modify: `client/src/components/profile/ProfileBadgesSection.tsx`
+- Modify: `client/src/components/stats/StatsBadgesSection.tsx`
+- Modify: `client/src/i18n/locales/fr.ts`, `client/src/i18n/locales/en.ts`
+- Test: `client/src/components/badges/__tests__/BadgeGrid.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `BADGES`, `BADGE_CATEGORIES`, `BadgeCategory` (Task 1).
+- Produces: `<BadgeGrid achievements={Achievement[]} />`.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `client/src/components/badges/__tests__/BadgeGrid.test.tsx` :
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BadgeGrid } from "../BadgeGrid";
+import { I18nProvider } from "@/i18n/provider";
+
+function renderGrid(achievements: { badgeId: string }[] = []) {
+  return render(
+    <I18nProvider>
+      <BadgeGrid achievements={achievements as never} />
+    </I18nProvider>,
+  );
+}
+
+describe("BadgeGrid", () => {
+  it("affiche les 6 catégories", () => {
+    renderGrid();
+    for (const label of ["Volume", "Impact", "Régularité", "Records", "Habitudes", "Performance"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("affiche le compteur de débloqués par catégorie", () => {
+    renderGrid([{ badgeId: "first_trip" }, { badgeId: "trips_10" }]);
+    expect(screen.getByText("2/12")).toBeInTheDocument();
+  });
+
+  it("affiche les 46 badges", () => {
+    renderGrid();
+    expect(screen.getAllByRole("listitem")).toHaveLength(46);
+  });
+});
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `cd client && bunx vitest run src/components/badges/__tests__/BadgeGrid.test.tsx`
+Expected: FAIL — `Cannot find module '../BadgeGrid'`.
+
+- [ ] **Step 3: Écrire le composant**
+
+Créer `client/src/components/badges/BadgeGrid.tsx` :
+
+```tsx
+import { BADGES, BADGE_CATEGORIES, type BadgeCategory, type BadgeId } from "@ecoride/shared/types";
+import type { Achievement } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+const badgesByCategory = BADGE_CATEGORIES.map((category) => ({
+  category,
+  ids: (Object.keys(BADGES) as BadgeId[]).filter((id) => BADGES[id].category === category),
+}));
+
+interface BadgeGridProps {
+  achievements: Achievement[];
+}
+
+export function BadgeGrid({ achievements }: BadgeGridProps) {
+  const t = useT();
+  const unlocked = new Set(achievements.map((a) => a.badgeId));
+
+  return (
+    <div className="space-y-6">
+      {badgesByCategory.map(({ category, ids }) => {
+        const count = ids.filter((id) => unlocked.has(id)).length;
+
+        return (
+          <section key={category} className="space-y-3">
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+                {t(`badges.category.${category}` as Parameters<typeof t>[0])}
+              </h3>
+              <span className="text-xs font-bold text-text-dim">
+                {count}/{ids.length}
+              </span>
+            </div>
+            <ul className="grid grid-cols-4 gap-4">
+              {ids.map((id) => {
+                const badge = BADGES[id];
+                const isUnlocked = unlocked.has(id);
+
+                return (
+                  <li
+                    key={id}
+                    className={`flex flex-col items-center gap-2 ${!isUnlocked ? "opacity-40" : ""}`}
+                  >
+                    <div
+                      className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
+                        isUnlocked
+                          ? "bg-primary/10 text-primary-light"
+                          : "bg-surface-high text-text-dim"
+                      }`}
+                    >
+                      <span className="text-2xl">{badge.icon}</span>
+                    </div>
+                    <span className="text-center text-xs font-bold uppercase leading-tight text-text-muted">
+                      {badge.label}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+Ajouter dans `client/src/i18n/locales/fr.ts` :
+
+```ts
+  "badges.category.volume": "Volume",
+  "badges.category.impact": "Impact",
+  "badges.category.regularity": "Régularité",
+  "badges.category.records": "Records",
+  "badges.category.habits": "Habitudes",
+  "badges.category.performance": "Performance",
+```
+
+et dans `en.ts` :
+
+```ts
+  "badges.category.volume": "Volume",
+  "badges.category.impact": "Impact",
+  "badges.category.regularity": "Consistency",
+  "badges.category.records": "Records",
+  "badges.category.habits": "Habits",
+  "badges.category.performance": "Performance",
+```
+
+- [ ] **Step 4: Remplacer les deux sections dupliquées**
+
+`client/src/components/profile/ProfileBadgesSection.tsx` devient :
+
+```tsx
+import type { Achievement } from "@ecoride/shared/types";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { useT } from "@/i18n/provider";
+
+interface ProfileBadgesSectionProps {
+  achievements: Achievement[];
+}
+
+export function ProfileBadgesSection({ achievements }: ProfileBadgesSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-bold tracking-tight">{t("profile.badges.title")}</h2>
+      <BadgeGrid achievements={achievements} />
+    </section>
+  );
+}
+```
+
+`client/src/components/stats/StatsBadgesSection.tsx` devient :
+
+```tsx
+import type { Achievement } from "@ecoride/shared/types";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { useT } from "@/i18n/provider";
+
+type StatsBadgesSectionProps = {
+  achievements: Achievement[];
+};
+
+export function StatsBadgesSection({ achievements }: StatsBadgesSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+        {t("stats.badges.title")}
+      </h3>
+      <BadgeGrid achievements={achievements} />
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5: Lancer les tests**
+
+Run: `cd client && bunx vitest run src/components/badges/`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/badges client/src/components/profile/ProfileBadgesSection.tsx client/src/components/stats/StatsBadgesSection.tsx client/src/i18n/locales
+git commit -m "feat(badges): grille unique groupée par catégorie"
+```
+
+---
+
+### Task 7: ChallengeCard
+
+**Files:**
+
+- Create: `client/src/components/badges/ChallengeCard.tsx`
+- Modify: `client/src/components/stats/StatsBadgesSection.tsx`
+- Modify: `client/src/pages/DashboardPage.tsx`
+- Modify: `client/src/i18n/locales/fr.ts`, `en.ts`
+- Test: `client/src/components/badges/__tests__/ChallengeCard.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `ChallengeProgressDto` (Task 5).
+- Produces: `<ChallengeCard period="week" | "month" progress={ChallengeProgressDto} compact?: boolean />`.
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `client/src/components/badges/__tests__/ChallengeCard.test.tsx` :
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChallengeCard } from "../ChallengeCard";
+import { I18nProvider } from "@/i18n/provider";
+
+const progress = { distanceKm: 32, goalKm: 50, tripCount: 6, activeDays: 3, co2Kg: 7.4 };
+
+describe("ChallengeCard", () => {
+  it("affiche la distance et l'objectif", () => {
+    render(
+      <I18nProvider>
+        <ChallengeCard period="week" progress={progress} />
+      </I18nProvider>,
+    );
+    expect(screen.getByText(/32/)).toBeInTheDocument();
+    expect(screen.getByText(/50/)).toBeInTheDocument();
+  });
+
+  it("borne la barre de progression à 100 % au-delà de l'objectif", () => {
+    render(
+      <I18nProvider>
+        <ChallengeCard period="week" progress={{ ...progress, distanceKm: 80 }} />
+      </I18nProvider>,
+    );
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "100");
+  });
+
+  it("masque les compteurs secondaires en mode compact", () => {
+    render(
+      <I18nProvider>
+        <ChallengeCard period="week" progress={progress} compact />
+      </I18nProvider>,
+    );
+    expect(screen.queryByText(/7,4/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `cd client && bunx vitest run src/components/badges/__tests__/ChallengeCard.test.tsx`
+Expected: FAIL — module introuvable.
+
+- [ ] **Step 3: Écrire le composant**
+
+Créer `client/src/components/badges/ChallengeCard.tsx` :
+
+```tsx
+import type { ChallengeProgressDto } from "@ecoride/shared/types";
+import { useT } from "@/i18n/provider";
+
+interface ChallengeCardProps {
+  period: "week" | "month";
+  progress: ChallengeProgressDto;
+  compact?: boolean;
+}
+
+export function ChallengeCard({ period, progress, compact = false }: ChallengeCardProps) {
+  const t = useT();
+  const pct = Math.min(100, Math.round((progress.distanceKm / progress.goalKm) * 100));
+
+  return (
+    <section className="space-y-2 rounded-2xl bg-surface-high p-4">
+      <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+        {t(`badges.challenge.${period}` as Parameters<typeof t>[0])}
+      </h3>
+
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="h-2 overflow-hidden rounded-full bg-surface"
+      >
+        <div className="h-full rounded-full bg-primary" style={{ width: `${pct}%` }} />
+      </div>
+
+      <p className="text-sm font-bold">
+        {Math.round(progress.distanceKm)} / {progress.goalKm} km
+      </p>
+
+      {!compact && (
+        <p className="text-xs text-text-muted">
+          {progress.tripCount} · {progress.activeDays} · {progress.co2Kg.toFixed(1)} kg CO₂
+        </p>
+      )}
+    </section>
+  );
+}
+```
+
+Ajouter dans `fr.ts` :
+
+```ts
+  "badges.challenge.week": "Défi de la semaine",
+  "badges.challenge.month": "Défi du mois",
+```
+
+et dans `en.ts` :
+
+```ts
+  "badges.challenge.week": "Weekly challenge",
+  "badges.challenge.month": "Monthly challenge",
+```
+
+- [ ] **Step 4: Brancher les deux emplacements**
+
+`StatsBadgesSection` gagne une prop `challenges` optionnelle et rend les deux cartes
+détaillées au-dessus de la grille :
+
+```tsx
+import type { Achievement, ChallengeProgressDto } from "@ecoride/shared/types";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { ChallengeCard } from "@/components/badges/ChallengeCard";
+import { useT } from "@/i18n/provider";
+
+type StatsBadgesSectionProps = {
+  achievements: Achievement[];
+  challenges?: { week: ChallengeProgressDto; month: ChallengeProgressDto };
+};
+
+export function StatsBadgesSection({ achievements, challenges }: StatsBadgesSectionProps) {
+  const t = useT();
+
+  return (
+    <section className="space-y-4">
+      {challenges && (
+        <div className="space-y-3">
+          <ChallengeCard period="week" progress={challenges.week} />
+          <ChallengeCard period="month" progress={challenges.month} />
+        </div>
+      )}
+      <h3 className="text-sm font-bold uppercase tracking-[0.15em] text-on-surface-variant">
+        {t("stats.badges.title")}
+      </h3>
+      <BadgeGrid achievements={achievements} />
+    </section>
+  );
+}
+```
+
+Le parent (`StatsPage`) passe `challenges={stats.challenges}` depuis la réponse
+`/api/stats` qu'il charge déjà. La prop est optionnelle pour que la page reste
+affichable pendant le chargement.
+
+Dans `DashboardPage`, insérer la version compacte au-dessus des sections existantes,
+en la conditionnant à la présence des données :
+
+```tsx
+{
+  stats?.challenges && <ChallengeCard period="week" progress={stats.challenges.week} compact />;
+}
+```
+
+⚠️ Ouvrir `client/src/pages/StatsPage.tsx` et `DashboardPage.tsx` avant d'éditer : le nom
+exact du hook de chargement des stats et la forme de son retour varient selon la page.
+Reprendre l'existant, ne pas inventer de nouveau fetch.
+
+- [ ] **Step 5: Lancer les tests**
+
+Run: `cd client && bunx vitest run src/components/badges/ && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/badges client/src/components/stats client/src/pages/DashboardPage.tsx client/src/i18n/locales
+git commit -m "feat(badges): carte de défi hebdo et mensuel"
+```
+
+---
+
+### Task 8: e2e Playwright
+
+**Files:**
+
+- Create: `client/e2e/badges-categories.spec.ts`
+
+**Interfaces:**
+
+- Consumes: tout ce qui précède.
+
+- [ ] **Step 1: Écrire le test**
+
+Le repo n'a **pas** de helper de stub : chaque spec appelle `page.route("**/api/**", ...)`
+en ligne et discrimine sur l'URL. Ouvrir `client/e2e/stats-period.spec.ts` et reprendre son
+préambule tel quel — désinscription du service worker, stub de `registerSW.js`, stub de
+`/api/auth/` — sans quoi la page redirige vers `/login` et le test échoue sans rapport avec
+les badges.
+
+```ts
+import { test, expect } from "@playwright/test";
+
+const CHALLENGES = {
+  week: { distanceKm: 32, goalKm: 50, tripCount: 6, activeDays: 3, co2Kg: 7.4 },
+  month: { distanceKm: 178, goalKm: 250, tripCount: 24, activeDays: 14, co2Kg: 41 },
+};
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify(body),
+});
+
+test.describe("Badges par catégorie", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker?.getRegistrations();
+      if (regs) await Promise.all(regs.map((r) => r.unregister()));
+      const names = await caches.keys();
+      await Promise.all(names.map((n) => caches.delete(n)));
+    });
+
+    await page.route("**/registerSW.js", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "// noop" }),
+    );
+
+    await page.route("**/api/**", (route) => {
+      const url = route.request().url();
+
+      if (url.includes("/api/auth/")) {
+        return route.fulfill(
+          json({ session: { id: "s", userId: "u" }, user: { id: "u", name: "Test" } }),
+        );
+      }
+
+      if (url.includes("/api/stats")) {
+        return route.fulfill(
+          json({
+            ok: true,
+            data: {
+              totalDistanceKm: 1159.8,
+              totalCo2SavedKg: 187.5,
+              achievements: [{ badgeId: "first_trip" }, { badgeId: "km_1000" }],
+              challenges: CHALLENGES,
+            },
+          }),
+        );
+      }
+
+      return route.fulfill(json({ ok: true, data: {} }));
+    });
+  });
+
+  test("affiche les 6 catégories", async ({ page }) => {
+    await page.goto("/stats");
+
+    for (const label of ["Volume", "Impact", "Régularité", "Records", "Habitudes", "Performance"]) {
+      await expect(page.getByText(label, { exact: true })).toBeVisible();
+    }
+  });
+
+  test("affiche la barre de progression du défi hebdo", async ({ page }) => {
+    await page.goto("/stats");
+
+    // 32 / 50 = 64 %
+    await expect(page.getByRole("progressbar").first()).toHaveAttribute("aria-valuenow", "64");
+  });
+});
+```
+
+⚠️ Le stub de `/api/auth/` ci-dessus est réduit au minimum. Si la page redirige quand même
+vers `/login`, copier la réponse d'authentification complète depuis `stats-period.spec.ts`,
+qui contient tous les champs attendus par le client.
+
+- [ ] **Step 2: Lancer**
+
+Run: `cd client && bunx playwright test e2e/badges-categories.spec.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Vérification complète**
+
+```bash
+bun run typecheck && bun run lint && bun run format:check
+cd server && bun run test:coverage
+cd ../client && bunx vitest run
+```
+
+Expected: tout vert.
+
+- [ ] **Step 4: Commit et PR**
+
+```bash
+git add client/e2e/badges-categories.spec.ts
+git commit -m "feat(badges): e2e sur les catégories et la carte de défi"
+git push -u origin feat/badges-categories
+gh pr create --title "feat(badges): 46 badges en 6 catégories et défis glissants" --body "Implémente docs/superpowers/specs/2026-07-28-badges-categories-design.md"
+```
+
+---
+
+## Points ouverts hérités de la spec
+
+À trancher avant merge, ils ne bloquent aucune tâche :
+
+1. **`trips_250` / `trips_500`** — nombre de trajets réel inconnu, paliers posés au jugé.
+2. **`streak_14` / `streak_100`** — plus longue série inconnue. 100 jours est peut-être hors d'atteinte, 60 serait un repli.
+3. **Import historique** — si des trajets antérieurs à mars 2026 existent, toute la calibration des paliers est trop optimiste.
+4. **Libellés i18n** — reportés (voir « Décision de périmètre » plus haut). À reprendre si le texte des notifications push est un jour localisé.

--- a/docs/superpowers/plans/2026-07-28-badges-categories.md
+++ b/docs/superpowers/plans/2026-07-28-badges-categories.md
@@ -4,7 +4,7 @@
 
 **Goal:** Faire passer le catalogue de 13 à 46 badges répartis en 6 catégories, corriger les badges streak indexés sur la mauvaise métrique, et ajouter deux défis glissants hebdo/mensuel calculés à la lecture.
 
-**Architecture:** `BADGE_THRESHOLDS` garde sa forme `Record<BadgeId, (s: UserStats) => boolean>` — on élargit `UserStats` de 5 à 16 champs plutôt que de changer le moteur. Les agrégats coûteux (records journée, mois actifs, objectifs atteints, défis courants) se replient en TypeScript depuis une seule requête « sommes par jour UTC », dans une fonction pure testable sans base. Côté client, la grille de badges dupliquée entre profil et stats devient un composant unique groupé par catégorie.
+**Architecture:** `BADGE_THRESHOLDS` garde sa forme `Record<BadgeId, (s: UserStats) => boolean>` — on élargit `UserStats` de 5 à 17 champs plutôt que de changer le moteur. Les agrégats coûteux (records journée, mois actifs, objectifs atteints, défis courants) se replient en TypeScript depuis une seule requête « sommes par jour UTC », dans une fonction pure testable sans base. Côté client, la grille de badges dupliquée entre profil et stats devient un composant unique groupé par catégorie.
 
 **Tech Stack:** Bun, Hono, Drizzle ORM, PostgreSQL, vitest, React 19, TailwindCSS v4, Playwright.
 
@@ -279,7 +279,7 @@ git commit -m "feat(badges): catalogue de 46 badges répartis en 6 catégories"
 **Interfaces:**
 
 - Consumes: `BadgeId` (Task 1).
-- Produces: `UserStats` à 16 champs, `BADGE_THRESHOLDS` à 46 entrées.
+- Produces: `UserStats` à 17 champs, `BADGE_THRESHOLDS` à 46 entrées.
 
 - [ ] **Step 1: Élargir le constructeur de test**
 

--- a/docs/superpowers/specs/2026-07-28-badges-categories-design.md
+++ b/docs/superpowers/specs/2026-07-28-badges-categories-design.md
@@ -45,6 +45,27 @@ Rythme dérivé : ~61 km/semaine, ~10 kg CO₂/semaine, ~4,3 L/semaine, ~7,5 €
 
 ---
 
+## Modèle temporel
+
+Le backend est **UTC-only par décision explicite et testée** :
+
+- `server/src/lib/streaks.ts:13` — « Backend calculations stay UTC-only. User timezone is
+  a presentation concern handled in the frontend from the saved profile setting. »
+- `server/src/auth/timezone.test.ts:18` — `it("ignores timezone headers because backend
+processing is UTC-only")`, et `timezoneMiddleware` jette délibérément `x-timezone`.
+
+Cette spec **conserve** cette décision, avec **une seule exception assumée** :
+
+| Ce qui est calculé                                         | Fuseau    | Pourquoi                                                                                        |
+| ---------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| Records jour / semaine / mois, mois actifs, défis, streaks | **UTC**   | Cohérence avec `computeStreak`; l'écart ne touche que les trajets à cheval sur minuit           |
+| `weekend_20`, `all_week` (jour de la semaine)              | **UTC**   | Même raison                                                                                     |
+| `early_bird`, `night_owl` (heure de la journée)            | **LOCAL** | En UTC, « avant 7 h » devient « avant 9 h » à Paris en été : le badge serait factuellement faux |
+
+Une heure de la journée est intrinsèquement locale — c'est le seul cas où l'UTC produit
+un badge dont le libellé ment. Le `user.timezone` peut être nul : dans ce cas on retombe
+sur `DEFAULT_TIMEZONE` via `normalizeTimezone()` (`server/src/lib/timezone.ts`).
+
 ## Les trois strates
 
 | Strate                | Exemple                         | Stockage                    | Reset                           |
@@ -136,7 +157,9 @@ sur les défis glissants, qui eux ne laissent aucune trace.
 
 ### 🕐 Habitudes — 4
 
-Toutes les heures sont **locales**, via `user.timezone`.
+`early_bird` et `night_owl` lisent l'**heure locale** via `user.timezone`.
+`weekend_20` et `all_week` restent en **UTC** comme le reste du backend — l'écart ne
+concerne que les trajets à cheval sur minuit. Voir « Modèle temporel » ci-dessous.
 
 | id               | seuil                                           | icône |
 | ---------------- | ----------------------------------------------- | ----- |
@@ -165,10 +188,10 @@ Seuils **fixes et partagés**, pas configurables ni adaptatifs : comparables ent
 utilisateurs, aucune UI de réglage, aucun effet de seuil qui s'effondre après une semaine
 de vacances.
 
-| Défi                                         | Objectif principal | Compteurs secondaires           |
-| -------------------------------------------- | ------------------ | ------------------------------- |
-| **Semaine** (lundi → dimanche, heure locale) | **50 km**          | trajets, jours actifs (/4), CO₂ |
-| **Mois** (mois civil, heure locale)          | **250 km**         | trajets, jours actifs, CO₂      |
+| Défi                                | Objectif principal | Compteurs secondaires           |
+| ----------------------------------- | ------------------ | ------------------------------- |
+| **Semaine** (lundi → dimanche, UTC) | **50 km**          | trajets, jours actifs (/4), CO₂ |
+| **Mois** (mois civil, UTC)          | **250 km**         | trajets, jours actifs, CO₂      |
 
 Le défi CO₂ est une transformation linéaire du défi km (facteur ADEME constant) : il
 afficherait toujours le même pourcentage. Il est donc **compteur secondaire**, pas
@@ -219,10 +242,11 @@ export interface UserStats {
 
 - **A** — agrégat une-ligne : les sommes existantes, plus `SUM(fuelSavedL)`,
   `MAX(distanceKm)`, `MAX(durationSec)`, `MAX(distanceKm / durationSec)` filtré sur
-  `distanceKm >= 5`, et des `COUNT(*) FILTER (WHERE ...)` pour les habitudes (heure
-  locale < 7, ≥ 21, week-end) plus `COUNT(DISTINCT dow)`.
-- **B** — sommes par **jour local** (`started_at AT TIME ZONE user.timezone`) :
-  une ligne par jour actif, ≤ 730 après deux ans.
+  `distanceKm >= 5`, et des `COUNT(*) FILTER (WHERE ...)` pour les habitudes : heure
+  **locale** < 7 et ≥ 21 (`EXTRACT(hour FROM started_at AT TIME ZONE $tz)`), week-end et
+  `COUNT(DISTINCT dow)` en **UTC**.
+- **B** — sommes par **jour UTC** (`DATE(started_at AT TIME ZONE 'UTC')`, même expression
+  que `computeStreak`) : une ligne par jour actif, ≤ 730 après deux ans.
 - **C** — `computeStreak()`, inchangé, dont on utilise désormais `longest`.
 
 ### computeDerivedStats — fonction pure
@@ -267,7 +291,7 @@ deux lignes de plus dans le même repli. Ils sont exposés dans la réponse `/ap
 - **`BADGE_THRESHOLDS`** — le fichier de tests existant suit déjà le pattern « seuil exact
   - juste en dessous ». Étendu aux 33 nouveaux badges.
 - **`computeDerivedStats`** — repli semaine/mois, frontière lundi, passage à l'heure
-  d'hiver, fuseau non-Paris, tableau vide.
+  d'hiver, tableau vide.
 - **Révocation** — un test par famille de nouveaux badges vérifiant que la suppression
   d'un trajet sous le seuil retire bien le badge (et, pour les streaks passés sur
   `longest`, qu'elle ne le retire **pas** à tort).

--- a/docs/superpowers/specs/2026-07-28-badges-categories-design.md
+++ b/docs/superpowers/specs/2026-07-28-badges-categories-design.md
@@ -1,0 +1,295 @@
+# Badges — nouveaux paliers, catégories et défis glissants
+
+**Date** : 2026-07-28
+**Statut** : spec validée, prête pour le plan d'implémentation
+
+---
+
+## Problème
+
+Les 13 badges actuels couvrent 5 axes cumulatifs à vie (trajets, km, CO₂, streak, argent).
+Trois défauts :
+
+1. **Échelles trouées** — un seul palier pour l'argent, aucun pour le carburant, et un
+   écart de 900 kg entre `co2_100kg` et `co2_1t`.
+2. **Les badges streak sont sur `currentStreak`** alors que `computeStreak()` renvoie aussi
+   `longest`. Conséquence : une série cassée ne retire rien tout de suite (car
+   `reevaluateBadges` ne tourne qu'à la suppression d'un trajet), mais le jour où
+   l'utilisateur supprime un trajet quelconque, `streak_30` disparaît sans rapport avec
+   la suppression. Incohérent dans les deux sens.
+3. **Aucun objectif court terme** — tous les seuils sont à vie, donc après quelques mois
+   plus rien n'est atteignable à court terme.
+
+L'UI aggrave le tout : `ProfileBadgesSection` et `StatsBadgesSection` sont la même grille
+copiée deux fois, sans regroupement, et les libellés sont du français en dur dans
+`shared/types.ts` alors que `client/src/i18n/locales/en.ts` existe.
+
+## Contrainte structurante
+
+`reevaluateBadges()` révoque un badge dont le prédicat redevient faux après suppression
+d'un trajet. **Tout badge doit donc être une fonction pure d'agrégats recalculables** —
+pas d'événement daté. Cette contrainte est conservée telle quelle : `BADGE_THRESHOLDS`
+garde sa forme `Record<BadgeId, (s: UserStats) => boolean>`, seul `UserStats` s'élargit.
+
+## Calibration
+
+Chiffres réels de référence au 2026-07-28 : **1 159,8 km**, **187,5 kg CO₂**,
+**18 km/h** de moyenne, sur une fenêtre de 19 semaines (premier commit du repo :
+2026-03-21).
+
+Rythme dérivé : ~61 km/semaine, ~10 kg CO₂/semaine, ~4,3 L/semaine, ~7,5 €/semaine.
+
+> **Hypothèse** : aucun trajet antérieur à mars 2026 n'a été importé. Si c'est faux, la
+> fenêtre de 19 semaines sous-estime la période réelle et tous les paliers ci-dessous sont
+> trop rapprochés.
+
+---
+
+## Les trois strates
+
+| Strate                | Exemple                         | Stockage                    | Reset                           |
+| --------------------- | ------------------------------- | --------------------------- | ------------------------------- |
+| **Défis**             | 32 / 50 km cette semaine        | aucun, calculé à la lecture | automatique (fenêtre glissante) |
+| **Constance**         | objectif hebdo atteint 10×      | `achievements`              | jamais                          |
+| **Paliers / records** | meilleur mois ≥ 250 km, 1 t CO₂ | `achievements`              | jamais                          |
+
+Un badge qui reset n'est pas un accomplissement mais un objectif en cours : il a un état
+(32/50), pas une date de déblocage. Le stocker imposerait une colonne période, un index
+unique et une UI affichant N fois le même badge. Calculé à la lecture depuis la fenêtre
+courante, le reset est gratuit.
+
+---
+
+## Catalogue — 46 badges permanents, 6 catégories
+
+Les 13 badges existants **gardent leur id** : aucune migration de données.
+Les 33 nouveaux sont en **gras**.
+
+### 🚴 Volume — 12
+
+| id              | seuil                     | icône |
+| --------------- | ------------------------- | ----- |
+| `first_trip`    | 1 trajet                  | 🚴    |
+| `trips_10`      | 10 trajets                | 🔟    |
+| `trips_50`      | 50 trajets                | 🏅    |
+| `trips_100`     | 100 trajets               | 💯    |
+| **`trips_250`** | 250 trajets ⚠️ à calibrer | 🎖️    |
+| **`trips_500`** | 500 trajets ⚠️ à calibrer | 🏆    |
+| `km_100`        | 100 km                    | 🛤️    |
+| `km_500`        | 500 km                    | 🗺️    |
+| `km_1000`       | 1 000 km                  | 🌍    |
+| **`km_2500`**   | 2 500 km (~8 mois)        | 🧭    |
+| **`km_5000`**   | 5 000 km (~20 mois)       | 🛰️    |
+| **`km_10000`**  | 10 000 km (~3 ans)        | 🌐    |
+
+### 🌱 Impact — 13
+
+| id               | seuil                | icône |
+| ---------------- | -------------------- | ----- |
+| `co2_10kg`       | 10 kg CO₂            | 🌱    |
+| `co2_100kg`      | 100 kg               | 🌳    |
+| **`co2_250kg`**  | 250 kg (~6 semaines) | 🌿    |
+| **`co2_500kg`**  | 500 kg (~7 mois)     | 🍃    |
+| `co2_1t`         | 1 000 kg (~20 mois)  | 🌲    |
+| **`fuel_25l`**   | 25 L économisés      | ⛽    |
+| **`fuel_50l`**   | 50 L                 | 🛢️    |
+| **`fuel_100l`**  | 100 L (~1 mois)      | 🚫    |
+| **`fuel_250l`**  | 250 L (~9 mois)      | 🏭    |
+| `money_100`      | 100 €                | 💰    |
+| **`money_250`**  | 250 € (~3,5 mois)    | 💶    |
+| **`money_500`**  | 500 € (~10 mois)     | 💸    |
+| **`money_1000`** | 1 000 € (~2 ans)     | 💎    |
+
+### 🔥 Régularité — 9
+
+**Tous les badges streak passent de `currentStreak` à `longestStreak`.** Une série de
+30 jours réalisée en janvier reste un accomplissement en juillet.
+
+| id                     | seuil                           | icône |
+| ---------------------- | ------------------------------- | ----- |
+| **`streak_3`**         | 3 jours consécutifs             | 🌤️    |
+| `streak_7`             | 7 jours                         | 🔥    |
+| **`streak_14`**        | 14 jours ⚠️ à calibrer          | 🌗    |
+| `streak_30`            | 30 jours                        | ⚡    |
+| **`streak_100`**       | 100 jours ⚠️ à calibrer         | 🌟    |
+| **`months_active_6`**  | 6 mois civils avec ≥ 1 trajet   | 📆    |
+| **`months_active_12`** | 12 mois civils                  | 🎂    |
+| **`weekly_goal_10`**   | objectif hebdo atteint 10 fois  | 🎯    |
+| **`monthly_goal_3`**   | objectif mensuel atteint 3 fois | 🗓️    |
+
+Les deux derniers sont la strate « constance » : ils rendent permanent l'effort fourni
+sur les défis glissants, qui eux ne laissent aucune trace.
+
+### 🏆 Records — 5
+
+| id            | seuil                     | icône |
+| ------------- | ------------------------- | ----- |
+| **`day_30`**  | meilleure journée ≥ 30 km | ☀️    |
+| **`day_50`**  | meilleure journée ≥ 50 km | 🌞    |
+| **`trip_25`** | plus long trajet ≥ 25 km  | 🚀    |
+| **`trip_50`** | plus long trajet ≥ 50 km  | 🛫    |
+| **`trip_2h`** | plus long trajet ≥ 2 h    | ⏱️    |
+
+> Les records semaine/mois (`week_100`, `month_250`) sont **retirés** du catalogue : ils
+> feraient doublon avec les défis glissants, qui disent la même chose avec une barre de
+> progression vivante.
+
+### 🕐 Habitudes — 4
+
+Toutes les heures sont **locales**, via `user.timezone`.
+
+| id               | seuil                                           | icône |
+| ---------------- | ----------------------------------------------- | ----- |
+| **`early_bird`** | 10 trajets démarrés avant 7 h                   | 🌅    |
+| **`night_owl`**  | 10 trajets démarrés après 21 h                  | 🦉    |
+| **`weekend_20`** | 20 trajets samedi ou dimanche                   | 🎒    |
+| **`all_week`**   | ≥ 1 trajet sur chacun des 7 jours de la semaine | 📅    |
+
+### ⚡ Performance — 3
+
+Sur le **meilleur trajet**, pas la moyenne à vie : à 18 km/h de moyenne, des seuils à
+20 ou 25 km/h seraient hors d'atteinte à vie. Garde-fou : **distance minimale de 5 km**,
+sinon une descente de 500 m décroche le badge.
+
+| id             | seuil                     | icône |
+| -------------- | ------------------------- | ----- |
+| **`speed_20`** | meilleur trajet ≥ 20 km/h | ⚡    |
+| **`speed_22`** | ≥ 22 km/h                 | 💨    |
+| **`speed_25`** | ≥ 25 km/h                 | 🔥    |
+
+---
+
+## Défis glissants
+
+Seuils **fixes et partagés**, pas configurables ni adaptatifs : comparables entre
+utilisateurs, aucune UI de réglage, aucun effet de seuil qui s'effondre après une semaine
+de vacances.
+
+| Défi                                         | Objectif principal | Compteurs secondaires           |
+| -------------------------------------------- | ------------------ | ------------------------------- |
+| **Semaine** (lundi → dimanche, heure locale) | **50 km**          | trajets, jours actifs (/4), CO₂ |
+| **Mois** (mois civil, heure locale)          | **250 km**         | trajets, jours actifs, CO₂      |
+
+Le défi CO₂ est une transformation linéaire du défi km (facteur ADEME constant) : il
+afficherait toujours le même pourcentage. Il est donc **compteur secondaire**, pas
+barre de progression — sinon deux barres disent la même chose.
+
+```
+DÉFI DE LA SEMAINE                    4 jours restants
+████████████░░░░░░░░  32 / 50 km
+  6 trajets · 3 / 4 jours actifs · 7,4 kg CO₂
+```
+
+---
+
+## Implémentation serveur
+
+### UserStats
+
+Passe de 5 à 16 champs. `BADGE_THRESHOLDS` garde exactement sa forme actuelle.
+`currentStreak` **disparaît** de `UserStats` : plus aucun badge ne s'appuie dessus une
+fois les streaks passés sur `longest`. Il reste calculé par `computeStreak()` pour
+l'affichage des stats, simplement il n'entre plus dans l'évaluation des badges.
+
+```ts
+export interface UserStats {
+  // existants
+  totalDistanceKm: number;
+  totalCo2SavedKg: number;
+  totalMoneySavedEur: number;
+  tripCount: number;
+  // nouveaux
+  longestStreak: number;
+  totalFuelSavedL: number;
+  maxTripDistanceKm: number;
+  maxTripDurationSec: number;
+  maxTripSpeedKmh: number; // trajets ≥ 5 km uniquement
+  maxDayDistanceKm: number;
+  monthsActive: number;
+  earlyTripCount: number; // départ < 7 h locale
+  nightTripCount: number; // départ ≥ 21 h locale
+  weekendTripCount: number;
+  distinctWeekdayCount: number; // 7 → all_week
+  weeklyGoalsMet: number;
+  monthlyGoalsMet: number;
+}
+```
+
+### Trois requêtes
+
+- **A** — agrégat une-ligne : les sommes existantes, plus `SUM(fuelSavedL)`,
+  `MAX(distanceKm)`, `MAX(durationSec)`, `MAX(distanceKm / durationSec)` filtré sur
+  `distanceKm >= 5`, et des `COUNT(*) FILTER (WHERE ...)` pour les habitudes (heure
+  locale < 7, ≥ 21, week-end) plus `COUNT(DISTINCT dow)`.
+- **B** — sommes par **jour local** (`started_at AT TIME ZONE user.timezone`) :
+  une ligne par jour actif, ≤ 730 après deux ans.
+- **C** — `computeStreak()`, inchangé, dont on utilise désormais `longest`.
+
+### computeDerivedStats — fonction pure
+
+Les records journée, les mois actifs, les compteurs d'objectifs atteints et l'état des
+deux défis courants se replient depuis **B**, en TypeScript, dans une fonction pure :
+
+```ts
+computeDerivedStats(
+  dailyRows: { day: string; distanceKm: number; co2Kg: number; tripCount: number }[],
+  today: string,
+): DerivedStats
+```
+
+Motif : la logique risquée (frontières de semaine ISO, changement d'heure, fuseau
+non-Paris) devient testable sans base de données — même pattern que
+`computeStreakFromDates`, déjà présent dans le repo. Le paramètre `today` est injecté
+plutôt que lu depuis l'horloge, pour que les tests soient déterministes.
+
+Les défis courants n'ajoutent **aucune requête** : la semaine et le mois en cours sont
+deux lignes de plus dans le même repli. Ils sont exposés dans la réponse `/api/stats`.
+
+---
+
+## Implémentation client
+
+- **`BadgeGrid`** — composant unique extrait de `ProfileBadgesSection` et
+  `StatsBadgesSection`, qui sont aujourd'hui la même grille dupliquée. Groupé par
+  catégorie, avec un compteur `7/11` par catégorie.
+- **`shared/types.ts`** — `BADGES` gagne un champ `category`; nouvelle constante
+  `BADGE_CATEGORIES` pour l'ordre d'affichage.
+- **i18n** — les libellés passent de français en dur à des clés `badges.<id>.label`
+  dans `fr.ts` et `en.ts` (46 × 2 entrées). Sans ça, 33 nouveaux libellés en dur
+  aggravent le trou existant côté anglais.
+- **`ChallengeCard`** — un seul composant avec une prop `compact` : version compacte sur
+  le dashboard, version détaillée en tête de la section badges.
+
+---
+
+## Tests
+
+- **`BADGE_THRESHOLDS`** — le fichier de tests existant suit déjà le pattern « seuil exact
+  - juste en dessous ». Étendu aux 33 nouveaux badges.
+- **`computeDerivedStats`** — repli semaine/mois, frontière lundi, passage à l'heure
+  d'hiver, fuseau non-Paris, tableau vide.
+- **Révocation** — un test par famille de nouveaux badges vérifiant que la suppression
+  d'un trajet sous le seuil retire bien le badge (et, pour les streaks passés sur
+  `longest`, qu'elle ne le retire **pas** à tort).
+- **Garde-fou vitesse** — un trajet de 500 m à 40 km/h ne décroche pas `speed_25`.
+- **e2e Playwright** — la section badges affiche les 6 catégories avec leurs compteurs;
+  la carte défi affiche une barre de progression.
+
+---
+
+## Hors périmètre
+
+- Objectifs configurables par l'utilisateur (roadmap v3.0) — les seuils sont fixes ici.
+- Badges saisonniers accumulables (une ligne par période) — écarté, casse `BadgeId` statique.
+- Badges non révocables — écarté, produit des badges fantômes après suppression de trajets.
+- Dénivelé : `GpsPoint` ne porte que `lat`, `lng`, `ts`. Pas d'altitude, pas de badge grimpeur.
+
+---
+
+## Points ouverts
+
+1. **`trips_250` / `trips_500`** — nombre de trajets actuel inconnu, paliers au jugé.
+2. **`streak_14` / `streak_100`** — plus longue série inconnue. 100 jours est peut-être
+   hors d'atteinte; 60 serait un repli raisonnable.
+3. **Import historique** — si des trajets antérieurs à mars 2026 ont été importés, toute
+   la calibration ci-dessus est trop optimiste et les paliers doivent être écartés.

--- a/docs/superpowers/specs/2026-07-28-badges-categories-design.md
+++ b/docs/superpowers/specs/2026-07-28-badges-categories-design.md
@@ -39,9 +39,9 @@ Chiffres réels de référence au 2026-07-28 : **1 159,8 km**, **187,5 kg CO₂*
 
 Rythme dérivé : ~61 km/semaine, ~10 kg CO₂/semaine, ~4,3 L/semaine, ~7,5 €/semaine.
 
-> **Hypothèse** : aucun trajet antérieur à mars 2026 n'a été importé. Si c'est faux, la
-> fenêtre de 19 semaines sous-estime la période réelle et tous les paliers ci-dessous sont
-> trop rapprochés.
+> **Hypothèse CONFIRMÉE le 2026-07-28** : aucun trajet antérieur à mars 2026 n'a été
+> importé. La fenêtre de 19 semaines est donc valide et la calibration tient.
+> Données réelles complémentaires : 137 trajets (7,4/semaine), série max 4 jours.
 
 ---
 
@@ -88,20 +88,20 @@ Les 33 nouveaux sont en **gras**.
 
 ### 🚴 Volume — 12
 
-| id              | seuil                     | icône |
-| --------------- | ------------------------- | ----- |
-| `first_trip`    | 1 trajet                  | 🚴    |
-| `trips_10`      | 10 trajets                | 🔟    |
-| `trips_50`      | 50 trajets                | 🏅    |
-| `trips_100`     | 100 trajets               | 💯    |
-| **`trips_250`** | 250 trajets ⚠️ à calibrer | 🎖️    |
-| **`trips_500`** | 500 trajets ⚠️ à calibrer | 🏆    |
-| `km_100`        | 100 km                    | 🛤️    |
-| `km_500`        | 500 km                    | 🗺️    |
-| `km_1000`       | 1 000 km                  | 🌍    |
-| **`km_2500`**   | 2 500 km (~8 mois)        | 🧭    |
-| **`km_5000`**   | 5 000 km (~20 mois)       | 🛰️    |
-| **`km_10000`**  | 10 000 km (~3 ans)        | 🌐    |
+| id              | seuil                 | icône |
+| --------------- | --------------------- | ----- |
+| `first_trip`    | 1 trajet              | 🚴    |
+| `trips_10`      | 10 trajets            | 🔟    |
+| `trips_50`      | 50 trajets            | 🏅    |
+| `trips_100`     | 100 trajets           | 💯    |
+| **`trips_250`** | 250 trajets (~4 mois) | 🎖️    |
+| **`trips_500`** | 500 trajets (~1 an)   | 🏆    |
+| `km_100`        | 100 km                | 🛤️    |
+| `km_500`        | 500 km                | 🗺️    |
+| `km_1000`       | 1 000 km              | 🌍    |
+| **`km_2500`**   | 2 500 km (~8 mois)    | 🧭    |
+| **`km_5000`**   | 5 000 km (~20 mois)   | 🛰️    |
+| **`km_10000`**  | 10 000 km (~3 ans)    | 🌐    |
 
 ### 🌱 Impact — 13
 
@@ -126,17 +126,17 @@ Les 33 nouveaux sont en **gras**.
 **Tous les badges streak passent de `currentStreak` à `longestStreak`.** Une série de
 30 jours réalisée en janvier reste un accomplissement en juillet.
 
-| id                     | seuil                           | icône |
-| ---------------------- | ------------------------------- | ----- |
-| **`streak_3`**         | 3 jours consécutifs             | 🌤️    |
-| `streak_7`             | 7 jours                         | 🔥    |
-| **`streak_14`**        | 14 jours ⚠️ à calibrer          | 🌗    |
-| `streak_30`            | 30 jours                        | ⚡    |
-| **`streak_100`**       | 100 jours ⚠️ à calibrer         | 🌟    |
-| **`months_active_6`**  | 6 mois civils avec ≥ 1 trajet   | 📆    |
-| **`months_active_12`** | 12 mois civils                  | 🎂    |
-| **`weekly_goal_10`**   | objectif hebdo atteint 10 fois  | 🎯    |
-| **`monthly_goal_3`**   | objectif mensuel atteint 3 fois | 🗓️    |
+| id                     | seuil                            | icône |
+| ---------------------- | -------------------------------- | ----- |
+| **`streak_3`**         | 3 jours consécutifs              | 🌤️    |
+| `streak_7`             | 7 jours                          | 🔥    |
+| **`streak_14`**        | 14 jours                         | 🌗    |
+| `streak_30`            | 30 jours                         | ⚡    |
+| **`streak_60`**        | 60 jours (2× le record de l'app) | 🌟    |
+| **`months_active_6`**  | 6 mois civils avec ≥ 1 trajet    | 📆    |
+| **`months_active_12`** | 12 mois civils                   | 🎂    |
+| **`weekly_goal_10`**   | objectif hebdo atteint 10 fois   | 🎯    |
+| **`monthly_goal_3`**   | objectif mensuel atteint 3 fois  | 🗓️    |
 
 Les deux derniers sont la strate « constance » : ils rendent permanent l'effort fourni
 sur les défis glissants, qui eux ne laissent aucune trace.
@@ -312,8 +312,11 @@ deux lignes de plus dans le même repli. Ils sont exposés dans la réponse `/ap
 
 ## Points ouverts
 
-1. **`trips_250` / `trips_500`** — nombre de trajets actuel inconnu, paliers au jugé.
-2. **`streak_14` / `streak_100`** — plus longue série inconnue. 100 jours est peut-être
+1. ~~**`trips_250` / `trips_500`**~~ — RÉSOLU 2026-07-28 : 137 trajets, soit 7,4/semaine.
+   Les paliers posés au jugé tombent juste (~4 mois et ~1 an). Inchangés.
+2. ~~**`streak_14` / `streak_100`**~~ — RÉSOLU 2026-07-28. Données réelles : série max 4
+   (record de l'app : 30). `streak_100` remplacé par `streak_60`, soit le double du record
+   actuel. Ancienne note : 100 jours est peut-être
    hors d'atteinte; 60 serait un repli raisonnable.
-3. **Import historique** — si des trajets antérieurs à mars 2026 ont été importés, toute
-   la calibration ci-dessus est trop optimiste et les paliers doivent être écartés.
+3. ~~**Import historique**~~ — RÉSOLU 2026-07-28 : aucun import antérieur à mars 2026.
+   La calibration est valide.

--- a/server/src/lib/__tests__/badges-catalog.test.ts
+++ b/server/src/lib/__tests__/badges-catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BADGES, BADGE_CATEGORIES, type BadgeId } from "../types";
+import { BADGES, BADGE_CATEGORIES, type BadgeId } from "@ecoride/shared/types";
 
 describe("BADGES catalog", () => {
   it("contient 46 badges", () => {

--- a/server/src/lib/__tests__/badges-db.test.ts
+++ b/server/src/lib/__tests__/badges-db.test.ts
@@ -226,53 +226,58 @@ describe("evaluateAndUnlockBadges", () => {
     );
   });
 
-  it("lit chaque badge depuis sa propre colonne d'agrégat", async () => {
-    // Douze colonnes, douze valeurs distinctes, douze badges pilotés chacun par
-    // un seul champ. Une colonne renommée ou disparue de la requête retombe sur
-    // `undefined ?? 0` — et fait tomber précisément son badge ici.
-    const insertChain = makeInsertChain();
-    mockCollectStats({
-      totalDistanceKm: 5100, // km_5000
-      totalCo2SavedKg: 260, // co2_250kg
-      totalMoneySavedEur: 510, // money_500
-      totalFuelSavedL: 51, // fuel_50l
-      tripCount: 251, // trips_250
-      maxTripDistanceKm: 52, // trip_50
-      maxTripDurationSec: 7201, // trip_2h
-      maxTripSpeedKmh: 26, // speed_25
-      earlyTripCount: 11, // early_bird
-      nightTripCount: 12, // night_owl
-      weekendTripCount: 21, // weekend_20
-      distinctWeekdayCount: 7, // all_week
-    });
+  it("sélectionne exactement les 12 colonnes d'agrégat attendues", async () => {
+    // La fausse ligne est fabriquée par le test : les assertions sur les badges
+    // prouvent que chaque champ est LU depuis la bonne clé, jamais que la requête
+    // la PRODUIT. Seule la projection réellement passée à db.select() le montre —
+    // c'est elle qui tombe si une colonne est renommée ou supprimée.
+    mockCollectStats({});
     mockDb.select.mockReturnValueOnce(makeSelectChain([]));
-    mockDb.insert.mockReturnValue(insertChain);
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
-    const result = await evaluateAndUnlockBadges("user-1");
+    await evaluateAndUnlockBadges("user-1");
 
-    // La fausse ligne est fabriquée par le test : elle prouve que chaque champ
-    // est LU depuis la bonne clé, mais pas que la requête la PRODUIT. On vérifie
-    // donc séparément la projection réellement passée à db.select() — c'est ce
-    // qui tombe si une colonne est renommée ou supprimée de la requête.
     const aggProjection = mockDb.select.mock.calls[1]?.[0] as Record<string, unknown>;
     expect(Object.keys(aggProjection).sort()).toEqual(Object.keys(ZERO_AGG).sort());
+  });
 
-    for (const badgeId of [
-      "km_5000",
-      "co2_250kg",
-      "money_500",
-      "fuel_50l",
-      "trips_250",
-      "trip_50",
-      "trip_2h",
-      "speed_25",
-      "early_bird",
-      "night_owl",
-      "weekend_20",
-      "all_week",
-    ]) {
-      expect(result).toContain(badgeId);
+  describe("chaque badge est lu depuis sa propre colonne d'agrégat", () => {
+    // Une seule colonne non nulle à la fois. Une table où toutes les colonnes
+    // dépassent leur seuil en même temps ne détecterait PAS un câblage croisé
+    // entre deux champs de même seuil (earlyTripCount et nightTripCount valent
+    // tous deux 10, donc les échanger laisserait les deux badges débloqués).
+    // En isolant chaque colonne, tout croisement fait disparaître son badge.
+    const CASES = [
+      { column: "totalDistanceKm", value: 5000, badge: "km_5000" },
+      { column: "totalCo2SavedKg", value: 250, badge: "co2_250kg" },
+      { column: "totalMoneySavedEur", value: 500, badge: "money_500" },
+      { column: "totalFuelSavedL", value: 50, badge: "fuel_50l" },
+      { column: "tripCount", value: 250, badge: "trips_250" },
+      { column: "maxTripDistanceKm", value: 50, badge: "trip_50" },
+      { column: "maxTripDurationSec", value: 7200, badge: "trip_2h" },
+      { column: "maxTripSpeedKmh", value: 25, badge: "speed_25" },
+      { column: "earlyTripCount", value: 10, badge: "early_bird" },
+      { column: "nightTripCount", value: 10, badge: "night_owl" },
+      { column: "weekendTripCount", value: 20, badge: "weekend_20" },
+      { column: "distinctWeekdayCount", value: 7, badge: "all_week" },
+    ] as const;
+
+    for (const { column, value, badge } of CASES) {
+      it(`${column} alimente ${badge} et lui seul`, async () => {
+        mockDb.insert.mockReturnValue(makeInsertChain());
+        mockCollectStats({ [column]: value });
+        mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+        mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
+
+        const result = await evaluateAndUnlockBadges("user-1");
+
+        expect(result).toContain(badge);
+        // Aucun des onze autres badges pilotés par une colonne d'agrégat ne doit
+        // se débloquer : leur colonne est restée à zéro.
+        for (const other of CASES) {
+          if (other.badge !== badge) expect(result).not.toContain(other.badge);
+        }
+      });
     }
   });
 

--- a/server/src/lib/__tests__/badges-db.test.ts
+++ b/server/src/lib/__tests__/badges-db.test.ts
@@ -45,29 +45,56 @@ const mockComputeStreak = vi.mocked(computeStreak);
 /**
  * `where()` termine la requête pour les selects simples, mais la requête
  * journalière ajoute `.groupBy()`. On renvoie donc un thenable qui porte aussi
- * `groupBy`, ce qui couvre les deux formes avec un seul helper.
+ * `groupBy`, ce qui couvre les deux formes avec un seul helper. `groupBy` est
+ * ré-exposé sur le chaînage pour qu'un test puisse vérifier qu'il a bien été
+ * appelé : sans regroupement, la requête journalière renverrait une seule ligne
+ * agrégée sur tout l'historique et maxDayDistanceKm vaudrait le total à vie.
  */
 function makeSelectChain(resolvedValue: unknown[]) {
-  const terminal = Object.assign(Promise.resolve(resolvedValue), {
-    groupBy: vi.fn().mockResolvedValue(resolvedValue),
-  });
+  const groupBy = vi.fn().mockResolvedValue(resolvedValue);
+  const terminal = Object.assign(Promise.resolve(resolvedValue), { groupBy });
   const chain = {
     from: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnValue(terminal),
+    groupBy,
   };
   return chain;
 }
 
 /**
- * collectUserStats() enchaîne trois selects : profil (timezone), agrégat
- * une-ligne, puis sommes par jour. Les tests n'ont besoin de piloter que
- * l'agrégat ; les deux autres reçoivent des valeurs neutres.
+ * Les 12 colonnes que sélectionne la requête d'agrégat. Les tests partent de ce
+ * socle pour que chaque colonne soit réellement présente dans la fausse ligne :
+ * une colonne absente retomberait sur `undefined ?? 0` et masquerait un renommage.
  */
-function mockCollectStats(agg: Record<string, number> | null, daily: unknown[] = []) {
+const ZERO_AGG = {
+  totalDistanceKm: 0,
+  totalCo2SavedKg: 0,
+  totalMoneySavedEur: 0,
+  totalFuelSavedL: 0,
+  tripCount: 0,
+  maxTripDistanceKm: 0,
+  maxTripDurationSec: 0,
+  maxTripSpeedKmh: 0,
+  earlyTripCount: 0,
+  nightTripCount: 0,
+  weekendTripCount: 0,
+  distinctWeekdayCount: 0,
+};
+
+/**
+ * collectUserStats() enchaîne trois selects : profil (timezone), agrégat
+ * une-ligne, puis sommes par jour. Renvoie les trois faux chaînages pour que les
+ * tests puissent assertion sur leur usage.
+ */
+function mockCollectStats(agg: Partial<typeof ZERO_AGG> | null, daily: unknown[] = []) {
+  const profileChain = makeSelectChain([{ timezone: "UTC" }]);
+  const aggChain = makeSelectChain(agg === null ? [] : [{ ...ZERO_AGG, ...agg }]);
+  const dailyChain = makeSelectChain(daily);
   mockDb.select
-    .mockReturnValueOnce(makeSelectChain([{ timezone: "UTC" }]))
-    .mockReturnValueOnce(makeSelectChain(agg === null ? [] : [agg]))
-    .mockReturnValueOnce(makeSelectChain(daily));
+    .mockReturnValueOnce(profileChain)
+    .mockReturnValueOnce(aggChain)
+    .mockReturnValueOnce(dailyChain);
+  return { profileChain, aggChain, dailyChain };
 }
 
 function makeInsertChain() {
@@ -177,7 +204,7 @@ describe("evaluateAndUnlockBadges", () => {
 
   it("unlocks the daily record badges from the per-day rows", async () => {
     const insertChain = makeInsertChain();
-    mockCollectStats(
+    const { dailyChain } = mockCollectStats(
       { totalDistanceKm: 60, totalCo2SavedKg: 6, totalMoneySavedEur: 20, tripCount: 3 },
       [{ day: "2026-07-20", distanceKm: 55, co2Kg: 5, tripCount: 2 }],
     );
@@ -188,6 +215,65 @@ describe("evaluateAndUnlockBadges", () => {
     const result = await evaluateAndUnlockBadges("user-1");
     expect(result).toContain("day_30");
     expect(result).toContain("day_50");
+    // La requête journalière DOIT être regroupée. Sans groupBy, PostgreSQL
+    // renverrait une ligne unique agrégée sur tout l'historique : day_30 et
+    // day_50 se débloqueraient pour quiconque a cumulé 30 km à vie.
+    expect(dailyChain.groupBy).toHaveBeenCalled();
+    // computeDerivedStats attend exactement ces quatre colonnes.
+    const dailyProjection = mockDb.select.mock.calls[2]?.[0] as Record<string, unknown>;
+    expect(Object.keys(dailyProjection).sort()).toEqual(
+      ["co2Kg", "day", "distanceKm", "tripCount"].sort(),
+    );
+  });
+
+  it("lit chaque badge depuis sa propre colonne d'agrégat", async () => {
+    // Douze colonnes, douze valeurs distinctes, douze badges pilotés chacun par
+    // un seul champ. Une colonne renommée ou disparue de la requête retombe sur
+    // `undefined ?? 0` — et fait tomber précisément son badge ici.
+    const insertChain = makeInsertChain();
+    mockCollectStats({
+      totalDistanceKm: 5100, // km_5000
+      totalCo2SavedKg: 260, // co2_250kg
+      totalMoneySavedEur: 510, // money_500
+      totalFuelSavedL: 51, // fuel_50l
+      tripCount: 251, // trips_250
+      maxTripDistanceKm: 52, // trip_50
+      maxTripDurationSec: 7201, // trip_2h
+      maxTripSpeedKmh: 26, // speed_25
+      earlyTripCount: 11, // early_bird
+      nightTripCount: 12, // night_owl
+      weekendTripCount: 21, // weekend_20
+      distinctWeekdayCount: 7, // all_week
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(insertChain);
+    mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
+
+    const result = await evaluateAndUnlockBadges("user-1");
+
+    // La fausse ligne est fabriquée par le test : elle prouve que chaque champ
+    // est LU depuis la bonne clé, mais pas que la requête la PRODUIT. On vérifie
+    // donc séparément la projection réellement passée à db.select() — c'est ce
+    // qui tombe si une colonne est renommée ou supprimée de la requête.
+    const aggProjection = mockDb.select.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(Object.keys(aggProjection).sort()).toEqual(Object.keys(ZERO_AGG).sort());
+
+    for (const badgeId of [
+      "km_5000",
+      "co2_250kg",
+      "money_500",
+      "fuel_50l",
+      "trips_250",
+      "trip_50",
+      "trip_2h",
+      "speed_25",
+      "early_bird",
+      "night_owl",
+      "weekend_20",
+      "all_week",
+    ]) {
+      expect(result).toContain(badgeId);
+    }
   });
 
   it("handles empty aggregate result gracefully (fallback to 0)", async () => {

--- a/server/src/lib/__tests__/badges-db.test.ts
+++ b/server/src/lib/__tests__/badges-db.test.ts
@@ -12,8 +12,17 @@ vi.mock("../../db", () => ({
   },
 }));
 vi.mock("../../db/schema", () => ({
-  trips: { userId: {}, distanceKm: {}, co2SavedKg: {}, moneySavedEur: {} },
+  trips: {
+    userId: {},
+    distanceKm: {},
+    durationSec: {},
+    co2SavedKg: {},
+    moneySavedEur: {},
+    fuelSavedL: {},
+    startedAt: {},
+  },
   achievements: { userId: {}, badgeId: {} },
+  user: { id: {}, timezone: {} },
 }));
 vi.mock("../streaks", () => ({ computeStreak: vi.fn() }));
 
@@ -33,12 +42,32 @@ const mockComputeStreak = vi.mocked(computeStreak);
 // Per-test chain builder
 // ---------------------------------------------------------------------------
 
+/**
+ * `where()` termine la requête pour les selects simples, mais la requête
+ * journalière ajoute `.groupBy()`. On renvoie donc un thenable qui porte aussi
+ * `groupBy`, ce qui couvre les deux formes avec un seul helper.
+ */
 function makeSelectChain(resolvedValue: unknown[]) {
+  const terminal = Object.assign(Promise.resolve(resolvedValue), {
+    groupBy: vi.fn().mockResolvedValue(resolvedValue),
+  });
   const chain = {
     from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockResolvedValue(resolvedValue),
+    where: vi.fn().mockReturnValue(terminal),
   };
   return chain;
+}
+
+/**
+ * collectUserStats() enchaîne trois selects : profil (timezone), agrégat
+ * une-ligne, puis sommes par jour. Les tests n'ont besoin de piloter que
+ * l'agrégat ; les deux autres reçoivent des valeurs neutres.
+ */
+function mockCollectStats(agg: Record<string, number> | null, daily: unknown[] = []) {
+  mockDb.select
+    .mockReturnValueOnce(makeSelectChain([{ timezone: "UTC" }]))
+    .mockReturnValueOnce(makeSelectChain(agg === null ? [] : [agg]))
+    .mockReturnValueOnce(makeSelectChain(daily));
 }
 
 function makeInsertChain() {
@@ -62,13 +91,13 @@ beforeEach(() => {
 
 describe("evaluateAndUnlockBadges", () => {
   it("returns [] when no thresholds are met", async () => {
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats({
+      totalDistanceKm: 0,
+      totalCo2SavedKg: 0,
+      totalMoneySavedEur: 0,
+      tripCount: 0,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
     const result = await evaluateAndUnlockBadges("user-1");
@@ -78,13 +107,13 @@ describe("evaluateAndUnlockBadges", () => {
 
   it("unlocks first_trip badge on first trip", async () => {
     const insertChain = makeInsertChain();
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats({
+      totalDistanceKm: 10,
+      totalCo2SavedKg: 1,
+      totalMoneySavedEur: 5,
+      tripCount: 1,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockDb.insert.mockReturnValue(insertChain);
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
 
@@ -97,13 +126,13 @@ describe("evaluateAndUnlockBadges", () => {
   });
 
   it("does not re-unlock already earned badges", async () => {
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
+    mockCollectStats({
+      totalDistanceKm: 10,
+      totalCo2SavedKg: 1,
+      totalMoneySavedEur: 5,
+      tripCount: 1,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
 
     const result = await evaluateAndUnlockBadges("user-1");
@@ -113,13 +142,13 @@ describe("evaluateAndUnlockBadges", () => {
 
   it("unlocks multiple badges at once when thresholds are met", async () => {
     const insertChain = makeInsertChain();
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 150, totalCo2SavedKg: 15, totalMoneySavedEur: 30, tripCount: 10 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats({
+      totalDistanceKm: 150,
+      totalCo2SavedKg: 15,
+      totalMoneySavedEur: 30,
+      tripCount: 10,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockDb.insert.mockReturnValue(insertChain);
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
@@ -132,13 +161,13 @@ describe("evaluateAndUnlockBadges", () => {
 
   it("unlocks money_100 badge at 100 EUR saved", async () => {
     const insertChain = makeInsertChain();
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 50, totalCo2SavedKg: 5, totalMoneySavedEur: 100, tripCount: 10 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats({
+      totalDistanceKm: 50,
+      totalCo2SavedKg: 5,
+      totalMoneySavedEur: 100,
+      tripCount: 10,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockDb.insert.mockReturnValue(insertChain);
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
@@ -146,8 +175,24 @@ describe("evaluateAndUnlockBadges", () => {
     expect(result).toContain("money_100");
   });
 
+  it("unlocks the daily record badges from the per-day rows", async () => {
+    const insertChain = makeInsertChain();
+    mockCollectStats(
+      { totalDistanceKm: 60, totalCo2SavedKg: 6, totalMoneySavedEur: 20, tripCount: 3 },
+      [{ day: "2026-07-20", distanceKm: 55, co2Kg: 5, tripCount: 2 }],
+    );
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
+    mockDb.insert.mockReturnValue(insertChain);
+    mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
+
+    const result = await evaluateAndUnlockBadges("user-1");
+    expect(result).toContain("day_30");
+    expect(result).toContain("day_50");
+  });
+
   it("handles empty aggregate result gracefully (fallback to 0)", async () => {
-    mockDb.select.mockReturnValueOnce(makeSelectChain([])).mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats(null);
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
     const result = await evaluateAndUnlockBadges("user-1");
@@ -161,13 +206,13 @@ describe("evaluateAndUnlockBadges", () => {
 
 describe("reevaluateBadges", () => {
   it("returns [] when all unlocked badges are still earned", async () => {
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 10, totalCo2SavedKg: 1, totalMoneySavedEur: 5, tripCount: 1 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
+    mockCollectStats({
+      totalDistanceKm: 10,
+      totalCo2SavedKg: 1,
+      totalMoneySavedEur: 5,
+      tripCount: 1,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }]));
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
 
     const result = await reevaluateBadges("user-1");
@@ -177,13 +222,15 @@ describe("reevaluateBadges", () => {
 
   it("revokes badges whose thresholds are no longer met", async () => {
     const deleteChain = makeDeleteChain();
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 5, totalCo2SavedKg: 0.5, totalMoneySavedEur: 2, tripCount: 5 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([{ badgeId: "first_trip" }, { badgeId: "trips_10" }]));
+    mockCollectStats({
+      totalDistanceKm: 5,
+      totalCo2SavedKg: 0.5,
+      totalMoneySavedEur: 2,
+      tripCount: 5,
+    });
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([{ badgeId: "first_trip" }, { badgeId: "trips_10" }]),
+    );
     mockDb.delete.mockReturnValue(deleteChain);
     mockComputeStreak.mockResolvedValue({ current: 1, longest: 1 });
 
@@ -193,21 +240,34 @@ describe("reevaluateBadges", () => {
     expect(deleteChain.where).toHaveBeenCalled();
   });
 
+  it("garde un badge streak quand la série en cours est cassée mais le record tient", async () => {
+    // Régression : les prédicats streak lisent longestStreak, pas la série en
+    // cours — sinon toute suppression de trajet révoquait le badge.
+    mockCollectStats({
+      totalDistanceKm: 200,
+      totalCo2SavedKg: 20,
+      totalMoneySavedEur: 60,
+      tripCount: 40,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([{ badgeId: "streak_7" }]));
+    mockComputeStreak.mockResolvedValue({ current: 0, longest: 12 });
+
+    const result = await reevaluateBadges("user-1");
+    expect(result).toEqual([]);
+    expect(mockDb.delete).not.toHaveBeenCalled();
+  });
+
   it("revokes all badges when stats are zeroed", async () => {
     const deleteChain = makeDeleteChain();
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
-        ]),
-      )
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { badgeId: "first_trip" },
-          { badgeId: "km_100" },
-          { badgeId: "trips_10" },
-        ]),
-      );
+    mockCollectStats({
+      totalDistanceKm: 0,
+      totalCo2SavedKg: 0,
+      totalMoneySavedEur: 0,
+      tripCount: 0,
+    });
+    mockDb.select.mockReturnValueOnce(
+      makeSelectChain([{ badgeId: "first_trip" }, { badgeId: "km_100" }, { badgeId: "trips_10" }]),
+    );
     mockDb.delete.mockReturnValue(deleteChain);
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
@@ -217,13 +277,13 @@ describe("reevaluateBadges", () => {
   });
 
   it("returns [] when user has no badges", async () => {
-    mockDb.select
-      .mockReturnValueOnce(
-        makeSelectChain([
-          { totalDistanceKm: 0, totalCo2SavedKg: 0, totalMoneySavedEur: 0, tripCount: 0 },
-        ]),
-      )
-      .mockReturnValueOnce(makeSelectChain([]));
+    mockCollectStats({
+      totalDistanceKm: 0,
+      totalCo2SavedKg: 0,
+      totalMoneySavedEur: 0,
+      tripCount: 0,
+    });
+    mockDb.select.mockReturnValueOnce(makeSelectChain([]));
     mockComputeStreak.mockResolvedValue({ current: 0, longest: 0 });
 
     const result = await reevaluateBadges("user-1");

--- a/server/src/lib/__tests__/badges.test.ts
+++ b/server/src/lib/__tests__/badges.test.ts
@@ -5,6 +5,7 @@ vi.mock("../../db", () => ({ db: {} }));
 vi.mock("../../db/schema", () => ({ trips: {}, achievements: {} }));
 vi.mock("../streaks", () => ({ computeStreak: vi.fn() }));
 
+import type { BadgeId } from "@ecoride/shared/types";
 import { BADGE_THRESHOLDS, type UserStats } from "../badges";
 
 function makeStats(overrides: Partial<UserStats> = {}): UserStats {
@@ -12,8 +13,20 @@ function makeStats(overrides: Partial<UserStats> = {}): UserStats {
     totalDistanceKm: 0,
     totalCo2SavedKg: 0,
     totalMoneySavedEur: 0,
+    totalFuelSavedL: 0,
     tripCount: 0,
-    currentStreak: 0,
+    longestStreak: 0,
+    maxTripDistanceKm: 0,
+    maxTripDurationSec: 0,
+    maxTripSpeedKmh: 0,
+    maxDayDistanceKm: 0,
+    monthsActive: 0,
+    earlyTripCount: 0,
+    nightTripCount: 0,
+    weekendTripCount: 0,
+    distinctWeekdayCount: 0,
+    weeklyGoalsMet: 0,
+    monthlyGoalsMet: 0,
     ...overrides,
   };
 }
@@ -125,25 +138,25 @@ describe("BADGE_THRESHOLDS", () => {
 
   describe("streak_7", () => {
     it("unlocks at exactly 7-day streak", () => {
-      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 7 }))).toBe(true);
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ longestStreak: 7 }))).toBe(true);
     });
 
     it("does not unlock at 6-day streak", () => {
-      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 6 }))).toBe(false);
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ longestStreak: 6 }))).toBe(false);
     });
 
     it("unlocks above threshold", () => {
-      expect(BADGE_THRESHOLDS.streak_7(makeStats({ currentStreak: 14 }))).toBe(true);
+      expect(BADGE_THRESHOLDS.streak_7(makeStats({ longestStreak: 14 }))).toBe(true);
     });
   });
 
   describe("streak_30", () => {
     it("unlocks at exactly 30-day streak", () => {
-      expect(BADGE_THRESHOLDS.streak_30(makeStats({ currentStreak: 30 }))).toBe(true);
+      expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 30 }))).toBe(true);
     });
 
     it("does not unlock at 29-day streak", () => {
-      expect(BADGE_THRESHOLDS.streak_30(makeStats({ currentStreak: 29 }))).toBe(false);
+      expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 29 }))).toBe(false);
     });
   });
 
@@ -166,7 +179,7 @@ describe("BADGE_THRESHOLDS", () => {
       const stats = makeStats({
         totalDistanceKm: 100,
         tripCount: 0,
-        currentStreak: 0,
+        longestStreak: 0,
       });
       expect(BADGE_THRESHOLDS.km_100(stats)).toBe(true);
       expect(BADGE_THRESHOLDS.first_trip(stats)).toBe(false);
@@ -174,12 +187,67 @@ describe("BADGE_THRESHOLDS", () => {
 
     it("streak badge ignores distance and co2", () => {
       const stats = makeStats({
-        currentStreak: 7,
+        longestStreak: 7,
         totalDistanceKm: 0,
         totalCo2SavedKg: 0,
       });
       expect(BADGE_THRESHOLDS.streak_7(stats)).toBe(true);
       expect(BADGE_THRESHOLDS.km_100(stats)).toBe(false);
     });
+  });
+});
+
+describe("nouveaux paliers cumulatifs", () => {
+  const cases: [BadgeId, keyof UserStats, number][] = [
+    ["trips_250", "tripCount", 250],
+    ["trips_500", "tripCount", 500],
+    ["km_2500", "totalDistanceKm", 2500],
+    ["km_5000", "totalDistanceKm", 5000],
+    ["km_10000", "totalDistanceKm", 10000],
+    ["co2_250kg", "totalCo2SavedKg", 250],
+    ["co2_500kg", "totalCo2SavedKg", 500],
+    ["fuel_25l", "totalFuelSavedL", 25],
+    ["fuel_50l", "totalFuelSavedL", 50],
+    ["fuel_100l", "totalFuelSavedL", 100],
+    ["fuel_250l", "totalFuelSavedL", 250],
+    ["money_250", "totalMoneySavedEur", 250],
+    ["money_500", "totalMoneySavedEur", 500],
+    ["money_1000", "totalMoneySavedEur", 1000],
+    ["streak_3", "longestStreak", 3],
+    ["streak_14", "longestStreak", 14],
+    ["streak_100", "longestStreak", 100],
+    ["months_active_6", "monthsActive", 6],
+    ["months_active_12", "monthsActive", 12],
+    ["weekly_goal_10", "weeklyGoalsMet", 10],
+    ["monthly_goal_3", "monthlyGoalsMet", 3],
+    ["day_30", "maxDayDistanceKm", 30],
+    ["day_50", "maxDayDistanceKm", 50],
+    ["trip_25", "maxTripDistanceKm", 25],
+    ["trip_50", "maxTripDistanceKm", 50],
+    ["trip_2h", "maxTripDurationSec", 7200],
+    ["early_bird", "earlyTripCount", 10],
+    ["night_owl", "nightTripCount", 10],
+    ["weekend_20", "weekendTripCount", 20],
+    ["all_week", "distinctWeekdayCount", 7],
+    ["speed_20", "maxTripSpeedKmh", 20],
+    ["speed_22", "maxTripSpeedKmh", 22],
+    ["speed_25", "maxTripSpeedKmh", 25],
+  ];
+
+  for (const [badgeId, field, threshold] of cases) {
+    it(`${badgeId} se débloque au seuil exact et pas juste en dessous`, () => {
+      expect(BADGE_THRESHOLDS[badgeId](makeStats({ [field]: threshold }))).toBe(true);
+      expect(BADGE_THRESHOLDS[badgeId](makeStats({ [field]: threshold - 1 }))).toBe(false);
+    });
+  }
+});
+
+describe("badges streak indexés sur longestStreak", () => {
+  it("garde streak_7 quand la série actuelle est cassée mais que le record tient", () => {
+    expect(BADGE_THRESHOLDS.streak_7(makeStats({ longestStreak: 12 }))).toBe(true);
+  });
+
+  it("ne débloque pas streak_30 avec un record de 29", () => {
+    expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 29 }))).toBe(false);
   });
 });

--- a/server/src/lib/__tests__/badges.test.ts
+++ b/server/src/lib/__tests__/badges.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 // Mock db to prevent real Postgres connection on module load
 vi.mock("../../db", () => ({ db: {} }));
-vi.mock("../../db/schema", () => ({ trips: {}, achievements: {} }));
+vi.mock("../../db/schema", () => ({ trips: {}, achievements: {}, user: {} }));
 vi.mock("../streaks", () => ({ computeStreak: vi.fn() }));
 
 import type { BadgeId } from "@ecoride/shared/types";
@@ -249,5 +249,23 @@ describe("badges streak indexés sur longestStreak", () => {
 
   it("ne débloque pas streak_30 avec un record de 29", () => {
     expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 29 }))).toBe(false);
+  });
+});
+
+describe("révocation", () => {
+  it("retire un badge de palier dont le seuil n'est plus atteint", () => {
+    expect(BADGE_THRESHOLDS.km_2500(makeStats({ totalDistanceKm: 2499 }))).toBe(false);
+  });
+
+  it("ne retire pas un badge streak quand la série en cours est nulle mais le record tient", () => {
+    // Régression : avant, les badges streak lisaient currentStreak et
+    // disparaissaient à la première suppression de trajet.
+    expect(BADGE_THRESHOLDS.streak_30(makeStats({ longestStreak: 31 }))).toBe(true);
+  });
+
+  it("ignore un trajet court et rapide pour les badges de vitesse", () => {
+    // maxTripSpeedKmh n'est alimenté que par les trajets >= 5 km,
+    // donc une descente de 500 m à 40 km/h laisse le champ à 0.
+    expect(BADGE_THRESHOLDS.speed_25(makeStats({ maxTripSpeedKmh: 0 }))).toBe(false);
   });
 });

--- a/server/src/lib/__tests__/badges.test.ts
+++ b/server/src/lib/__tests__/badges.test.ts
@@ -215,7 +215,7 @@ describe("nouveaux paliers cumulatifs", () => {
     ["money_1000", "totalMoneySavedEur", 1000],
     ["streak_3", "longestStreak", 3],
     ["streak_14", "longestStreak", 14],
-    ["streak_100", "longestStreak", 100],
+    ["streak_60", "longestStreak", 60],
     ["months_active_6", "monthsActive", 6],
     ["months_active_12", "monthsActive", 12],
     ["weekly_goal_10", "weeklyGoalsMet", 10],

--- a/server/src/lib/__tests__/daily-rollup-shared.test.ts
+++ b/server/src/lib/__tests__/daily-rollup-shared.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import type { AuthEnv } from "../../types/context";
+
+/**
+ * Garde-fou d'équivalence : les badges (`collectUserStats`) et la carte de défi
+ * (`GET /api/stats/summary`) doivent tirer leurs sommes journalières de la MÊME
+ * fonction. Tant que les deux portaient une copie textuelle de la requête, une
+ * modification de l'une sans l'autre passait typecheck et suite de tests, et se
+ * traduisait en prod par un badge et une carte se contredisant sur la même
+ * semaine.
+ *
+ * Ce test mord si l'un des deux sites réinline sa propre requête journalière.
+ * Ce qu'il ne couvre PAS : la correction du SQL lui-même (aucune base réelle
+ * n'est sollicitée ici) — voir daily-rollup.test.ts pour la forme de la
+ * requête, et le triage n°1 de la revue pour la validation SQL en CI.
+ */
+
+const mocks = vi.hoisted(() => {
+  const fetchDailyRows = vi.fn().mockResolvedValue([
+    { day: "2026-07-20", distanceKm: 30, co2Kg: 5, tripCount: 3 },
+    { day: "2026-07-21", distanceKm: 25, co2Kg: 4, tripCount: 2 },
+  ]);
+  // Une seule ligne sert à la fois de profil (timezone) et d'agrégat : les deux
+  // requêtes non journalières se terminent sur `where()`.
+  const row = {
+    timezone: "Europe/Paris",
+    totalDistanceKm: 55,
+    totalCo2SavedKg: 9,
+    totalMoneySavedEur: 7,
+    totalFuelSavedL: 4,
+    tripCount: 5,
+    maxTripDistanceKm: 20,
+    maxTripDurationSec: 3600,
+    maxTripSpeedKmh: 22,
+    earlyTripCount: 0,
+    nightTripCount: 0,
+    weekendTripCount: 0,
+    distinctWeekdayCount: 2,
+  };
+  const where = vi.fn().mockResolvedValue([row]);
+  const from = vi.fn().mockReturnValue({ where });
+  const select = vi.fn().mockReturnValue({ from });
+  return { fetchDailyRows, select, from, where };
+});
+
+vi.mock("../daily-rollup", () => ({ fetchDailyRows: mocks.fetchDailyRows }));
+vi.mock("../../db", () => ({ db: { select: mocks.select } }));
+vi.mock("../../db/schema", () => ({
+  trips: {
+    userId: {},
+    startedAt: {},
+    distanceKm: {},
+    durationSec: {},
+    co2SavedKg: {},
+    moneySavedEur: {},
+    fuelSavedL: {},
+  },
+  achievements: { userId: {}, badgeId: {} },
+  user: { id: {}, timezone: {} },
+}));
+vi.mock("../streaks", () => ({
+  computeStreak: vi.fn().mockResolvedValue({ current: 2, longest: 9 }),
+}));
+
+import { collectUserStats } from "../badges";
+import { statsRouter } from "../../routes/stats.routes";
+
+function buildApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", { id: "user-1", timezone: "Europe/Paris" } as AuthEnv["Variables"]["user"]);
+    await next();
+  });
+  app.route("/stats", statsRouter);
+  return app;
+}
+
+describe("fetchDailyRows partagée par les badges et la carte de défi", () => {
+  beforeEach(() => mocks.fetchDailyRows.mockClear());
+
+  it("collectUserStats passe par fetchDailyRows", async () => {
+    await collectUserStats("user-1");
+    expect(mocks.fetchDailyRows).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchDailyRows).toHaveBeenCalledWith("user-1");
+  });
+
+  it("GET /stats/summary passe par fetchDailyRows", async () => {
+    const res = await buildApp().request("/stats/summary?period=month");
+    expect(res.status).toBe(200);
+    expect(mocks.fetchDailyRows).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchDailyRows).toHaveBeenCalledWith("user-1");
+  });
+
+  it("les lignes partagées alimentent bien les stats dérivées des badges", async () => {
+    // Les deux sites consomment la même sortie via computeDerivedStats : ce qui
+    // sort de fetchDailyRows se retrouve tel quel dans les seuils de badges.
+    const stats = await collectUserStats("user-1");
+    expect(stats.maxDayDistanceKm).toBe(30);
+  });
+});

--- a/server/src/lib/__tests__/daily-rollup.test.ts
+++ b/server/src/lib/__tests__/daily-rollup.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../db", () => ({ db: { select: vi.fn() } }));
+vi.mock("../../db/schema", () => ({
+  trips: { userId: {}, startedAt: {}, distanceKm: {}, co2SavedKg: {} },
+}));
+
+import { db } from "../../db";
+import { fetchDailyRows } from "../daily-rollup";
+
+const mockDb = vi.mocked(db) as { select: ReturnType<typeof vi.fn> };
+
+const ROWS = [
+  { day: "2026-07-20", distanceKm: 12.5, co2Kg: 2.1, tripCount: 2 },
+  { day: "2026-07-21", distanceKm: 8, co2Kg: 1.3, tripCount: 1 },
+];
+
+function chain(rows: unknown[]) {
+  const groupBy = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn().mockReturnValue({ groupBy });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from, where, groupBy };
+}
+
+describe("fetchDailyRows", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sélectionne exactement les quatre colonnes de DailyRow", async () => {
+    const c = chain(ROWS);
+    mockDb.select.mockReturnValue({ from: c.from });
+
+    await fetchDailyRows("user-1");
+
+    const columns = mockDb.select.mock.calls[0]![0] as Record<string, unknown>;
+    // Un renommage ou une colonne perdue casserait computeDerivedStats
+    // silencieusement (`undefined` propagé en NaN dans les sommes).
+    expect(Object.keys(columns).sort()).toEqual(["co2Kg", "day", "distanceKm", "tripCount"]);
+  });
+
+  it("filtre sur l'utilisateur et regroupe (sans groupBy, une seule ligne à vie)", async () => {
+    const c = chain(ROWS);
+    mockDb.select.mockReturnValue({ from: c.from });
+
+    const rows = await fetchDailyRows("user-1");
+
+    expect(c.where).toHaveBeenCalledTimes(1);
+    expect(c.groupBy).toHaveBeenCalledTimes(1);
+    expect(rows).toEqual(ROWS);
+  });
+});

--- a/server/src/lib/__tests__/derived-stats.test.ts
+++ b/server/src/lib/__tests__/derived-stats.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { computeDerivedStats, WEEKLY_GOAL_KM, type DailyRow } from "../derived-stats";
+
+function row(day: string, distanceKm: number, tripCount = 1): DailyRow {
+  return { day, distanceKm, co2Kg: distanceKm * 0.1617, tripCount };
+}
+
+describe("computeDerivedStats", () => {
+  it("renvoie des compteurs à zéro sur un historique vide", () => {
+    const d = computeDerivedStats([], "2026-07-28");
+    expect(d.maxDayDistanceKm).toBe(0);
+    expect(d.monthsActive).toBe(0);
+    expect(d.weeklyGoalsMet).toBe(0);
+    expect(d.monthlyGoalsMet).toBe(0);
+    expect(d.currentWeek.distanceKm).toBe(0);
+    expect(d.currentWeek.goalKm).toBe(WEEKLY_GOAL_KM);
+  });
+
+  it("retient la meilleure journée", () => {
+    const d = computeDerivedStats([row("2026-07-01", 12), row("2026-07-02", 41)], "2026-07-28");
+    expect(d.maxDayDistanceKm).toBe(41);
+  });
+
+  it("compte les mois civils distincts", () => {
+    const d = computeDerivedStats(
+      [row("2026-05-30", 10), row("2026-06-01", 10), row("2026-06-20", 10)],
+      "2026-07-28",
+    );
+    expect(d.monthsActive).toBe(2);
+  });
+
+  it("fait démarrer la semaine le lundi", () => {
+    // 2026-07-26 est un dimanche, 2026-07-27 le lundi suivant.
+    const d = computeDerivedStats([row("2026-07-26", 30), row("2026-07-27", 20)], "2026-07-28");
+    // Seul le lundi et après comptent dans la semaine en cours.
+    expect(d.currentWeek.distanceKm).toBe(20);
+  });
+
+  it("compte une semaine réussie quand le cumul lundi-dimanche atteint l'objectif", () => {
+    const d = computeDerivedStats(
+      [row("2026-07-06", 25), row("2026-07-08", 25), row("2026-07-13", 10)],
+      "2026-07-28",
+    );
+    expect(d.weeklyGoalsMet).toBe(1);
+  });
+
+  it("compte les mois réussis à 250 km", () => {
+    const d = computeDerivedStats(
+      [row("2026-05-02", 150), row("2026-05-20", 100), row("2026-06-02", 40)],
+      "2026-07-28",
+    );
+    expect(d.monthlyGoalsMet).toBe(1);
+  });
+
+  it("agrège trajets, jours actifs et CO₂ du mois en cours", () => {
+    const d = computeDerivedStats(
+      [row("2026-07-02", 20, 3), row("2026-07-15", 30, 2), row("2026-06-30", 99, 9)],
+      "2026-07-28",
+    );
+    expect(d.currentMonth.distanceKm).toBe(50);
+    expect(d.currentMonth.tripCount).toBe(5);
+    expect(d.currentMonth.activeDays).toBe(2);
+    expect(d.currentMonth.co2Kg).toBeCloseTo(50 * 0.1617, 3);
+  });
+
+  it("n'est pas perturbé par le passage à l'heure d'hiver", () => {
+    // 2026-10-25 est le dimanche du changement d'heure en Europe.
+    // Les jours arrivent en UTC : la semaine doit rester à 7 jours.
+    const d = computeDerivedStats(
+      [row("2026-10-19", 10), row("2026-10-25", 10), row("2026-10-26", 10)],
+      "2026-10-26",
+    );
+    expect(d.currentWeek.distanceKm).toBe(10);
+  });
+});

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -12,24 +12,85 @@ export interface UserStats {
   totalDistanceKm: number;
   totalCo2SavedKg: number;
   totalMoneySavedEur: number;
+  totalFuelSavedL: number;
   tripCount: number;
-  currentStreak: number;
+  /** Plus longue série jamais réalisée. Les badges streak s'appuient dessus, pas sur la série en cours. */
+  longestStreak: number;
+  maxTripDistanceKm: number;
+  maxTripDurationSec: number;
+  /** Vitesse du meilleur trajet d'au moins 5 km. Sous ce seuil, une descente courte fausserait tout. */
+  maxTripSpeedKmh: number;
+  maxDayDistanceKm: number;
+  monthsActive: number;
+  /** Trajets démarrés avant 7 h — heure LOCALE, seule exception à la règle UTC-only du backend. */
+  earlyTripCount: number;
+  /** Trajets démarrés à 21 h ou après — heure LOCALE. */
+  nightTripCount: number;
+  weekendTripCount: number;
+  /** Nombre de jours de la semaine distincts (UTC). 7 = all_week. */
+  distinctWeekdayCount: number;
+  weeklyGoalsMet: number;
+  monthlyGoalsMet: number;
 }
 
 export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
+  // Volume
   first_trip: (s) => s.tripCount >= 1,
   trips_10: (s) => s.tripCount >= 10,
   trips_50: (s) => s.tripCount >= 50,
   trips_100: (s) => s.tripCount >= 100,
+  trips_250: (s) => s.tripCount >= 250,
+  trips_500: (s) => s.tripCount >= 500,
   km_100: (s) => s.totalDistanceKm >= 100,
   km_500: (s) => s.totalDistanceKm >= 500,
   km_1000: (s) => s.totalDistanceKm >= 1000,
+  km_2500: (s) => s.totalDistanceKm >= 2500,
+  km_5000: (s) => s.totalDistanceKm >= 5000,
+  km_10000: (s) => s.totalDistanceKm >= 10000,
+
+  // Impact
   co2_10kg: (s) => s.totalCo2SavedKg >= 10,
   co2_100kg: (s) => s.totalCo2SavedKg >= 100,
+  co2_250kg: (s) => s.totalCo2SavedKg >= 250,
+  co2_500kg: (s) => s.totalCo2SavedKg >= 500,
   co2_1t: (s) => s.totalCo2SavedKg >= 1000,
-  streak_7: (s) => s.currentStreak >= 7,
-  streak_30: (s) => s.currentStreak >= 30,
+  fuel_25l: (s) => s.totalFuelSavedL >= 25,
+  fuel_50l: (s) => s.totalFuelSavedL >= 50,
+  fuel_100l: (s) => s.totalFuelSavedL >= 100,
+  fuel_250l: (s) => s.totalFuelSavedL >= 250,
   money_100: (s) => s.totalMoneySavedEur >= 100,
+  money_250: (s) => s.totalMoneySavedEur >= 250,
+  money_500: (s) => s.totalMoneySavedEur >= 500,
+  money_1000: (s) => s.totalMoneySavedEur >= 1000,
+
+  // Régularité — sur longestStreak, pas sur la série en cours
+  streak_3: (s) => s.longestStreak >= 3,
+  streak_7: (s) => s.longestStreak >= 7,
+  streak_14: (s) => s.longestStreak >= 14,
+  streak_30: (s) => s.longestStreak >= 30,
+  streak_100: (s) => s.longestStreak >= 100,
+  months_active_6: (s) => s.monthsActive >= 6,
+  months_active_12: (s) => s.monthsActive >= 12,
+  weekly_goal_10: (s) => s.weeklyGoalsMet >= 10,
+  monthly_goal_3: (s) => s.monthlyGoalsMet >= 3,
+
+  // Records
+  day_30: (s) => s.maxDayDistanceKm >= 30,
+  day_50: (s) => s.maxDayDistanceKm >= 50,
+  trip_25: (s) => s.maxTripDistanceKm >= 25,
+  trip_50: (s) => s.maxTripDistanceKm >= 50,
+  trip_2h: (s) => s.maxTripDurationSec >= 7200,
+
+  // Habitudes
+  early_bird: (s) => s.earlyTripCount >= 10,
+  night_owl: (s) => s.nightTripCount >= 10,
+  weekend_20: (s) => s.weekendTripCount >= 20,
+  all_week: (s) => s.distinctWeekdayCount >= 7,
+
+  // Performance
+  speed_20: (s) => s.maxTripSpeedKmh >= 20,
+  speed_22: (s) => s.maxTripSpeedKmh >= 22,
+  speed_25: (s) => s.maxTripSpeedKmh >= 25,
 };
 
 /**

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -70,7 +70,7 @@ export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
   streak_7: (s) => s.longestStreak >= 7,
   streak_14: (s) => s.longestStreak >= 14,
   streak_30: (s) => s.longestStreak >= 30,
-  streak_100: (s) => s.longestStreak >= 100,
+  streak_60: (s) => s.longestStreak >= 60,
   months_active_6: (s) => s.monthsActive >= 6,
   months_active_12: (s) => s.monthsActive >= 12,
   weekly_goal_10: (s) => s.weeklyGoalsMet >= 10,

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -3,6 +3,7 @@ import { db } from "../db";
 import { trips, achievements, user } from "../db/schema";
 import { computeStreak } from "./streaks";
 import { computeDerivedStats, type DailyRow } from "./derived-stats";
+import { fetchDailyRows } from "./daily-rollup";
 import { normalizeTimezone } from "./timezone";
 import type { BadgeId } from "@ecoride/shared/types";
 
@@ -113,6 +114,11 @@ export async function collectUserStats(userId: string): Promise<UserStats> {
   // intrinsèquement locale, sinon "avant 7 h" devient "avant 9 h" à Paris en été.
   const tz = normalizeTimezone(profile?.timezone);
   const localHour = sql<number>`EXTRACT(hour FROM ${trips.startedAt} AT TIME ZONE ${tz}::text)`;
+  // Décalage connu et accepté : le jour de semaine reste UTC alors que
+  // localHour ci-dessus est local. Un trajet parisien du lundi 00h30 vaut
+  // 23h30 UTC dimanche et compte donc comme un trajet de week-end pour
+  // weekend_20 / all_week. Faible fréquence, et la règle UTC-only du backend
+  // prime — ce n'est pas un oubli.
   const utcDow = sql<number>`EXTRACT(dow FROM ${trips.startedAt} AT TIME ZONE 'UTC')`;
 
   const [agg] = await db
@@ -139,17 +145,8 @@ export async function collectUserStats(userId: string): Promise<UserStats> {
     .from(trips)
     .where(eq(trips.userId, userId));
 
-  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
-  const dailyRows: DailyRow[] = await db
-    .select({
-      day: dayExpr.as("day"),
-      distanceKm: sum(trips.distanceKm).mapWith(Number),
-      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
-      tripCount: count(),
-    })
-    .from(trips)
-    .where(eq(trips.userId, userId))
-    .groupBy(dayExpr);
+  // Partagée avec GET /api/stats/summary : voir daily-rollup.ts.
+  const dailyRows: DailyRow[] = await fetchDailyRows(userId);
 
   const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
   const streaks = await computeStreak(userId);

--- a/server/src/lib/badges.ts
+++ b/server/src/lib/badges.ts
@@ -1,7 +1,9 @@
-import { eq, and, sum, count, inArray } from "drizzle-orm";
+import { eq, and, sum, count, max, sql, inArray } from "drizzle-orm";
 import { db } from "../db";
-import { trips, achievements } from "../db/schema";
+import { trips, achievements, user } from "../db/schema";
 import { computeStreak } from "./streaks";
+import { computeDerivedStats, type DailyRow } from "./derived-stats";
+import { normalizeTimezone } from "./timezone";
 import type { BadgeId } from "@ecoride/shared/types";
 
 /**
@@ -94,6 +96,86 @@ export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
 };
 
 /**
+ * Agrège toutes les métriques dont dépendent les badges.
+ *
+ * Trois requêtes :
+ *   A — agrégat une-ligne (sommes, maxima, compteurs d'habitudes)
+ *   B — sommes par jour UTC, repliées en TypeScript par computeDerivedStats
+ *   C — computeStreak, dont on ne garde que `longest`
+ */
+export async function collectUserStats(userId: string): Promise<UserStats> {
+  const [profile] = await db
+    .select({ timezone: user.timezone })
+    .from(user)
+    .where(eq(user.id, userId));
+
+  // Seule exception à la règle UTC-only du backend : l'heure de la journée est
+  // intrinsèquement locale, sinon "avant 7 h" devient "avant 9 h" à Paris en été.
+  const tz = normalizeTimezone(profile?.timezone);
+  const localHour = sql<number>`EXTRACT(hour FROM ${trips.startedAt} AT TIME ZONE ${tz}::text)`;
+  const utcDow = sql<number>`EXTRACT(dow FROM ${trips.startedAt} AT TIME ZONE 'UTC')`;
+
+  const [agg] = await db
+    .select({
+      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
+      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
+      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
+      totalFuelSavedL: sum(trips.fuelSavedL).mapWith(Number),
+      tripCount: count(),
+      maxTripDistanceKm: max(trips.distanceKm).mapWith(Number),
+      maxTripDurationSec: max(trips.durationSec).mapWith(Number),
+      // Seuls les trajets d'au moins 5 km comptent : sinon une descente de 500 m
+      // à 40 km/h débloquerait speed_25.
+      maxTripSpeedKmh: sql<number>`coalesce(max(
+        case when ${trips.distanceKm} >= 5 and ${trips.durationSec} > 0
+        then ${trips.distanceKm} / (${trips.durationSec} / 3600.0)
+        end
+      ), 0)`.mapWith(Number),
+      earlyTripCount: sql<number>`count(*) filter (where ${localHour} < 7)`.mapWith(Number),
+      nightTripCount: sql<number>`count(*) filter (where ${localHour} >= 21)`.mapWith(Number),
+      weekendTripCount: sql<number>`count(*) filter (where ${utcDow} in (0, 6))`.mapWith(Number),
+      distinctWeekdayCount: sql<number>`count(distinct ${utcDow})`.mapWith(Number),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId));
+
+  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
+  const dailyRows: DailyRow[] = await db
+    .select({
+      day: dayExpr.as("day"),
+      distanceKm: sum(trips.distanceKm).mapWith(Number),
+      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId))
+    .groupBy(dayExpr);
+
+  const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
+  const streaks = await computeStreak(userId);
+
+  return {
+    totalDistanceKm: agg?.totalDistanceKm ?? 0,
+    totalCo2SavedKg: agg?.totalCo2SavedKg ?? 0,
+    totalMoneySavedEur: agg?.totalMoneySavedEur ?? 0,
+    totalFuelSavedL: agg?.totalFuelSavedL ?? 0,
+    tripCount: agg?.tripCount ?? 0,
+    longestStreak: streaks.longest,
+    maxTripDistanceKm: agg?.maxTripDistanceKm ?? 0,
+    maxTripDurationSec: agg?.maxTripDurationSec ?? 0,
+    maxTripSpeedKmh: agg?.maxTripSpeedKmh ?? 0,
+    maxDayDistanceKm: derived.maxDayDistanceKm,
+    monthsActive: derived.monthsActive,
+    earlyTripCount: agg?.earlyTripCount ?? 0,
+    nightTripCount: agg?.nightTripCount ?? 0,
+    weekendTripCount: agg?.weekendTripCount ?? 0,
+    distinctWeekdayCount: agg?.distinctWeekdayCount ?? 0,
+    weeklyGoalsMet: derived.weeklyGoalsMet,
+    monthlyGoalsMet: derived.monthlyGoalsMet,
+  };
+}
+
+/**
  * Evaluate all badge thresholds for a user and insert any newly unlocked badges.
  * Uses ON CONFLICT DO NOTHING to gracefully handle races / duplicates.
  *
@@ -101,25 +183,7 @@ export const BADGE_THRESHOLDS: Record<BadgeId, (s: UserStats) => boolean> = {
  */
 export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]> {
   // 1. Aggregate lifetime stats
-  const [stats] = await db
-    .select({
-      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
-      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
-      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
-      tripCount: count(),
-    })
-    .from(trips)
-    .where(eq(trips.userId, userId));
-
-  const streaks = await computeStreak(userId);
-
-  const userStats: UserStats = {
-    totalDistanceKm: stats?.totalDistanceKm ?? 0,
-    totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
-    totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
-    tripCount: stats?.tripCount ?? 0,
-    currentStreak: streaks.current,
-  };
+  const userStats = await collectUserStats(userId);
 
   // 2. Get already-unlocked badge IDs
   const existing = await db
@@ -159,26 +223,8 @@ export async function evaluateAndUnlockBadges(userId: string): Promise<BadgeId[]
  * @returns Array of BadgeIds that were revoked.
  */
 export async function reevaluateBadges(userId: string): Promise<BadgeId[]> {
-  // 1. Aggregate lifetime stats (same query as evaluateAndUnlockBadges)
-  const [stats] = await db
-    .select({
-      totalDistanceKm: sum(trips.distanceKm).mapWith(Number),
-      totalCo2SavedKg: sum(trips.co2SavedKg).mapWith(Number),
-      totalMoneySavedEur: sum(trips.moneySavedEur).mapWith(Number),
-      tripCount: count(),
-    })
-    .from(trips)
-    .where(eq(trips.userId, userId));
-
-  const streaks = await computeStreak(userId);
-
-  const userStats: UserStats = {
-    totalDistanceKm: stats?.totalDistanceKm ?? 0,
-    totalCo2SavedKg: stats?.totalCo2SavedKg ?? 0,
-    totalMoneySavedEur: stats?.totalMoneySavedEur ?? 0,
-    tripCount: stats?.tripCount ?? 0,
-    currentStreak: streaks.current,
-  };
+  // 1. Aggregate lifetime stats (same collector as evaluateAndUnlockBadges)
+  const userStats = await collectUserStats(userId);
 
   // 2. Get all currently unlocked badges
   const existing = await db

--- a/server/src/lib/daily-rollup.ts
+++ b/server/src/lib/daily-rollup.ts
@@ -1,0 +1,37 @@
+/**
+ * Source unique des sommes par jour UTC.
+ *
+ * Deux consommateurs s'appuient dessus et DOIVENT voir exactement les mêmes
+ * lignes : `collectUserStats` (badges, dont `weekly_goal_*` et `day_*`) et
+ * `GET /api/stats/summary` (carte de défi hebdo/mensuel). Tant que les deux
+ * partageaient une copie textuelle de la requête, rien n'empêchait qu'une
+ * modification de l'une — par exemple regrouper en fuseau local — laisse
+ * l'autre inchangée : le badge et la carte se contrediraient alors sur la
+ * même semaine, sans qu'aucun test ne bronche.
+ *
+ * La définition du « jour » ici (`DATE(startedAt AT TIME ZONE 'UTC')`) est
+ * aussi celle de `computeStreak` (streaks.ts) — voir le commentaire là-bas.
+ *
+ * `startedAt` est un `timestamptz` : `AT TIME ZONE 'UTC'` produit un timestamp
+ * nu, donc le découpage en jours ne dépend pas du `TimeZone` de session
+ * PostgreSQL.
+ */
+
+import { eq, sum, count, sql } from "drizzle-orm";
+import { db } from "../db";
+import { trips } from "../db/schema";
+import type { DailyRow } from "./derived-stats";
+
+export async function fetchDailyRows(userId: string): Promise<DailyRow[]> {
+  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
+  return db
+    .select({
+      day: dayExpr.as("day"),
+      distanceKm: sum(trips.distanceKm).mapWith(Number),
+      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, userId))
+    .groupBy(dayExpr);
+}

--- a/server/src/lib/derived-stats.ts
+++ b/server/src/lib/derived-stats.ts
@@ -1,0 +1,107 @@
+/**
+ * Repli des sommes journalières en records, mois actifs, objectifs atteints
+ * et état des deux défis en cours.
+ *
+ * Fonction pure : aucun accès base, aucune lecture d'horloge. `today` est
+ * injecté pour que les tests soient déterministes. Toutes les dates sont des
+ * jours UTC au format YYYY-MM-DD, cohérent avec computeStreak().
+ */
+
+import type { ChallengeProgressDto } from "@ecoride/shared/types";
+
+export const WEEKLY_GOAL_KM = 50;
+export const MONTHLY_GOAL_KM = 250;
+
+export interface DailyRow {
+  day: string; // YYYY-MM-DD, UTC
+  distanceKm: number;
+  co2Kg: number;
+  tripCount: number;
+}
+
+export interface DerivedStats {
+  maxDayDistanceKm: number;
+  monthsActive: number;
+  weeklyGoalsMet: number;
+  monthlyGoalsMet: number;
+  currentWeek: ChallengeProgressDto;
+  currentMonth: ChallengeProgressDto;
+}
+
+interface Bucket {
+  distanceKm: number;
+  co2Kg: number;
+  tripCount: number;
+  activeDays: number;
+}
+
+function emptyBucket(): Bucket {
+  return { distanceKm: 0, co2Kg: 0, tripCount: 0, activeDays: 0 };
+}
+
+/** Lundi de la semaine ISO contenant `day`, au format YYYY-MM-DD. */
+export function isoWeekStart(day: string): string {
+  const d = new Date(`${day}T00:00:00Z`);
+  // getUTCDay(): 0 = dimanche. On ramène dimanche à 7 pour que lundi = 1.
+  const dow = d.getUTCDay() === 0 ? 7 : d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - (dow - 1));
+  return d.toISOString().slice(0, 10);
+}
+
+function monthKey(day: string): string {
+  return day.slice(0, 7); // YYYY-MM
+}
+
+function fold(rows: DailyRow[], keyOf: (day: string) => string): Map<string, Bucket> {
+  const buckets = new Map<string, Bucket>();
+  for (const r of rows) {
+    const key = keyOf(r.day);
+    const b = buckets.get(key) ?? emptyBucket();
+    b.distanceKm += r.distanceKm;
+    b.co2Kg += r.co2Kg;
+    b.tripCount += r.tripCount;
+    b.activeDays += 1;
+    buckets.set(key, b);
+  }
+  return buckets;
+}
+
+function toProgress(b: Bucket | undefined, goalKm: number): ChallengeProgressDto {
+  const bucket = b ?? emptyBucket();
+  return {
+    distanceKm: bucket.distanceKm,
+    goalKm,
+    tripCount: bucket.tripCount,
+    activeDays: bucket.activeDays,
+    co2Kg: bucket.co2Kg,
+  };
+}
+
+export function computeDerivedStats(rows: DailyRow[], today: string): DerivedStats {
+  const weeks = fold(rows, isoWeekStart);
+  const months = fold(rows, monthKey);
+
+  let maxDayDistanceKm = 0;
+  for (const r of rows) {
+    if (r.distanceKm > maxDayDistanceKm) maxDayDistanceKm = r.distanceKm;
+  }
+
+  let weeklyGoalsMet = 0;
+  for (const b of weeks.values()) {
+    if (b.distanceKm >= WEEKLY_GOAL_KM) weeklyGoalsMet += 1;
+  }
+
+  let monthlyGoalsMet = 0;
+  for (const b of months.values()) {
+    if (b.distanceKm >= MONTHLY_GOAL_KM) monthlyGoalsMet += 1;
+  }
+
+  return {
+    maxDayDistanceKm,
+    monthsActive: months.size,
+    weeklyGoalsMet,
+    monthlyGoalsMet,
+    currentWeek: toProgress(weeks.get(isoWeekStart(today)), WEEKLY_GOAL_KM),
+    currentMonth: toProgress(months.get(monthKey(today)), MONTHLY_GOAL_KM),
+  };
+}

--- a/server/src/lib/streaks.ts
+++ b/server/src/lib/streaks.ts
@@ -16,7 +16,10 @@ function todayUtc(): string {
  * @param userId - The user to compute streaks for
  */
 export async function computeStreak(userId: string): Promise<{ current: number; longest: number }> {
-  // Get distinct UTC trip dates ordered descending via GROUP BY DATE
+  // Get distinct UTC trip dates ordered descending via GROUP BY DATE.
+  // La définition du jour ci-dessous reflète volontairement celle de
+  // fetchDailyRows (lib/daily-rollup.ts) : si l'une change, l'autre doit
+  // suivre, sinon séries et défis parleront de jours différents.
   const rows = await db
     .select({ day: sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`.as("day") })
     .from(trips)

--- a/server/src/routes/__tests__/stats.test.ts
+++ b/server/src/routes/__tests__/stats.test.ts
@@ -3,20 +3,32 @@ import { Hono } from "hono";
 import type { AuthEnv } from "../../types/context";
 
 const mocks = vi.hoisted(() => {
-  const mockWhere = vi.fn().mockResolvedValue([
-    {
-      totalDistanceKm: 12.3,
-      totalCo2SavedKg: 1.234,
-      totalMoneySavedEur: 2.5,
-      totalFuelSavedL: 0.7,
-      tripCount: 2,
-      activeUsers: 1,
-    },
-  ]);
+  // `where()` termine la requête pour l'agrégat simple (summary, community), mais
+  // la requête journalière des défis ajoute `.groupBy()`. On renvoie donc un
+  // thenable qui porte aussi `groupBy`, pour couvrir les deux formes avec un seul
+  // mock de `where` — voir server/src/lib/__tests__/badges-db.test.ts pour le même
+  // pattern côté collectUserStats.
+  function makeTerminal(rows: unknown[], dailyRows: unknown[] = []) {
+    const groupBy = vi.fn().mockResolvedValue(dailyRows);
+    return Object.assign(Promise.resolve(rows), { groupBy });
+  }
+
+  const mockWhere = vi.fn().mockReturnValue(
+    makeTerminal([
+      {
+        totalDistanceKm: 12.3,
+        totalCo2SavedKg: 1.234,
+        totalMoneySavedEur: 2.5,
+        totalFuelSavedL: 0.7,
+        tripCount: 2,
+        activeUsers: 1,
+      },
+    ]),
+  );
   const mockFrom = vi.fn(() => ({ where: mockWhere }));
   const mockSelect = vi.fn(() => ({ from: mockFrom }));
   const mockComputeStreak = vi.fn().mockResolvedValue({ current: 4, longest: 9 });
-  return { mockWhere, mockFrom, mockSelect, mockComputeStreak };
+  return { mockWhere, mockFrom, mockSelect, mockComputeStreak, makeTerminal };
 });
 
 vi.mock("../../db", () => ({
@@ -58,16 +70,18 @@ describe("GET /stats/summary", () => {
     mocks.mockFrom.mockClear();
     mocks.mockWhere.mockClear();
     mocks.mockComputeStreak.mockClear();
-    mocks.mockWhere.mockResolvedValue([
-      {
-        totalDistanceKm: 12.3,
-        totalCo2SavedKg: 1.234,
-        totalMoneySavedEur: 2.5,
-        totalFuelSavedL: 0.7,
-        tripCount: 2,
-        activeUsers: 1,
-      },
-    ]);
+    mocks.mockWhere.mockReturnValue(
+      mocks.makeTerminal([
+        {
+          totalDistanceKm: 12.3,
+          totalCo2SavedKg: 1.234,
+          totalMoneySavedEur: 2.5,
+          totalFuelSavedL: 0.7,
+          tripCount: 2,
+          activeUsers: 1,
+        },
+      ]),
+    );
     mocks.mockComputeStreak.mockResolvedValue({ current: 4, longest: 9 });
   });
 
@@ -83,6 +97,82 @@ describe("GET /stats/summary", () => {
     expect(body.data.currentStreak).toBe(4);
     expect(body.data.longestStreak).toBe(9);
     expect(mocks.mockComputeStreak).toHaveBeenCalledWith("user-1");
+  });
+
+  it("expose la progression des défis hebdo et mensuel, calculée depuis les sommes journalières", async () => {
+    // "Aujourd'hui" = mercredi 2025-01-15. Semaine ISO en cours: lundi
+    // 2025-01-13 -> dimanche 2025-01-19. Mois en cours: 2025-01.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+
+    mocks.mockWhere.mockReturnValue(
+      mocks.makeTerminal(
+        [
+          {
+            totalDistanceKm: 12.3,
+            totalCo2SavedKg: 1.234,
+            totalMoneySavedEur: 2.5,
+            totalFuelSavedL: 0.7,
+            tripCount: 2,
+            activeUsers: 1,
+          },
+        ],
+        [
+          // Deux jours dans la semaine ET le mois en cours.
+          { day: "2025-01-13", distanceKm: 20, co2Kg: 2, tripCount: 1 },
+          { day: "2025-01-14", distanceKm: 15, co2Kg: 1.5, tripCount: 1 },
+          // Un jour hors semaine mais toujours dans le mois — ne doit compter
+          // que dans `month`, pas dans `week`.
+          { day: "2025-01-02", distanceKm: 5, co2Kg: 0.5, tripCount: 1 },
+          // Un jour hors semaine ET hors mois — ne doit compter nulle part.
+          { day: "2024-12-01", distanceKm: 100, co2Kg: 10, tripCount: 5 },
+        ],
+      ),
+    );
+
+    try {
+      const res = await buildApp().request("/stats/summary");
+      const body = (await res.json()) as {
+        ok: boolean;
+        data: {
+          challenges: {
+            week: {
+              distanceKm: number;
+              goalKm: number;
+              tripCount: number;
+              activeDays: number;
+              co2Kg: number;
+            };
+            month: {
+              distanceKm: number;
+              goalKm: number;
+              tripCount: number;
+              activeDays: number;
+              co2Kg: number;
+            };
+          };
+        };
+      };
+
+      expect(res.status).toBe(200);
+      // Passthrough des constantes de production (WEEKLY_GOAL_KM / MONTHLY_GOAL_KM) :
+      // structurel, mais confirme que la route branche bien computeDerivedStats et
+      // non une valeur codée en dur dans la route elle-même.
+      expect(body.data.challenges.week.goalKm).toBe(50);
+      expect(body.data.challenges.month.goalKm).toBe(250);
+      // Ce qui suit est calculé par la route à partir des lignes journalières
+      // simulées ci-dessus — ce n'est PAS une valeur que le mock a fournie
+      // directement, donc ça pin le vrai calcul (agrégation + repli ISO-semaine).
+      expect(body.data.challenges.week.distanceKm).toBe(35); // 20 + 15, exclut le 02/01 et le 01/12
+      expect(body.data.challenges.week.tripCount).toBe(2);
+      expect(body.data.challenges.week.activeDays).toBe(2);
+      expect(body.data.challenges.week.co2Kg).toBeCloseTo(3.5);
+      expect(body.data.challenges.month.distanceKm).toBe(40); // 20 + 15 + 5, exclut le 01/12
+      expect(body.data.challenges.month.tripCount).toBe(3);
+      expect(body.data.challenges.month.activeDays).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/server/src/routes/__tests__/trips-create.test.ts
+++ b/server/src/routes/__tests__/trips-create.test.ts
@@ -254,4 +254,86 @@ describe("POST /trips", () => {
     expect(res.status).toBe(201);
     expect(mocks.mockGetFuelPrice).toHaveBeenCalledWith("sp95");
   });
+
+  // --- Rafale de notifications push ------------------------------------------
+  // Le catalogue est passé de 13 à 46 badges : au premier trajet suivant le
+  // déploiement, un utilisateur ancien franchit d'un coup une vingtaine de
+  // seuils. Sans plafond, son téléphone vibre vingt fois et vingt requêtes
+  // web-push partent pour un seul POST.
+
+  async function postLiveTrip() {
+    const endedAt = new Date().toISOString();
+    const startedAt = new Date(Date.now() - 600 * 1000).toISOString();
+    return buildApp().request("/trips", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        distanceKm: 10,
+        durationSec: 600,
+        startedAt,
+        endedAt,
+        gpsPoints: null,
+      }),
+    });
+  }
+
+  it("envoie une notification par badge tant qu'ils sont peu nombreux", async () => {
+    mocks.mockSendPushToUser.mockResolvedValue(undefined);
+    mocks.mockEvaluateAndUnlockBadges.mockResolvedValue(["first_trip", "trips_10", "km_100"]);
+
+    expect((await postLiveTrip()).status).toBe(201);
+
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledTimes(3);
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ body: "Badge débloqué : Premier trajet 🚴" }),
+    );
+  });
+
+  it("agrège en une seule notification au-delà de 3 badges", async () => {
+    mocks.mockSendPushToUser.mockResolvedValue(undefined);
+    const many = [
+      "first_trip",
+      "trips_10",
+      "trips_50",
+      "trips_100",
+      "km_100",
+      "km_500",
+      "km_1000",
+      "co2_10kg",
+      "co2_100kg",
+      "fuel_25l",
+      "fuel_50l",
+      "money_100",
+      "money_250",
+    ];
+    mocks.mockEvaluateAndUnlockBadges.mockResolvedValue(many);
+
+    expect((await postLiveTrip()).status).toBe(201);
+
+    // Une seule requête push, pas treize.
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledTimes(1);
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledWith("user-1", {
+      title: "ecoRide",
+      body: "Badge débloqué : Premier trajet 🚴 +12 autres",
+    });
+  });
+
+  it("reste par badge exactement au seuil (4 badges = agrégé, 3 = détaillé)", async () => {
+    mocks.mockSendPushToUser.mockResolvedValue(undefined);
+    mocks.mockEvaluateAndUnlockBadges.mockResolvedValue([
+      "first_trip",
+      "trips_10",
+      "km_100",
+      "co2_10kg",
+    ]);
+
+    expect((await postLiveTrip()).status).toBe(201);
+
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledTimes(1);
+    expect(mocks.mockSendPushToUser).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ body: "Badge débloqué : Premier trajet 🚴 +3 autres" }),
+    );
+  });
 });

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -6,6 +6,7 @@ import { db } from "../db";
 import { trips } from "../db/schema";
 import { validationHook } from "../lib/validation";
 import { computeStreak } from "../lib/streaks";
+import { computeDerivedStats, type DailyRow } from "../lib/derived-stats";
 import { rateLimit } from "../lib/rate-limit";
 import type { AuthEnv } from "../types/context";
 import type {
@@ -71,6 +72,20 @@ statsRouter.get("/summary", zValidator("query", statsQuery, validationHook), asy
 
   const streaks = await computeStreak(currentUser.id);
 
+  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
+  const dailyRows: DailyRow[] = await db
+    .select({
+      day: dayExpr.as("day"),
+      distanceKm: sum(trips.distanceKm).mapWith(Number),
+      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
+      tripCount: count(),
+    })
+    .from(trips)
+    .where(eq(trips.userId, currentUser.id))
+    .groupBy(dayExpr);
+
+  const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
+
   return c.json({
     ok: true,
     data: {
@@ -81,6 +96,7 @@ statsRouter.get("/summary", zValidator("query", statsQuery, validationHook), asy
       tripCount: stats?.tripCount ?? 0,
       currentStreak: streaks.current,
       longestStreak: streaks.longest,
+      challenges: { week: derived.currentWeek, month: derived.currentMonth },
     },
   });
 });

--- a/server/src/routes/stats.routes.ts
+++ b/server/src/routes/stats.routes.ts
@@ -7,6 +7,7 @@ import { trips } from "../db/schema";
 import { validationHook } from "../lib/validation";
 import { computeStreak } from "../lib/streaks";
 import { computeDerivedStats, type DailyRow } from "../lib/derived-stats";
+import { fetchDailyRows } from "../lib/daily-rollup";
 import { rateLimit } from "../lib/rate-limit";
 import type { AuthEnv } from "../types/context";
 import type {
@@ -72,17 +73,9 @@ statsRouter.get("/summary", zValidator("query", statsQuery, validationHook), asy
 
   const streaks = await computeStreak(currentUser.id);
 
-  const dayExpr = sql<string>`DATE(${trips.startedAt} AT TIME ZONE 'UTC')`;
-  const dailyRows: DailyRow[] = await db
-    .select({
-      day: dayExpr.as("day"),
-      distanceKm: sum(trips.distanceKm).mapWith(Number),
-      co2Kg: sum(trips.co2SavedKg).mapWith(Number),
-      tripCount: count(),
-    })
-    .from(trips)
-    .where(eq(trips.userId, currentUser.id))
-    .groupBy(dayExpr);
+  // Partagée avec collectUserStats (badges) : voir lib/daily-rollup.ts. La carte
+  // de défi et weekly_goal_* doivent parler de la même semaine.
+  const dailyRows: DailyRow[] = await fetchDailyRows(currentUser.id);
 
   const derived = computeDerivedStats(dailyRows, new Date().toISOString().slice(0, 10));
 

--- a/server/src/routes/trips.routes.ts
+++ b/server/src/routes/trips.routes.ts
@@ -129,18 +129,36 @@ tripsRouter.post(
       currentUser.id,
     );
 
-    // Fire-and-forget: push notifications for newly unlocked badges
-    for (const badgeId of newBadges) {
-      const badge = BADGES[badgeId as BadgeId];
+    // Fire-and-forget: push notifications for newly unlocked badges.
+    // Au-delà du seuil, une seule notification agrégée : un utilisateur ancien
+    // peut franchir vingt seuils d'un coup au premier trajet suivant un
+    // enrichissement du catalogue. Vingt vibrations d'affilée — et vingt
+    // requêtes web-push pour un seul POST — sont une nuisance, pas une fête.
+    const BADGE_PUSH_BURST_LIMIT = 3;
+    if (newBadges.length > BADGE_PUSH_BURST_LIMIT) {
+      const first = BADGES[newBadges[0]! as BadgeId];
       reportBackgroundError(
         sendPushToUser(currentUser.id, {
           title: "ecoRide",
-          body: `Badge débloqué : ${badge.label} ${badge.icon}`,
+          body: `Badge débloqué : ${first.label} ${first.icon} +${newBadges.length - 1} autres`,
         }),
         requestLogger,
         "badge_push_failed",
-        { badgeId },
+        { badgeCount: newBadges.length },
       );
+    } else {
+      for (const badgeId of newBadges) {
+        const badge = BADGES[badgeId as BadgeId];
+        reportBackgroundError(
+          sendPushToUser(currentUser.id, {
+            title: "ecoRide",
+            body: `Badge débloqué : ${badge.label} ${badge.icon}`,
+          }),
+          requestLogger,
+          "badge_push_failed",
+          { badgeId },
+        );
+      }
     }
 
     // Fire-and-forget: check leaderboard overtakes — only for live trips,

--- a/shared/__tests__/badges-catalog.test.ts
+++ b/shared/__tests__/badges-catalog.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { BADGES, BADGE_CATEGORIES, type BadgeId } from "../types";
+
+describe("BADGES catalog", () => {
+  it("contient 46 badges", () => {
+    expect(Object.keys(BADGES)).toHaveLength(46);
+  });
+
+  it("garde les 13 ids historiques intacts", () => {
+    const legacy: BadgeId[] = [
+      "first_trip",
+      "trips_10",
+      "trips_50",
+      "trips_100",
+      "km_100",
+      "km_500",
+      "km_1000",
+      "co2_10kg",
+      "co2_100kg",
+      "co2_1t",
+      "streak_7",
+      "streak_30",
+      "money_100",
+    ];
+    for (const id of legacy) {
+      expect(BADGES[id]).toBeDefined();
+    }
+  });
+
+  it("donne à chaque badge une catégorie connue", () => {
+    for (const badge of Object.values(BADGES)) {
+      expect(BADGE_CATEGORIES).toContain(badge.category);
+    }
+  });
+
+  it("a un id cohérent avec sa clé", () => {
+    for (const [key, badge] of Object.entries(BADGES)) {
+      expect(badge.id).toBe(key);
+    }
+  });
+
+  it("répartit les badges dans les 6 catégories aux bons effectifs", () => {
+    const counts = BADGE_CATEGORIES.map(
+      (c) => Object.values(BADGES).filter((b) => b.category === c).length,
+    );
+    expect(counts).toEqual([12, 13, 9, 5, 4, 3]);
+  });
+});

--- a/shared/api-contracts.ts
+++ b/shared/api-contracts.ts
@@ -7,6 +7,7 @@ import type {
   FuelType,
   WeekDay,
   Super73Mode,
+  ChallengeProgressDto,
 } from "./types";
 
 // ---- Route definitions ----
@@ -195,6 +196,7 @@ export interface StatsSummaryResponse {
   tripCount: number;
   currentStreak: number;
   longestStreak: number;
+  challenges: { week: ChallengeProgressDto; month: ChallengeProgressDto };
 }
 
 export interface LeaderboardEntry {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -156,12 +156,7 @@ export const BADGES = {
   streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥", category: "regularity" },
   streak_14: { id: "streak_14", label: "14 jours d'affilée", icon: "🌗", category: "regularity" },
   streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡", category: "regularity" },
-  streak_100: {
-    id: "streak_100",
-    label: "100 jours d'affilée",
-    icon: "🌟",
-    category: "regularity",
-  },
+  streak_60: { id: "streak_60", label: "60 jours d'affilée", icon: "🌟", category: "regularity" },
   months_active_6: {
     id: "months_active_6",
     label: "6 mois actifs",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -110,23 +110,123 @@ export const CO2_KG_PER_LITER = 2.31;
 
 // ---- Badge definitions (static, not in DB) ----
 
+export const BADGE_CATEGORIES = [
+  "volume",
+  "impact",
+  "regularity",
+  "records",
+  "habits",
+  "performance",
+] as const;
+
+export type BadgeCategory = (typeof BADGE_CATEGORIES)[number];
+
 export const BADGES = {
-  first_trip: { id: "first_trip", label: "Premier trajet", icon: "🚴" },
-  trips_10: { id: "trips_10", label: "10 trajets", icon: "🔟" },
-  trips_50: { id: "trips_50", label: "50 trajets", icon: "🏅" },
-  trips_100: { id: "trips_100", label: "100 trajets", icon: "💯" },
-  km_100: { id: "km_100", label: "100 km", icon: "🛤️" },
-  km_500: { id: "km_500", label: "500 km", icon: "🗺️" },
-  km_1000: { id: "km_1000", label: "1 000 km", icon: "🌍" },
-  co2_10kg: { id: "co2_10kg", label: "10 kg CO₂ économisés", icon: "🌱" },
-  co2_100kg: { id: "co2_100kg", label: "100 kg CO₂ économisés", icon: "🌳" },
-  co2_1t: { id: "co2_1t", label: "1 tonne CO₂ économisée", icon: "🌲" },
-  streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥" },
-  streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡" },
-  money_100: { id: "money_100", label: "100 € économisés", icon: "💰" },
-} as const;
+  // ---- 🚴 Volume (12) ----
+  first_trip: { id: "first_trip", label: "Premier trajet", icon: "🚴", category: "volume" },
+  trips_10: { id: "trips_10", label: "10 trajets", icon: "🔟", category: "volume" },
+  trips_50: { id: "trips_50", label: "50 trajets", icon: "🏅", category: "volume" },
+  trips_100: { id: "trips_100", label: "100 trajets", icon: "💯", category: "volume" },
+  trips_250: { id: "trips_250", label: "250 trajets", icon: "🎖️", category: "volume" },
+  trips_500: { id: "trips_500", label: "500 trajets", icon: "🏆", category: "volume" },
+  km_100: { id: "km_100", label: "100 km", icon: "🛤️", category: "volume" },
+  km_500: { id: "km_500", label: "500 km", icon: "🗺️", category: "volume" },
+  km_1000: { id: "km_1000", label: "1 000 km", icon: "🌍", category: "volume" },
+  km_2500: { id: "km_2500", label: "2 500 km", icon: "🧭", category: "volume" },
+  km_5000: { id: "km_5000", label: "5 000 km", icon: "🛰️", category: "volume" },
+  km_10000: { id: "km_10000", label: "10 000 km", icon: "🌐", category: "volume" },
+
+  // ---- 🌱 Impact (13) ----
+  co2_10kg: { id: "co2_10kg", label: "10 kg CO₂ économisés", icon: "🌱", category: "impact" },
+  co2_100kg: { id: "co2_100kg", label: "100 kg CO₂ économisés", icon: "🌳", category: "impact" },
+  co2_250kg: { id: "co2_250kg", label: "250 kg CO₂ économisés", icon: "🌿", category: "impact" },
+  co2_500kg: { id: "co2_500kg", label: "500 kg CO₂ économisés", icon: "🍃", category: "impact" },
+  co2_1t: { id: "co2_1t", label: "1 tonne CO₂ économisée", icon: "🌲", category: "impact" },
+  fuel_25l: { id: "fuel_25l", label: "25 L économisés", icon: "⛽", category: "impact" },
+  fuel_50l: { id: "fuel_50l", label: "50 L économisés", icon: "🛢️", category: "impact" },
+  fuel_100l: { id: "fuel_100l", label: "100 L économisés", icon: "🚫", category: "impact" },
+  fuel_250l: { id: "fuel_250l", label: "250 L économisés", icon: "🏭", category: "impact" },
+  money_100: { id: "money_100", label: "100 € économisés", icon: "💰", category: "impact" },
+  money_250: { id: "money_250", label: "250 € économisés", icon: "💶", category: "impact" },
+  money_500: { id: "money_500", label: "500 € économisés", icon: "💸", category: "impact" },
+  money_1000: { id: "money_1000", label: "1 000 € économisés", icon: "💎", category: "impact" },
+
+  // ---- 🔥 Régularité (9) ----
+  streak_3: { id: "streak_3", label: "3 jours d'affilée", icon: "🌤️", category: "regularity" },
+  streak_7: { id: "streak_7", label: "7 jours de streak", icon: "🔥", category: "regularity" },
+  streak_14: { id: "streak_14", label: "14 jours d'affilée", icon: "🌗", category: "regularity" },
+  streak_30: { id: "streak_30", label: "30 jours de streak", icon: "⚡", category: "regularity" },
+  streak_100: {
+    id: "streak_100",
+    label: "100 jours d'affilée",
+    icon: "🌟",
+    category: "regularity",
+  },
+  months_active_6: {
+    id: "months_active_6",
+    label: "6 mois actifs",
+    icon: "📆",
+    category: "regularity",
+  },
+  months_active_12: {
+    id: "months_active_12",
+    label: "12 mois actifs",
+    icon: "🎂",
+    category: "regularity",
+  },
+  weekly_goal_10: {
+    id: "weekly_goal_10",
+    label: "10 objectifs hebdo",
+    icon: "🎯",
+    category: "regularity",
+  },
+  monthly_goal_3: {
+    id: "monthly_goal_3",
+    label: "3 objectifs mensuels",
+    icon: "🗓️",
+    category: "regularity",
+  },
+
+  // ---- 🏆 Records (5) ----
+  day_30: { id: "day_30", label: "30 km en un jour", icon: "☀️", category: "records" },
+  day_50: { id: "day_50", label: "50 km en un jour", icon: "🌞", category: "records" },
+  trip_25: { id: "trip_25", label: "Trajet de 25 km", icon: "🚀", category: "records" },
+  trip_50: { id: "trip_50", label: "Trajet de 50 km", icon: "🛫", category: "records" },
+  trip_2h: { id: "trip_2h", label: "2 h en selle", icon: "⏱️", category: "records" },
+
+  // ---- 🕐 Habitudes (4) ----
+  early_bird: { id: "early_bird", label: "Lève-tôt", icon: "🌅", category: "habits" },
+  night_owl: { id: "night_owl", label: "Noctambule", icon: "🦉", category: "habits" },
+  weekend_20: { id: "weekend_20", label: "20 trajets le week-end", icon: "🎒", category: "habits" },
+  all_week: {
+    id: "all_week",
+    label: "Tous les jours de la semaine",
+    icon: "📅",
+    category: "habits",
+  },
+
+  // ---- ⚡ Performance (3) ----
+  speed_20: { id: "speed_20", label: "20 km/h de moyenne", icon: "⚡", category: "performance" },
+  speed_22: { id: "speed_22", label: "22 km/h de moyenne", icon: "💨", category: "performance" },
+  speed_25: { id: "speed_25", label: "25 km/h de moyenne", icon: "🔥", category: "performance" },
+} as const satisfies Record<
+  string,
+  { id: string; label: string; icon: string; category: BadgeCategory }
+>;
 
 export type BadgeId = keyof typeof BADGES;
+
+/**
+ * État d'un défi glissant. Défini ici parce que le serveur le produit
+ * (derived-stats.ts) et le client le consomme (ChallengeCard.tsx).
+ */
+export interface ChallengeProgressDto {
+  distanceKm: number;
+  goalKm: number;
+  tripCount: number;
+  activeDays: number;
+  co2Kg: number;
+}
 
 // ---- Impact Meter references ----
 


### PR DESCRIPTION
Implémente `docs/superpowers/specs/2026-07-28-badges-categories-design.md`.
Le catalogue passe de 13 à 46 badges répartis en 6 catégories, corrige un bug latent sur les streaks, et ajoute deux défis glissants.

## Ce qui change pour l'utilisateur

- **46 badges** au lieu de 13, groupés en Volume / Impact / Régularité / Records / Habitudes / Performance, avec un compteur `débloqués/total` par catégorie.
- **Deux défis glissants** : 50 km/semaine et 250 km/mois, avec barre de progression. Calculés à la lecture, jamais stockés — le reset est gratuit.
- **Les badges de streak ne disparaissent plus à tort.** Ils lisaient `currentStreak` : une série cassée les laissait en place, mais la première suppression de trajet les faisait disparaître sans rapport. Ils lisent désormais `longestStreak` — une série de 30 jours en janvier reste acquise en juillet.

Les 13 ids historiques sont inchangés : **aucune migration de données**.

## Calibration

Sur données réelles : 1159,8 km, 187,5 kg CO₂, 137 trajets, 18 km/h, série max 4 jours (record de l'app : 30).

`streak_100` a été remplacé par `streak_60` — 100 jours consécutifs n'auraient jamais été atteints par personne. Les paliers `trips_250`/`trips_500` tombent à ~4 mois et ~1 an au rythme actuel.

## Vérifications au-delà de la CI

- **Le SQL a été validé contre un vrai PostgreSQL** (conteneur jetable + schéma réel + données adverses) : le garde-fou des 5 km ignore bien un trajet de 500 m à 40 km/h, l'exception de fuseau distingue 05:30 UTC de 04:30 UTC pour un utilisateur parisien, et le regroupement par jour somme les trajets au lieu de renvoyer le meilleur.
- **Les garde-fous ont été testés par sabotage** : retirer `.groupBy()`, retirer le plafonnement du pourcentage, inverser le ratio, supprimer une catégorie — chacun fait échouer le test censé l'attraper.

## Corrections issues de la revue finale

- **Rafale de notifications push** : au premier trajet après déploiement, un utilisateur ancien franchissait ~20 seuils d'un coup et recevait 20 notifications en quelques secondes. Au-delà de 3 badges, une notification agrégée unique est envoyée.
- **Les deux requêtes journalières** (badges et défis) étaient des copies textuelles. Si elles divergeaient, le badge et la carte se contrediraient sur la même semaine sans qu'aucun test ne bronche. Extraites dans `server/src/lib/daily-rollup.ts`.
- **Playwright ne construisait pas** avant de tourner : il testait `client/dist` tel quel, potentiellement périmé. Ça a coûté une tâche entière à deux agents qui déboguaient une spec correcte contre un build antérieur à la fonctionnalité.

## Connu et assumé

- Le badge `weekend_20` compte en jour UTC tandis que `early_bird`/`night_owl` comptent en heure locale — exception documentée, un trajet parisien du lundi 00h30 compte comme week-end.
- La barre de progression n'a pas de nom accessible (suivi post-merge).
- `trip-map-bounds.spec.ts` échoue — **vérifié comme préexistant**, il échoue aussi sur `main`.
- Rien en CI ne valide le SQL : les tests mockent `db.select()`. Ticket à ouvrir séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBWrRrCQT6Jea4Ldtk1Q3A